### PR TITLE
ci: add pre-commit hook to auto detect Chinese characters

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -29,7 +29,7 @@ jobs:
 
     env:
       CONAN_NON_INTERACTIVE: 1
-      # CI 特定配置：Linux Docker 挂载 Conan 和 uv 缓存
+      # CI specific config: mount Conan and uv cache in Linux Docker
       CIBW_CONTAINER_ENGINE: 'docker; create_args: -v /home/runner/.conan2:/root/.conan2'
       CIBW_ARCHS_LINUX: ${{ matrix.arch }}
       CIBW_ARCHS_MACOS: ${{ matrix.arch }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,3 +118,15 @@ repos:
       -build/include_what_you_use
 
     - --recursive
+
+#===========================================================================
+#                            CHINESE CHARACTER CHECK HOOK
+#===========================================================================
+- repo: local
+  hooks:
+  - id: no-chinese-characters
+    name: Check for Chinese characters in code
+    entry: python scripts/check_chinese.py
+    language: python
+    files: (Makefile|\.(c|cc|cpp|cxx|h|hpp|hxx|ipp|py|yaml|yml|sh|cmake|txt))$
+    exclude: ^(docs/|build/)

--- a/scripts/check_chinese.py
+++ b/scripts/check_chinese.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Check for Chinese characters in source code files."""
+
+import re
+import sys
+
+
+def main() -> int:
+    """Check files for Chinese characters."""
+    # CJK Unified Ideographs + Extension A + Extension B-F
+    pattern = re.compile(r"[\u3400-\u4DBF\u4E00-\u9FFF\U00020000-\U0002EBEF]")
+    found = False
+
+    for filepath in sys.argv[1:]:
+        try:
+            with open(filepath, encoding="utf-8", errors="surrogateescape") as f:
+                for line_num, line in enumerate(f, 1):
+                    if pattern.search(line):
+                        print(f"{filepath}:{line_num}: {line.rstrip()}")
+                        found = True
+        except OSError as e:
+            print(f"Error reading {filepath}: {e}", file=sys.stderr)
+            continue
+
+    return 1 if found else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/space/sq4_space_test.cpp
+++ b/tests/space/sq4_space_test.cpp
@@ -74,7 +74,7 @@ TEST_F(SQ4SpaceTest, InsertAndRemove) {
   EXPECT_EQ(space_->get_data_num(), 1);
 
   space_->remove(id);
-  EXPECT_EQ(space_->get_data_num(), 1);  // remove 只是标记删除
+  EXPECT_EQ(space_->get_data_num(), 1);  // remove only marks the item as deleted
 }
 
 TEST_F(SQ4SpaceTest, GetDistance) {

--- a/tests/space/sq8_space_test.cpp
+++ b/tests/space/sq8_space_test.cpp
@@ -70,7 +70,7 @@ TEST_F(SQ8SpaceTest, InsertAndRemove) {
   EXPECT_EQ(space_->get_data_num(), 1);
 
   space_->remove(id);
-  EXPECT_EQ(space_->get_data_num(), 1);  // remove 只是标记删除
+  EXPECT_EQ(space_->get_data_num(), 1);  // remove only marks the item as deleted
 }
 
 TEST_F(SQ8SpaceTest, GetDistance) {


### PR DESCRIPTION
## Summary
- Add `scripts/check_chinese.py` to detect Chinese characters in source code
- Add `no-chinese-characters` pre-commit hook to prevent future Chinese comments
- Translate existing Chinese comments to English

Fixes #62

## Test plan
- [x] Run `uvx pre-commit run no-chinese-characters --all-files` to verify no Chinese characters remain
- [x] Verify pre-commit hook catches new Chinese characters