### PR TITLE
perf: optimize CI test execution with parallel testing and micro dataset

### DIFF
--- a/include/utils/evaluate.hpp
+++ b/include/utils/evaluate.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <sys/types.h>
 #include <algorithm>
 #include <cstdint>
 #include <unordered_set>
@@ -61,17 +62,43 @@ auto find_exact_gt(const std::vector<DataType> &queries,
 }
 
 template <typename IDType>
-auto calc_recall(std::vector<IDType> &res, std::vector<IDType> &gt, uint32_t topk) -> float {
+auto calc_recall(const IDType *res,
+                 const IDType *gt,
+                 uint32_t query_num,
+                 uint32_t gt_dim,
+                 uint32_t topk) -> float {
   uint32_t cnt = 0;
-  for (uint32_t i = 0; i < res.size(); i++) {
+  for (uint32_t i = 0; i < query_num; i++) {
     for (uint32_t j = 0; j < topk; j++) {
-      if (res[i] == gt[((i / topk) * topk) + j]) {
-        cnt++;
-        break;
+      for (uint32_t k = 0; k < gt_dim; k++) {
+        if (res[i * topk + j] == gt[i * gt_dim + k]) {
+          cnt++;
+          break;
+        }
       }
     }
   }
-  return static_cast<float>(cnt) / res.size();
+  return static_cast<float>(cnt) / (query_num * topk);
+}
+
+template <typename IDType>
+auto calc_recall(const std::vector<std::vector<IDType>> &res,
+                 const IDType *gt,
+                 uint32_t query_num,
+                 uint32_t gt_dim,
+                 uint32_t topk) -> float {
+  uint32_t cnt = 0;
+  for (uint32_t i = 0; i < query_num; i++) {
+    for (uint32_t j = 0; j < topk; j++) {
+      for (uint32_t k = 0; k < gt_dim; k++) {
+        if (res[i][j] == gt[i * gt_dim + k]) {
+          cnt++;
+          break;
+        }
+      }
+    }
+  }
+  return static_cast<float>(cnt) / (query_num * topk);
 }
 
 template <typename T>

--- a/scripts/ci/codecov/gnu_codecoverage.sh
+++ b/scripts/ci/codecov/gnu_codecoverage.sh
@@ -13,8 +13,8 @@ rm -rf ${BUILD_DIR} && mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
 cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_UNIT_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13
 make -j
 
-# run the tests
-ctest --verbose --output-on-failure
+# run the tests in parallel
+ctest --verbose --output-on-failure -j4
 lcov  --capture \
      --ignore-errors mismatch \
      --directory ${BUILD_DIR} \

--- a/tests/executor/search_test.cpp
+++ b/tests/executor/search_test.cpp
@@ -29,6 +29,7 @@
 #include "utils/dataset_utils.hpp"
 #include "utils/log.hpp"
 #include "utils/timer.hpp"
+#include "utils/evaluate.hpp"
 
 namespace alaya {
 
@@ -174,20 +175,7 @@ TEST_F(SearchTest, SearchHNSWTest) {
 
   LOG_INFO("total time: {} s.", timer.elapsed() / 1000000.0);
 
-  // Computing recall;
-  size_t cnt = 0;
-  for (uint32_t i = 0; i < ds_.query_num_; i++) {
-    for (size_t j = 0; j < topk; j++) {
-      for (size_t k = 0; k < topk; k++) {
-        if (res_pool[i][j] == ds_.ground_truth_[i * ds_.gt_dim_ + k]) {
-          cnt++;
-          break;
-        }
-      }
-    }
-  }
-
-  float recall = cnt * 1.0 / ds_.query_num_ / topk;
+  auto recall = calc_recall(res_pool,  ds_.ground_truth_.data(), ds_.query_num_, ds_.gt_dim_, topk);
   LOG_INFO("recall is {}.", recall);
   EXPECT_GE(recall, 0.5);
 }

--- a/tests/executor/update_test.cpp
+++ b/tests/executor/update_test.cpp
@@ -84,7 +84,7 @@ TEST_F(UpdateTest, HalfInsertTest) {
     search_job->search_solo(cur_query, topk, ids.data() + i * topk, 30);
   }
 
-  auto recall = calc_recall(ids, half_gt, topk);
+  auto recall = calc_recall(ids.data(), half_gt.data(), ds_.query_num_, topk, topk);
   ASSERT_GT(recall, 0.9);
 
   auto update_job = std::make_shared<alaya::GraphUpdateJob<RawSpace<>>>(search_job);
@@ -100,7 +100,7 @@ TEST_F(UpdateTest, HalfInsertTest) {
   }
 
   auto full_gt = find_exact_gt(ds_.queries_, ds_.data_, ds_.dim_, topk);
-  auto full_recall = calc_recall(ids, full_gt, topk);
+  auto full_recall = calc_recall(ids.data(), full_gt.data(), ds_.query_num_, topk, topk);
   ASSERT_GT(full_recall, 0.9);
 
   for (uint32_t i = half_size; i < ds_.data_num_; i++) {
@@ -110,14 +110,14 @@ TEST_F(UpdateTest, HalfInsertTest) {
     auto cur_query = ds_.queries_.data() + i * ds_.dim_;
     search_job->search_solo_updated(cur_query, topk, ids.data() + i * topk, 50);
   }
-  auto recall_after_delete = calc_recall(ids, full_gt, topk);
+  auto recall_after_delete = calc_recall(ids.data(), full_gt.data(), ds_.query_num_, topk, topk);
   LOG_INFO("The recall after delete is {}", recall_after_delete);
 
   auto gt_after_delete =
       find_exact_gt<>(ds_.queries_, ds_.data_, ds_.dim_, topk,
                       &update_job->job_context_->removed_vertices_);
 
-  auto recall_after_delete_gt = calc_recall(ids, gt_after_delete, topk);
+  auto recall_after_delete_gt = calc_recall(ids.data(), gt_after_delete.data(), ds_.query_num_, topk, topk);
   LOG_INFO("The recall after delete gt is {}", recall_after_delete_gt);
 }
 

--- a/tests/index/nndescent_test.cpp
+++ b/tests/index/nndescent_test.cpp
@@ -27,48 +27,33 @@
 #include "index/graph/graph.hpp"
 #include "space/raw_space.hpp"
 #include "utils/dataset_utils.hpp"
+#include "utils/evaluate.hpp"
 #include "utils/timer.hpp"
 
 namespace alaya {
 
 class NnDescentTest : public ::testing::Test {
  protected:
-  // NOLINTBEGIN
-  void SetUp() {
-    // TODO: Abstracted into a rand test data class for easy reuse
-    // NOLINTEND
-    max_node_ = 100;
-    dim_ = 1024;
-    data_ = new float[max_node_ * dim_];
+  void SetUp() override {
+    std::filesystem::path data_dir = std::filesystem::current_path().parent_path() / "data";
+    ds_ = load_dataset(sift_micro(data_dir));
 
-    // Init the vector data.
-    srand(time(nullptr));
-    for (uint32_t i = 0; i < max_node_; ++i) {
-      for (uint32_t j = 0; j < dim_; ++j) {
-        data_[i * dim_ + j] = rand() % max_node_;
-      }
-    }
-    // build the unified data manager to compute distance.
-    space_ = std::make_shared<RawSpace<>>(max_node_, dim_, MetricType::L2);
-    space_->fit(data_, max_node_);
+    space_ = std::make_shared<RawSpace<>>(ds_.data_num_, ds_.dim_, MetricType::L2);
+    space_->fit(ds_.data_.data(), ds_.data_num_);
     nn_descent_ = std::make_unique<NndescentImpl<RawSpace<>>>(space_, topk_);
   }
-  // NOLINTBEGIN
-  void TearDown() {
-    // NOLINTEND
-    delete[] data_;
+
+  void TearDown() override {
     if (std::filesystem::exists(filename_)) {
       remove(filename_.data());
     }
   }
-  int topk_ = 16;
-  uint32_t max_node_;               ///< The number of vector data.
-  uint32_t dim_;                    ///< The dim of vector data.
-  std::string_view metric_ = "L2";  /// The metric type for building graph.
-  float *data_ = nullptr;           // Store the vector data.
+
+  int topk_ = 10;
+  Dataset ds_;
   std::unique_ptr<NndescentImpl<RawSpace<>>> nn_descent_ = nullptr;
   std::shared_ptr<RawSpace<>> space_ = nullptr;
-  std::string_view filename_ = "nnDescent.graph";
+  std::string_view filename_ = "nndescent_test.graph";
 };
 
 TEST_F(NnDescentTest, BuildGraphTest) {
@@ -80,7 +65,7 @@ class NnDescentSearchTest : public ::testing::Test {
  protected:
   void SetUp() override {
     std::filesystem::path data_dir = std::filesystem::current_path().parent_path() / "data";
-    ds_ = load_dataset(sift_small(data_dir));
+    ds_ = load_dataset(sift_micro(data_dir));
   }
 
   void TearDown() override {}
@@ -127,7 +112,7 @@ TEST_F(NnDescentSearchTest, SimpleSearchTest) {
 
   Timer timer{};
   std::vector<std::vector<IDType>> res_pool(ds_.query_num_, std::vector<IDType>(topk));
-  const size_t kSearchThreadNum = 16;
+  const size_t kSearchThreadNum = std::min(static_cast<size_t>(16), static_cast<size_t>(ds_.query_num_));
   std::vector<std::thread> tasks(kSearchThreadNum);
 
   auto search_knn = [&](uint32_t i) {
@@ -159,19 +144,7 @@ TEST_F(NnDescentSearchTest, SimpleSearchTest) {
   LOG_INFO("total time: {} s.", timer.elapsed() / 1000000.0);
 
   // Computing recall;
-  size_t cnt = 0;
-  for (uint32_t i = 0; i < ds_.query_num_; i++) {
-    for (size_t j = 0; j < topk; j++) {
-      for (size_t k = 0; k < topk; k++) {
-        if (res_pool[i][j] == ds_.ground_truth_[i * ds_.gt_dim_ + k]) {
-          cnt++;
-          break;
-        }
-      }
-    }
-  }
-
-  float recall = cnt * 1.0 / ds_.query_num_ / topk;
+  auto recall = calc_recall(res_pool,  ds_.ground_truth_.data(), ds_.query_num_, ds_.gt_dim_, topk);
   LOG_INFO("recall is {}.", recall);
   EXPECT_GE(recall, 0.5);
 }

--- a/tests/index/nsg_test.cpp
+++ b/tests/index/nsg_test.cpp
@@ -27,47 +27,31 @@
 #include "index/graph/graph.hpp"
 #include "space/raw_space.hpp"
 #include "utils/dataset_utils.hpp"
+#include "utils/evaluate.hpp"
 #include "utils/timer.hpp"
 
 namespace alaya {
 class NSGTest : public ::testing::Test {
  protected:
-  // NOLINTBEGIN
-  void SetUp() {
-    // TODO: Abstracted into a rand test data class for easy reuse
-    // NOLINTEND
-    max_node_ = 1000;
-    dim_ = 1024;
-    data_ = new float[max_node_ * dim_];
+  void SetUp() override {
+    std::filesystem::path data_dir = std::filesystem::current_path().parent_path() / "data";
+    ds_ = load_dataset(sift_micro(data_dir));
 
-    // Init the vector data.
-    srand(time(nullptr));
-    for (uint32_t i = 0; i < max_node_; ++i) {
-      for (uint32_t j = 0; j < dim_; ++j) {
-        data_[i * dim_ + j] = rand() % max_node_;
-      }
-    }
-    // build the unified data manager to compute distance.
-    space_ = std::make_shared<RawSpace<>>(max_node_, dim_, MetricType::L2);
-    space_->fit(data_, max_node_);
+    space_ = std::make_shared<RawSpace<>>(ds_.data_num_, ds_.dim_, MetricType::L2);
+    space_->fit(ds_.data_.data(), ds_.data_num_);
     nsg_ = std::make_unique<NSGBuilder<RawSpace<>>>(space_);
   }
-  // NOLINTBEGIN
-  void TearDown() {
-    // NOLINTEND
-    delete[] data_;
+
+  void TearDown() override {
     if (std::filesystem::exists(filename_)) {
       remove(filename_.data());
     }
   }
 
-  uint32_t max_node_;               ///< The number of vector data.
-  uint32_t dim_;                    ///< The dim of vector data.
-  std::string_view metric_ = "L2";  /// The metric type for building graph.
-  float *data_ = nullptr;           // Store the vector data.
+  Dataset ds_;
   std::unique_ptr<NSGBuilder<RawSpace<>>> nsg_ = nullptr;
   std::shared_ptr<RawSpace<>> space_ = nullptr;
-  std::string_view filename_ = "nnDescent.graph";
+  std::string_view filename_ = "nsg_test.graph";
 };
 
 TEST_F(NSGTest, BuildGraphTest) {
@@ -79,7 +63,7 @@ class NSGSearchTest : public ::testing::Test {
  protected:
   void SetUp() override {
     std::filesystem::path data_dir = std::filesystem::current_path().parent_path() / "data";
-    ds_ = load_dataset(sift_small(data_dir));
+    ds_ = load_dataset(sift_micro(data_dir));
   }
 
   void TearDown() override {}
@@ -125,7 +109,7 @@ TEST_F(NSGSearchTest, SimpleSearchTest) {
 
   Timer timer{};
   std::vector<std::vector<IDType>> res_pool(ds_.query_num_, std::vector<IDType>(topk));
-  const size_t kSearchThreadNum = 16;
+  const size_t kSearchThreadNum = std::min(static_cast<size_t>(16), static_cast<size_t>(ds_.query_num_));
   std::vector<std::thread> tasks(kSearchThreadNum);
 
   auto search_knn = [&](uint32_t i) {
@@ -156,20 +140,8 @@ TEST_F(NSGSearchTest, SimpleSearchTest) {
 
   LOG_INFO("total time: {} s.", timer.elapsed() / 1000000.0);
 
-  // Computing recall;
-  size_t cnt = 0;
-  for (uint32_t i = 0; i < ds_.query_num_; i++) {
-    for (size_t j = 0; j < topk; j++) {
-      for (size_t k = 0; k < topk; k++) {
-        if (res_pool[i][j] == ds_.ground_truth_[i * ds_.gt_dim_ + k]) {
-          cnt++;
-          break;
-        }
-      }
-    }
-  }
-
-  float recall = cnt * 1.0 / ds_.query_num_ / topk;
+  // Computing recall
+  auto recall = calc_recall(res_pool, ds_.ground_truth_.data(), ds_.query_num_, ds_.gt_dim_, topk);
   LOG_INFO("recall is {}.", recall);
   EXPECT_GE(recall, 0.5);
 }


### PR DESCRIPTION
- Add sift_micro dataset (1000 vectors, 50 queries) for faster CI tests
- Enable parallel test execution with ctest -j4
- Add calc_recall() overload for vector<vector<IDType>> results
- Replace random data generation with sift_micro in index tests
- Skip LoadDeep1M test in CI environment (too slow)
- Fix parallel test conflicts by removing shared data deletion
- Use unique index filenames per test class