### PR TITLE
fix: delete_by_filter cannot work properly

### DIFF
--- a/pyalaya/src/collection.py
+++ b/pyalaya/src/collection.py
@@ -221,8 +221,8 @@ class Collection:
         mask = self.__dataframe["metadata"].apply(lambda x: all(x.get(k) == v for k, v in filter.items()))
         for _, row in self.__dataframe[mask].iterrows():
             inner_id = self.__outer_inner_map[row["id"]]
-            del self.__outer_inner_map[row["id"]]
             self.__index_py.remove(self.__outer_inner_map[row["id"]])
+            del self.__outer_inner_map[row["id"]]
             del self.__inner_outer_map[inner_id]
         self.__dataframe = self.__dataframe[~mask]
 

--- a/pyalaya/tests/test_collection.py
+++ b/pyalaya/tests/test_collection.py
@@ -53,6 +53,18 @@ class TestCollection(unittest.TestCase):
         df = self.collection.filter_query({})
         self.assertEqual(len(df), 0)
 
+    def test_delete_by_filter(self):
+        items = [
+            (1, "Document 1", np.array([0.1, 0.2, 0.3]), {"category": "A"}),
+            (2, "Document 2", np.array([0.4, 0.5, 0.6]), {"category": "A"}),
+            (3, "Document 3", np.array([0.7, 0.8, 0.9]), {"category": "B"}),
+        ]
+        self.collection.insert(items)
+        self.collection.delete_by_filter({"category": "A"})
+        df = self.collection.filter_query({})
+        self.assertEqual(len(df["id"]), 1)
+        self.assertEqual(df["id"][0], 3)
+
     def test_filter_query(self):
         # items = [
         #   (1, "Document 1", np.array([0.1, 0.2, 0.3]), {"category": "A"}),


### PR DESCRIPTION
This pull request fixes the issue mentioned in issue #7 by changing the order of deleting and using the key in self.__outer_inner_map.

A unittest is added.
