### PR TITLE
fix: stabilize install and restore cross-platform wheel CI

### DIFF
--- a/include/executor/jobs/graph_hybrid_search_job.hpp
+++ b/include/executor/jobs/graph_hybrid_search_job.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -55,6 +56,18 @@ struct GraphHybridSearchJob {
   // `kIndexedExact` skips bitset construction and computes exact top-k directly on indexed ids.
   enum class Mode : uint8_t { kPlainSearch, kBitsetPrefilter, kIterativeFilter, kIndexedExact };
 
+  using FilterExecutor = MetadataFilterExecutor<IDType>;
+  using BlockedBitsetResult = typename FilterExecutor::BlockedBitsetResult;
+
+  struct PreparedHybridSearchPlan {
+    FilterExecutor filter_executor_;
+    Mode mode_ = Mode::kBitsetPrefilter;
+    std::optional<BlockedBitsetResult> prefilter_result_;
+
+    PreparedHybridSearchPlan(FilterExecutor filter_executor, Mode mode)
+        : filter_executor_(std::move(filter_executor)), mode_(mode) {}
+  };
+
   explicit GraphHybridSearchJob(std::shared_ptr<DistanceSpaceType> space,
                                 std::shared_ptr<Graph<DataType, IDType>> graph = nullptr,
                                 std::shared_ptr<BuildSpaceType> build_space = nullptr)
@@ -88,10 +101,17 @@ struct GraphHybridSearchJob {
   }
 
   auto make_filter_executor(const MetadataFilter &filter) const
-      -> MetadataFilterExecutor<IDType> requires(DistanceSpaceType::has_scalar_data) {
-    return MetadataFilterExecutor<IDType>(filter,
-                                          space_->get_scalar_storage(),
-                                          space_->get_data_num());
+      -> FilterExecutor requires(DistanceSpaceType::has_scalar_data) {
+    return FilterExecutor(filter, space_->get_scalar_storage(), space_->get_data_num());
+  }
+
+  auto make_filter_executor(const MetadataFilter &filter,
+                            typename FilterExecutor::IndexBuildMode index_build_mode) const
+      -> FilterExecutor requires(DistanceSpaceType::has_scalar_data) {
+    return FilterExecutor(filter,
+                          space_->get_scalar_storage(),
+                          space_->get_data_num(),
+                          index_build_mode);
   }
 
   static void validate_search_info(const SearchInfo &search_info, const char *search_name) {
@@ -120,14 +140,24 @@ struct GraphHybridSearchJob {
   [[nodiscard]] auto build_search_mode(const MetadataFilterExecutor<IDType> &filter_executor,
                                        const SearchInfo &search_info) const
       -> Mode requires(DistanceSpaceType::has_scalar_data) {
-    if (filter_executor.is_trivially_true()) {
+    return build_search_mode(filter_executor.is_trivially_true(),
+                             filter_executor.has_index_fast_path(),
+                             filter_executor.indexed_count(),
+                             search_info);
+  }
+
+  [[nodiscard]] auto build_search_mode(bool is_trivially_true,
+                                       bool has_index_fast_path,
+                                       size_t indexed_count,
+                                       const SearchInfo &search_info) const
+      -> Mode requires(DistanceSpaceType::has_scalar_data) {
+    if (is_trivially_true) {
       return Mode::kPlainSearch;
     }
 
     switch (search_info.filter_exec_hint_) {
       case FilterExecHint::kAuto:
-        if (filter_executor.has_index_fast_path() &&
-            should_use_brute_force_search(search_info, filter_executor.indexed_count())) {
+        if (has_index_fast_path && should_use_brute_force_search(search_info, indexed_count)) {
           return Mode::kIndexedExact;
         }
         return Mode::kBitsetPrefilter;
@@ -155,6 +185,20 @@ struct GraphHybridSearchJob {
     return count;
   }
 
+  [[nodiscard]] static auto estimate_prefilter_ef(const SearchInfo &search_info,
+                                                  size_t matched_count,
+                                                  size_t total_count) -> size_t {
+    if (matched_count == 0 || matched_count >= total_count) {
+      return search_info.ef_;
+    }
+
+    auto expected_ef = static_cast<size_t>(
+        (static_cast<double>(search_info.topk_) * static_cast<double>(total_count)) /
+        static_cast<double>(matched_count));
+    expected_ef += expected_ef / 2;  // 1.5x on default
+    return std::min<size_t>(total_count, std::max<size_t>(search_info.ef_, expected_ef));
+  }
+
   [[nodiscard]] auto adjust_ef_in_search_info(const SearchInfo &search_info,
                                               size_t matched_count,
                                               const char *search_name) const -> SearchInfo {
@@ -162,18 +206,9 @@ struct GraphHybridSearchJob {
       return search_info;
     }
 
-    // selectivity = matched_count / total_count,
-    // expected_ef = topk / selectivity
-    auto expected_ef = static_cast<size_t>(
-        (static_cast<double>(search_info.topk_) * static_cast<double>(space_->get_data_num())) /
-        static_cast<double>(matched_count));
-    // TODO(P2): The 1.5x ef inflation factor is fixed. Consider making it
-    // adaptive based on historical query performance or filter selectivity.
-    expected_ef += expected_ef / 2;  // 1.5x on default
-
     SearchInfo adjusted = search_info;
     adjusted.ef_ = static_cast<uint32_t>(
-        std::min<size_t>(space_->get_data_num(), std::max<size_t>(search_info.ef_, expected_ef)));
+        estimate_prefilter_ef(search_info, matched_count, space_->get_data_num()));
     if (adjusted.ef_ != search_info.ef_) {
       LOG_DEBUG("{}: inflate ef from {} to {} for sparse prefilter pushdown",
                 search_name,
@@ -190,7 +225,20 @@ struct GraphHybridSearchJob {
     }
 
     auto total_count = static_cast<size_t>(space_->get_data_num());
+    if (matched_count >= total_count) {
+      return false;
+    }
+
     auto topk = static_cast<size_t>(search_info.topk_);
+    auto ef = static_cast<size_t>(search_info.ef_);
+    if (matched_count <= ef) {
+      return true;
+    }
+
+    if (estimate_prefilter_ef(search_info, matched_count, total_count) >= matched_count) {
+      return true;
+    }
+
     if (topk >=
         static_cast<size_t>(static_cast<double>(total_count) * kHybridSearchBFTopkThreshold)) {
       return true;
@@ -206,10 +254,56 @@ struct GraphHybridSearchJob {
            static_cast<size_t>(static_cast<double>(matched_count) * kHybridSearchBFTopkThreshold);
   }
 
+  auto execute_brute_force_bitset(const DataType *query,
+                                  IDType *ids,
+                                  uint32_t topk,
+                                  const BlockedBitsetResult &bitset_result,
+                                  const char *search_name)
+      -> uint32_t requires(DistanceSpaceType::has_scalar_data) {
+    SearchBuffer<DistanceType> result_pool(topk);
+    auto run_candidates = [&](const auto &exact_distance) {
+      for (size_t raw_id = 0; raw_id < bitset_result.blocked_.size(); ++raw_id) {
+        if (!bitset_result.blocked_.get(raw_id)) {
+          auto id = static_cast<IDType>(raw_id);
+          result_pool.insert(id, exact_distance(id));
+        }
+      }
+    };
+
+    if constexpr (is_rabitq_space_v<DistanceSpaceType>) {
+      auto dist_func = space_->get_dist_func();
+      auto dim = space_->get_dim();
+      auto exact_distance = [&](IDType id) -> DistanceType {
+        return dist_func(query, space_->get_data_by_id(id), dim);
+      };
+      run_candidates(exact_distance);
+    } else if constexpr (std::is_same_v<DistanceSpaceType, BuildSpaceType>) {
+      auto exact_qc = space_->get_query_computer(query);
+      auto exact_distance = [&](IDType id) -> DistanceType {
+        return exact_qc(id);
+      };
+      run_candidates(exact_distance);
+    } else {
+      auto exact_qc = build_space_->get_query_computer(query);
+      auto exact_distance = [&](IDType id) -> DistanceType {
+        return exact_qc(id);
+      };
+      run_candidates(exact_distance);
+    }
+
+    auto res_size = materialize_result_ids(result_pool, ids, topk);
+    LOG_DEBUG("{}: brute_force_bitset matched_rows={}, results={}, requested={}",
+              search_name,
+              bitset_result.matched_count_,
+              res_size,
+              topk);
+    return res_size;
+  }
+
   auto execute_brute_force_filter(const DataType *query,
                                   IDType *ids,
                                   uint32_t topk,
-                                  const MetadataFilterExecutor<IDType> &filter_executor,
+                                  const FilterExecutor &filter_executor,
                                   const char *search_name)
       -> uint32_t requires(DistanceSpaceType::has_scalar_data) {
     SearchBuffer<DistanceType> result_pool(topk);
@@ -219,7 +313,9 @@ struct GraphHybridSearchJob {
     batch_ids.reserve(kBatchSize);
     auto run_indexed_candidates = [&](const auto &exact_distance) {
       for (auto id : filter_executor.indexed_ids()) {
-        result_pool.insert(id, exact_distance(id));
+        if (filter_executor.match(id)) {
+          result_pool.insert(id, exact_distance(id));
+        }
       }
     };
     auto run_full_scan = [&](const auto &exact_distance, size_t data_num) {
@@ -288,7 +384,7 @@ struct GraphHybridSearchJob {
   auto execute_iterative_filter(const DataType *query,
                                 IDType *ids,
                                 const SearchInfo &search_info,
-                                const MetadataFilterExecutor<IDType> &filter_executor,
+                                const FilterExecutor &filter_executor,
                                 const char *search_name)
       -> uint32_t requires(DistanceSpaceType::has_scalar_data) {
     GraphSearchJob<DistanceSpaceType, BuildSpaceType> base_job(space_,
@@ -329,13 +425,14 @@ struct GraphHybridSearchJob {
     return res_size;
   }
 
-  auto execute_bitset_prefilter(const DataType *query,
-                                IDType *ids,
-                                const SearchInfo &search_info,
-                                const MetadataFilterExecutor<IDType> &filter_executor,
-                                const char *search_name)
+  auto execute_prebuilt_bitset_prefilter(const DataType *query,
+                                         IDType *ids,
+                                         const SearchInfo &search_info,
+                                         const FilterExecutor &filter_executor,
+                                         const BlockedBitsetResult &bitset_result,
+                                         const char *search_name)
       -> uint32_t requires(DistanceSpaceType::has_scalar_data) {
-    auto bitset_result = filter_executor.build_blocked_bitset();
+    (void)filter_executor;
     if (bitset_result.matched_count_ == 0) {
       LOG_DEBUG("{}: bitset_prefilter matched zero rows", search_name);
       return 0;
@@ -370,11 +467,7 @@ struct GraphHybridSearchJob {
                 bitset_result.matched_count_,
                 search_info.topk_,
                 search_info.ef_);
-      return execute_brute_force_filter(query,
-                                        ids,
-                                        search_info.topk_,
-                                        filter_executor,
-                                        search_name);
+      return execute_brute_force_bitset(query, ids, search_info.topk_, bitset_result, search_name);
     }
 
     auto adjusted_search_info =
@@ -400,13 +493,125 @@ struct GraphHybridSearchJob {
                 search_name,
                 res_size,
                 required_results);
-      return execute_brute_force_filter(query,
-                                        ids,
-                                        search_info.topk_,
-                                        filter_executor,
-                                        search_name);
+      return execute_brute_force_bitset(query, ids, search_info.topk_, bitset_result, search_name);
     }
     return res_size;
+  }
+
+  auto execute_bitset_prefilter(const DataType *query,
+                                IDType *ids,
+                                const SearchInfo &search_info,
+                                const FilterExecutor &filter_executor,
+                                const char *search_name)
+      -> uint32_t requires(DistanceSpaceType::has_scalar_data) {
+    auto bitset_result = filter_executor.build_blocked_bitset();
+    return execute_prebuilt_bitset_prefilter(query,
+                                             ids,
+                                             search_info,
+                                             filter_executor,
+                                             bitset_result,
+                                             search_name);
+  }
+
+  [[nodiscard]] auto prepare_hybrid_search_plan(const MetadataFilter &filter,
+                                                const SearchInfo &search_info) const
+      -> PreparedHybridSearchPlan requires(DistanceSpaceType::has_scalar_data) {
+    validate_search_info(search_info, "hybrid_search");
+
+    auto filter_executor =
+        make_filter_executor(filter, FilterExecutor::IndexBuildMode::kSkip);
+    auto direct_bitset_result = filter_executor.build_direct_indexed_blocked_bitset();
+    if (direct_bitset_result.has_value()) {
+      auto mode = build_search_mode(filter_executor.is_trivially_true(),
+                                    true,
+                                    direct_bitset_result->matched_count_,
+                                    search_info);
+      if (mode != Mode::kBitsetPrefilter) {
+        filter_executor.materialize_index_fast_path();
+      }
+      PreparedHybridSearchPlan plan(std::move(filter_executor), mode);
+      if (mode == Mode::kBitsetPrefilter) {
+        plan.prefilter_result_ = std::move(direct_bitset_result);
+      }
+      return plan;
+    }
+
+    filter_executor.materialize_index_fast_path();
+    auto mode = build_search_mode(filter_executor, search_info);
+    PreparedHybridSearchPlan plan(std::move(filter_executor), mode);
+    if (mode == Mode::kBitsetPrefilter) {
+      plan.prefilter_result_ = plan.filter_executor_.build_blocked_bitset();
+    }
+    return plan;
+  }
+
+  void execute_prepared_hybrid_search(const DataType *query,
+                                      IDType *ids,
+                                      const SearchInfo &search_info,
+                                      const PreparedHybridSearchPlan &plan,
+                                      std::string *res)
+      requires(DistanceSpaceType::has_scalar_data) {
+    const char *search_name = "hybrid_search";
+    if constexpr (is_rabitq_space_v<DistanceSpaceType>) {
+      search_name = "rabitq_hybrid_search";
+    }
+
+    initialize_results(ids, res, search_info.topk_);
+    LOG_DEBUG("{}: plan={}, topk={}, ef={}, hint={}",
+              search_name,
+              mode_name(plan.mode_),
+              search_info.topk_,
+              search_info.ef_,
+              static_cast<int>(search_info.filter_exec_hint_));
+
+    uint32_t res_size = 0;
+    if (plan.mode_ == Mode::kPlainSearch) {
+      GraphSearchJob<DistanceSpaceType, BuildSpaceType> base_job(space_,
+                                                                 graph_,
+                                                                 nullptr,
+                                                                 build_space_);
+      if constexpr (is_rabitq_space_v<DistanceSpaceType>) {
+        base_job.rabitq_search_solo(query, search_info.topk_, ids, search_info.ef_);
+      } else {
+        base_job.search_solo(const_cast<DataType *>(query),
+                             ids,
+                             search_info.topk_,
+                             search_info.ef_);
+      }
+      res_size = std::min<uint32_t>(search_info.topk_, space_->get_data_num());
+    } else if (plan.mode_ == Mode::kIndexedExact) {
+      res_size = execute_brute_force_filter(query,
+                                            ids,
+                                            search_info.topk_,
+                                            plan.filter_executor_,
+                                            search_name);
+    } else if (plan.mode_ == Mode::kBitsetPrefilter) {
+      if (plan.prefilter_result_.has_value()) {
+        res_size = execute_prebuilt_bitset_prefilter(query,
+                                                     ids,
+                                                     search_info,
+                                                     plan.filter_executor_,
+                                                     *plan.prefilter_result_,
+                                                     search_name);
+      } else {
+        res_size = execute_bitset_prefilter(query,
+                                            ids,
+                                            search_info,
+                                            plan.filter_executor_,
+                                            search_name);
+      }
+    } else {
+      res_size =
+          execute_iterative_filter(query, ids, search_info, plan.filter_executor_, search_name);
+    }
+
+    materialize_item_ids(ids, res_size, res);
+    if (res_size < search_info.topk_) {
+      LOG_DEBUG("{}: only found {} results, requested {}",
+                search_name,
+                res_size,
+                search_info.topk_);
+    }
   }
 
   void hybrid_search_solo(DataType *query,
@@ -414,43 +619,8 @@ struct GraphHybridSearchJob {
                           const SearchInfo &search_info,
                           const MetadataFilter &filter,
                           std::string *res) requires(DistanceSpaceType::has_scalar_data) {
-    validate_search_info(search_info, "hybrid_search");
-    initialize_results(ids, res, search_info.topk_);
-
-    auto filter_executor = make_filter_executor(filter);
-    auto mode = build_search_mode(filter_executor, search_info);
-    LOG_DEBUG("hybrid_search: plan={}, topk={}, ef={}, hint={}",
-              mode_name(mode),
-              search_info.topk_,
-              search_info.ef_,
-              static_cast<int>(search_info.filter_exec_hint_));
-
-    uint32_t res_size = 0;
-    if (mode == Mode::kPlainSearch) {
-      GraphSearchJob<DistanceSpaceType, BuildSpaceType> base_job(space_,
-                                                                 graph_,
-                                                                 nullptr,
-                                                                 build_space_);
-      base_job.search_solo(query, ids, search_info.topk_, search_info.ef_);
-      res_size = std::min<uint32_t>(search_info.topk_, space_->get_data_num());
-    } else if (mode == Mode::kIndexedExact) {
-      res_size = execute_brute_force_filter(query,
-                                            ids,
-                                            search_info.topk_,
-                                            filter_executor,
-                                            "hybrid_search");
-    } else if (mode == Mode::kBitsetPrefilter) {
-      res_size =
-          execute_bitset_prefilter(query, ids, search_info, filter_executor, "hybrid_search");
-    } else {
-      res_size =
-          execute_iterative_filter(query, ids, search_info, filter_executor, "hybrid_search");
-    }
-
-    materialize_item_ids(ids, res_size, res);
-    if (res_size < search_info.topk_) {
-      LOG_DEBUG("hybrid_search: only found {} results, requested {}", res_size, search_info.topk_);
-    }
+    auto plan = prepare_hybrid_search_plan(filter, search_info);
+    execute_prepared_hybrid_search(query, ids, search_info, plan, res);
   }
 
   void hybrid_search_solo(DataType *query,
@@ -492,50 +662,8 @@ struct GraphHybridSearchJob {
     }
 
     validate_search_info(search_info, "rabitq_hybrid_search");
-    initialize_results(ids, res, search_info.topk_);
-
-    auto filter_executor = make_filter_executor(filter);
-    auto mode = build_search_mode(filter_executor, search_info);
-    LOG_DEBUG("rabitq_hybrid_search: plan={}, topk={}, ef={}, hint={}",
-              mode_name(mode),
-              search_info.topk_,
-              search_info.ef_,
-              static_cast<int>(search_info.filter_exec_hint_));
-
-    uint32_t res_size = 0;
-    if (mode == Mode::kPlainSearch) {
-      GraphSearchJob<DistanceSpaceType, BuildSpaceType> base_job(space_,
-                                                                 graph_,
-                                                                 nullptr,
-                                                                 build_space_);
-      base_job.rabitq_search_solo(query, search_info.topk_, ids, search_info.ef_);
-      res_size = std::min<uint32_t>(search_info.topk_, space_->get_data_num());
-    } else if (mode == Mode::kIndexedExact) {
-      res_size = execute_brute_force_filter(query,
-                                            ids,
-                                            search_info.topk_,
-                                            filter_executor,
-                                            "rabitq_hybrid_search");
-    } else if (mode == Mode::kBitsetPrefilter) {
-      res_size = execute_bitset_prefilter(query,
-                                          ids,
-                                          search_info,
-                                          filter_executor,
-                                          "rabitq_hybrid_search");
-    } else {
-      res_size = execute_iterative_filter(query,
-                                          ids,
-                                          search_info,
-                                          filter_executor,
-                                          "rabitq_hybrid_search");
-    }
-
-    materialize_item_ids(ids, res_size, res);
-    if (res_size < search_info.topk_) {
-      LOG_DEBUG("rabitq_hybrid_search: only found {} results, requested {}",
-                res_size,
-                search_info.topk_);
-    }
+    auto plan = prepare_hybrid_search_plan(filter, search_info);
+    execute_prepared_hybrid_search(query, ids, search_info, plan, res);
   }
 
   void rabitq_hybrid_search_solo(const DataType *query,

--- a/include/recovery/recovery_manager.hpp
+++ b/include/recovery/recovery_manager.hpp
@@ -4,15 +4,20 @@
 
 #pragma once
 
+#include <atomic>
 #include <filesystem>  // NOLINT(build/c++17)
 #include <fstream>
 #include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
+#ifndef _WIN32
+  #include <unistd.h>
+#endif
 
 #include "recovery/snapshot_manifest.hpp"
 #include "recovery/write_ahead_log.hpp"
+#include "utils/locks.hpp"
 #include "utils/log.hpp"
 #include "utils/platform_fs.hpp"
 
@@ -65,11 +70,33 @@ class RecoveryManager {
   [[nodiscard]] auto create_snapshot_dir() const -> fs::path {
     ensure_layout();
     auto now = SnapshotManifest::current_unix_ms();
-    std::ostringstream name;
-    name << "snapshot-" << now;
-    auto snapshot_dir = snapshots_dir_ / name.str();
-    fs::create_directories(snapshot_dir);
-    return snapshot_dir;
+    static std::atomic<uint64_t> snapshot_sequence{0};
+#ifdef _WIN32
+    const auto pid = 0;
+#else
+    const auto pid = static_cast<int64_t>(::getpid());
+#endif
+
+    for (int attempt = 0; attempt < 100; ++attempt) {
+      std::ostringstream name;
+      name << "snapshot-" << now << "-" << pid << "-"
+           << snapshot_sequence.fetch_add(1, std::memory_order_relaxed);
+      auto snapshot_dir = snapshots_dir_ / name.str();
+      std::error_code ec;
+      if (fs::create_directory(snapshot_dir, ec)) {
+        return snapshot_dir;
+      }
+      if (ec) {
+        throw std::runtime_error("Failed to create snapshot directory " + snapshot_dir.string() +
+                                 ": " + ec.message());
+      }
+    }
+    throw std::runtime_error("Failed to allocate a unique recovery snapshot directory");
+  }
+
+  [[nodiscard]] auto snapshot_lock_path() const -> fs::path {
+    ensure_layout();
+    return root_dir_ / "SNAPSHOT_LOCK";
   }
 
   // TODO(P2): The snapshot directory is only published after graph files and the RocksDB
@@ -87,6 +114,7 @@ class RecoveryManager {
   auto publish_snapshot(const SnapshotManifest &manifest, const fs::path &snapshot_dir) const
       -> void {
     ensure_layout();
+    validate_snapshot_complete(manifest, snapshot_dir);
     auto manifest_path = snapshot_dir / "manifest.txt";
     write_text_atomically(manifest_path, manifest.serialize());
     write_text_atomically(current_path_, manifest.snapshot_id_ + "\n");
@@ -156,8 +184,10 @@ class RecoveryManager {
    * @brief Replaces the active RocksDB directory with the checkpoint stored in a snapshot.
    *
    * If RocksDB recovery is not configured or the snapshot does not include a checkpoint, the method
-   * exits without modifying the active directory. Existing active contents are removed before the
-   * checkpoint is copied into place.
+   * exits without modifying the active directory. Restore is cross-process serialized and skipped
+   * when the active directory already corresponds to the requested snapshot, so concurrent readers
+   * do not repeatedly delete and recopy the same RocksDB files while other readers are opening
+   * them.
    */
   auto restore_active_rocksdb_from_snapshot(const SnapshotManifest &manifest,
                                             const fs::path &snapshot_dir) const -> void {
@@ -171,15 +201,104 @@ class RecoveryManager {
       return;
     }
 
-    fs::create_directories(active_rocksdb_path_.parent_path());
+    if (active_rocksdb_matches_snapshot(manifest)) {
+      LOG_DEBUG("recovery: active rocksdb already restored from snapshot id={}",
+                manifest.snapshot_id_);
+      return;
+    }
+
+    alaya::FileLock restore_lock(snapshot_lock_path());
+    if (active_rocksdb_matches_snapshot(manifest)) {
+      LOG_DEBUG("recovery: active rocksdb already restored from snapshot id={}",
+                manifest.snapshot_id_);
+      return;
+    }
+
+    auto parent = active_rocksdb_path_.parent_path();
+    if (!parent.empty()) {
+      fs::create_directories(parent);
+    }
+
+    auto staging_path = restore_staging_path();
     std::error_code ec;
-    fs::remove_all(active_rocksdb_path_, ec);
-    ec.clear();
-    copy_directory_recursive(source, active_rocksdb_path_);
+    fs::remove_all(staging_path, ec);
+    if (ec) {
+      throw std::runtime_error("Failed to remove stale RocksDB restore staging directory " +
+                               staging_path.string() + ": " + ec.message());
+    }
+
+    copy_directory_recursive(source, staging_path);
+    publish_staged_rocksdb_restore(staging_path);
+    write_text_atomically(restored_rocksdb_marker_path(), manifest.snapshot_id_ + "\n");
     LOG_INFO("recovery: restored rocksdb checkpoint from {}", source.string());
   }
 
  private:
+  [[nodiscard]] auto restored_rocksdb_marker_path() const -> fs::path {
+    return root_dir_ / "ACTIVE_ROCKSDB_SNAPSHOT";
+  }
+
+  [[nodiscard]] auto restore_staging_path() const -> fs::path {
+    auto staging_path = active_rocksdb_path_;
+    staging_path += ".restore.tmp";
+    return staging_path;
+  }
+
+  [[nodiscard]] auto active_rocksdb_matches_snapshot(const SnapshotManifest &manifest) const
+      -> bool {
+    if (!fs::is_directory(active_rocksdb_path_) || !fs::exists(active_rocksdb_path_ / "CURRENT")) {
+      return false;
+    }
+
+    auto marker = read_text(restored_rocksdb_marker_path());
+    return marker.has_value() && trim(marker.value()) == manifest.snapshot_id_;
+  }
+
+  auto publish_staged_rocksdb_restore(const fs::path &staging_path) const -> void {
+    std::error_code ec;
+    fs::remove_all(active_rocksdb_path_, ec);
+    if (ec) {
+      std::error_code cleanup_ec;
+      fs::remove_all(staging_path, cleanup_ec);
+      throw std::runtime_error("Failed to remove active RocksDB directory " +
+                               active_rocksdb_path_.string() + ": " + ec.message());
+    }
+
+    fs::rename(staging_path, active_rocksdb_path_, ec);
+    if (ec) {
+      std::error_code cleanup_ec;
+      fs::remove_all(staging_path, cleanup_ec);
+      throw std::runtime_error("Failed to publish restored RocksDB directory " +
+                               active_rocksdb_path_.string() + ": " + ec.message());
+    }
+
+    auto parent = active_rocksdb_path_.parent_path();
+    if (!parent.empty()) {
+      platform::sync_directory(parent);
+    }
+  }
+
+  static auto require_snapshot_component(const fs::path &snapshot_dir,
+                                         const std::string &relative_path,
+                                         const char *component_name) -> void {
+    if (relative_path.empty()) {
+      return;
+    }
+    auto component_path = snapshot_dir / relative_path;
+    if (!fs::exists(component_path)) {
+      throw std::runtime_error(std::string("Recovery snapshot is incomplete: missing ") +
+                               component_name + " at " + component_path.string());
+    }
+  }
+
+  static auto validate_snapshot_complete(const SnapshotManifest &manifest,
+                                         const fs::path &snapshot_dir) -> void {
+    require_snapshot_component(snapshot_dir, manifest.graph_file_, "graph snapshot");
+    require_snapshot_component(snapshot_dir, manifest.data_file_, "data snapshot");
+    require_snapshot_component(snapshot_dir, manifest.quant_file_, "quant snapshot");
+    require_snapshot_component(snapshot_dir, manifest.rocksdb_dir_, "RocksDB checkpoint");
+  }
+
   /**
    * @brief Removes stale snapshot directories after a new snapshot is published.
    *

--- a/include/storage/rocksdb_storage.hpp
+++ b/include/storage/rocksdb_storage.hpp
@@ -35,6 +35,7 @@
 
 #include "utils/index_encoding.hpp"
 #include "utils/log.hpp"
+#include "utils/query_utils.hpp"
 #include "utils/scalar_data.hpp"
 
 namespace alaya {
@@ -103,10 +104,29 @@ class RocksDBStorage {
       config_ = std::move(other.config_);
       cached_count_.store(other.cached_count_.load());
       read_only_ = other.read_only_;
+      invalidate_range_index_cache();
       other.read_only_ = false;
     }
     return *this;
   }
+
+  struct IntRangeIndexEntry {
+    int64_t value_;
+    IDType id_;
+  };
+
+  using IntRangeIndex = std::vector<IntRangeIndexEntry>;
+
+  struct IntRangeIndexRange {
+    std::shared_ptr<const IntRangeIndex> entries_;
+    size_t begin_ = 0;
+    size_t end_ = 0;
+  };
+
+  struct CachedBlockedBitset {
+    std::shared_ptr<const DynamicBitset> blocked_;
+    size_t matched_count_ = 0;
+  };
 
   /**
    * @brief Get ScalarData by internal ID
@@ -250,6 +270,7 @@ class RocksDBStorage {
     if (!replacing_existing) {
       ++cached_count_;
     }
+    invalidate_range_index_cache();
     return true;
   }
 
@@ -353,6 +374,7 @@ class RocksDBStorage {
     }
 
     cached_count_ += inserted_count;
+    invalidate_range_index_cache();
     return true;
   }
 
@@ -389,6 +411,7 @@ class RocksDBStorage {
     if (cached_count_ > 0) {
       --cached_count_;
     }
+    invalidate_range_index_cache();
     return true;
   }
 
@@ -440,6 +463,7 @@ class RocksDBStorage {
       return false;
     }
 
+    invalidate_range_index_cache();
     return true;
   }
 
@@ -549,23 +573,37 @@ class RocksDBStorage {
                                             const MetadataValue &value) const
       -> std::vector<IDType> {
     std::vector<IDType> ids;
+    visit_ids_by_field_value(field, value, [&ids](IDType id) {
+      ids.push_back(id);
+    });
+    return ids;
+  }
+
+  template <typename Visitor>
+  void visit_ids_by_field_value(const std::string &field,
+                                const MetadataValue &value,
+                                Visitor &&visitor) const {
     std::string encoded = index_encoding::encode_value(value);
     std::string prefix = index_encoding::make_field_index_prefix(field, encoded);
 
     rocksdb::ReadOptions read_opts;
     read_opts.fill_cache = false;
+    auto upper_bound = prefix_upper_bound(prefix);
+    rocksdb::Slice upper_bound_slice;
+    if (upper_bound.has_value()) {
+      upper_bound_slice = rocksdb::Slice(*upper_bound);
+      read_opts.iterate_upper_bound = &upper_bound_slice;
+    }
     std::unique_ptr<rocksdb::Iterator> iter(db_->NewIterator(read_opts));
 
     for (iter->Seek(prefix); iter->Valid(); iter->Next()) {
-      auto key = iter->key().ToString();
-      if (!key.starts_with(prefix)) {
+      auto key = iter->key();
+      if (!slice_starts_with(key, prefix)) {
         break;
       }
-      IDType id = index_encoding::extract_id_from_key<IDType>(key);
-      ids.push_back(id);
+      IDType id = extract_id_from_key_slice(key);
+      visitor(id);
     }
-
-    return ids;
   }
 
   /**
@@ -578,41 +616,116 @@ class RocksDBStorage {
   [[nodiscard]] auto get_ids_by_int_range(const std::string &field,
                                           int64_t min_value,
                                           int64_t max_value) const -> std::vector<IDType> {
+    if (auto range = get_int_range_index_range(field, min_value, max_value)) {
+      std::vector<IDType> ids;
+      ids.reserve(range->end_ - range->begin_);
+      for (size_t i = range->begin_; i < range->end_; ++i) {
+        ids.push_back((*range->entries_)[i].id_);
+      }
+      return ids;
+    }
+
     std::vector<IDType> ids;
+    visit_ids_by_int_range(field, min_value, max_value, [&ids](IDType id) {
+      ids.push_back(id);
+    });
+    return ids;
+  }
+
+  [[nodiscard]] auto get_int_range_index_range(const std::string &field,
+                                               int64_t min_value,
+                                               int64_t max_value) const
+      -> std::optional<IntRangeIndexRange> {
+    if (min_value > max_value) {
+      return IntRangeIndexRange{std::make_shared<IntRangeIndex>(), 0, 0};
+    }
+
+    auto entries = get_or_build_int_range_index(field);
+    if (entries == nullptr) {
+      return std::nullopt;
+    }
+
+    auto lower = std::lower_bound(entries->begin(),
+                                  entries->end(),
+                                  min_value,
+                                  [](const IntRangeIndexEntry &entry, int64_t value) {
+                                    return entry.value_ < value;
+                                  });
+    auto upper = std::upper_bound(entries->begin(),
+                                  entries->end(),
+                                  max_value,
+                                  [](int64_t value, const IntRangeIndexEntry &entry) {
+                                    return value < entry.value_;
+                                  });
+
+    return IntRangeIndexRange{
+        entries,
+        static_cast<size_t>(std::distance(entries->begin(), lower)),
+        static_cast<size_t>(std::distance(entries->begin(), upper)),
+    };
+  }
+
+  [[nodiscard]] auto get_int_range_blocked_bitset(const std::string &field,
+                                                  int64_t min_value,
+                                                  int64_t max_value,
+                                                  size_t data_num) const
+      -> std::optional<CachedBlockedBitset> {
+    auto cache_key = int_range_bitset_cache_key(field, min_value, max_value, data_num);
+    {
+      std::lock_guard<std::mutex> lock(range_index_cache_mutex_);
+      auto cached = int_range_bitset_cache_.find(cache_key);
+      if (cached != int_range_bitset_cache_.end()) {
+        return cached->second;
+      }
+    }
+
+    auto range = get_int_range_index_range(field, min_value, max_value);
+    if (!range.has_value()) {
+      return std::nullopt;
+    }
+
+    auto built = build_int_range_blocked_bitset(*range, data_num);
+    {
+      std::lock_guard<std::mutex> lock(range_index_cache_mutex_);
+      auto [it, inserted] = int_range_bitset_cache_.emplace(cache_key, built);
+      (void)inserted;
+      return it->second;
+    }
+  }
+
+  template <typename Visitor>
+  void visit_ids_by_int_range(const std::string &field,
+                              int64_t min_value,
+                              int64_t max_value,
+                              Visitor &&visitor) const {
+    if (min_value > max_value) {
+      return;
+    }
 
     std::string field_prefix = index_encoding::make_field_prefix(field);
-    std::string start_key = field_prefix + "i_" + index_encoding::encode_int64(min_value);
+    std::string typed_prefix = field_prefix + "i_";
+    std::string start_key = typed_prefix + index_encoding::encode_int64(min_value);
     std::string end_encoded = index_encoding::encode_int64(max_value);
+    std::string end_key_prefix = typed_prefix + end_encoded + "_";
 
     rocksdb::ReadOptions read_opts;
     read_opts.fill_cache = false;
+    auto upper_bound = prefix_upper_bound(end_key_prefix);
+    rocksdb::Slice upper_bound_slice;
+    if (upper_bound.has_value()) {
+      upper_bound_slice = rocksdb::Slice(*upper_bound);
+      read_opts.iterate_upper_bound = &upper_bound_slice;
+    }
     std::unique_ptr<rocksdb::Iterator> iter(db_->NewIterator(read_opts));
 
     for (iter->Seek(start_key); iter->Valid(); iter->Next()) {
-      auto key = iter->key().ToString();
-      // Check if still in the same field
-      if (!key.starts_with(field_prefix)) {
+      auto key = iter->key();
+      if (!slice_starts_with(key, typed_prefix)) {
         break;
       }
-      // Check if it's an int type (prefix "i_")
-      if (key.size() < field_prefix.size() + 2 || key.substr(field_prefix.size(), 2) != "i_") {
-        continue;
-      }
-      // Extract encoded value and check range
-      auto value_start = field_prefix.size() + 2;
-      auto value_end = key.rfind('_');
-      if (value_end == std::string::npos || value_end <= value_start) {
-        continue;
-      }
-      std::string encoded_value = key.substr(value_start, value_end - value_start);
-      if (encoded_value > end_encoded) {
-        break;  // Exceeded max value
-      }
-      IDType id = index_encoding::extract_id_from_key<IDType>(key);
-      ids.push_back(id);
+      IDType id = extract_id_from_key_slice(key);
+      visitor(id);
     }
-
-    return ids;
   }
 
   /**
@@ -626,37 +739,45 @@ class RocksDBStorage {
                                              double min_value,
                                              double max_value) const -> std::vector<IDType> {
     std::vector<IDType> ids;
+    visit_ids_by_double_range(field, min_value, max_value, [&ids](IDType id) {
+      ids.push_back(id);
+    });
+    return ids;
+  }
+
+  template <typename Visitor>
+  void visit_ids_by_double_range(const std::string &field,
+                                 double min_value,
+                                 double max_value,
+                                 Visitor &&visitor) const {
+    if (min_value > max_value) {
+      return;
+    }
 
     std::string field_prefix = index_encoding::make_field_prefix(field);
-    std::string start_key = field_prefix + "d_" + index_encoding::encode_double(min_value);
+    std::string typed_prefix = field_prefix + "d_";
+    std::string start_key = typed_prefix + index_encoding::encode_double(min_value);
     std::string end_encoded = index_encoding::encode_double(max_value);
+    std::string end_key_prefix = typed_prefix + end_encoded + "_";
 
     rocksdb::ReadOptions read_opts;
     read_opts.fill_cache = false;
+    auto upper_bound = prefix_upper_bound(end_key_prefix);
+    rocksdb::Slice upper_bound_slice;
+    if (upper_bound.has_value()) {
+      upper_bound_slice = rocksdb::Slice(*upper_bound);
+      read_opts.iterate_upper_bound = &upper_bound_slice;
+    }
     std::unique_ptr<rocksdb::Iterator> iter(db_->NewIterator(read_opts));
 
     for (iter->Seek(start_key); iter->Valid(); iter->Next()) {
-      auto key = iter->key().ToString();
-      if (!key.starts_with(field_prefix)) {
+      auto key = iter->key();
+      if (!slice_starts_with(key, typed_prefix)) {
         break;
       }
-      if (key.size() < field_prefix.size() + 2 || key.substr(field_prefix.size(), 2) != "d_") {
-        continue;
-      }
-      auto value_start = field_prefix.size() + 2;
-      auto value_end = key.rfind('_');
-      if (value_end == std::string::npos || value_end <= value_start) {
-        continue;
-      }
-      std::string encoded_value = key.substr(value_start, value_end - value_start);
-      if (encoded_value > end_encoded) {
-        break;
-      }
-      IDType id = index_encoding::extract_id_from_key<IDType>(key);
-      ids.push_back(id);
+      IDType id = extract_id_from_key_slice(key);
+      visitor(id);
     }
-
-    return ids;
   }
 
   [[nodiscard]] auto config() const -> const RocksDBConfig & { return config_; }
@@ -696,14 +817,14 @@ class RocksDBStorage {
     rocksdb::Status status = rocksdb::Checkpoint::Create(db_.get(), &checkpoint_raw);
     std::unique_ptr<rocksdb::Checkpoint> checkpoint(checkpoint_raw);
     if (!status.ok()) {
-      LOG_ERROR("Failed to create checkpoint: {}", status.ToString());
-      return;
+      throw std::runtime_error("Failed to create RocksDB checkpoint: " + status.ToString());
     }
 
     status = checkpoint->CreateCheckpoint(filepath);
 
     if (!status.ok()) {
-      LOG_ERROR("Failed to save checkpoint to {}: {}", filepath, status.ToString());
+      throw std::runtime_error("Failed to save RocksDB checkpoint to " + filepath + ": " +
+                               status.ToString());
     }
   }
 
@@ -759,6 +880,167 @@ class RocksDBStorage {
 
   static auto legacy_data_key(IDType id) -> std::string {
     return std::string(data_key_prefix()) + std::to_string(static_cast<UnsignedIDType>(id));
+  }
+
+  static auto slice_starts_with(const rocksdb::Slice &key, std::string_view prefix) -> bool {
+    return key.size() >= prefix.size() &&
+           std::memcmp(key.data(), prefix.data(), prefix.size()) == 0;
+  }
+
+  static auto prefix_upper_bound(std::string_view prefix) -> std::optional<std::string> {
+    std::string upper(prefix);
+    for (size_t i = upper.size(); i > 0; --i) {
+      auto byte = static_cast<unsigned char>(upper[i - 1]);
+      if (byte == 0xFFU) {
+        continue;
+      }
+      upper[i - 1] = static_cast<char>(byte + 1U);
+      upper.resize(i);
+      return upper;
+    }
+    return std::nullopt;
+  }
+
+  static auto extract_id_from_key_slice(const rocksdb::Slice &key) -> IDType {
+    return index_encoding::extract_id_from_key<IDType>(std::string_view(key.data(), key.size()));
+  }
+
+  static auto int_range_bitset_cache_key(const std::string &field,
+                                         int64_t min_value,
+                                         int64_t max_value,
+                                         size_t data_num) -> std::string {
+    return std::to_string(field.size()) + ":" + field + ":" + std::to_string(min_value) + ":" +
+           std::to_string(max_value) + ":" + std::to_string(data_num);
+  }
+
+  static auto parse_int_field_index_key(std::string_view key, size_t prefix_size)
+      -> std::optional<IntRangeIndexEntry> {
+    constexpr size_t kEncodedInt64Size = 16;
+    if (key.size() <= prefix_size + kEncodedInt64Size ||
+        key[prefix_size + kEncodedInt64Size] != '_') {
+      return std::nullopt;
+    }
+
+    auto encoded = std::string(key.substr(prefix_size, kEncodedInt64Size));
+    auto value = index_encoding::decode_int64(encoded);
+    auto id = index_encoding::extract_id_from_key<IDType>(key);
+    return IntRangeIndexEntry{value, id};
+  }
+
+  [[nodiscard]] auto get_or_build_int_range_index(const std::string &field) const
+      -> std::shared_ptr<const IntRangeIndex> {
+    {
+      std::lock_guard<std::mutex> lock(range_index_cache_mutex_);
+      auto cached = int_range_indexes_.find(field);
+      if (cached != int_range_indexes_.end()) {
+        return cached->second;
+      }
+    }
+
+    auto built = build_int_range_index(field);
+    {
+      std::lock_guard<std::mutex> lock(range_index_cache_mutex_);
+      auto [it, inserted] = int_range_indexes_.emplace(field, built);
+      (void)inserted;
+      return it->second;
+    }
+  }
+
+  [[nodiscard]] auto build_int_range_index(const std::string &field) const
+      -> std::shared_ptr<const IntRangeIndex> {
+    auto entries = std::make_shared<IntRangeIndex>();
+    std::string prefix = index_encoding::make_field_prefix(field) + "i_";
+
+    rocksdb::ReadOptions read_opts;
+    read_opts.fill_cache = false;
+    auto upper_bound = prefix_upper_bound(prefix);
+    rocksdb::Slice upper_bound_slice;
+    if (upper_bound.has_value()) {
+      upper_bound_slice = rocksdb::Slice(*upper_bound);
+      read_opts.iterate_upper_bound = &upper_bound_slice;
+    }
+
+    std::unique_ptr<rocksdb::Iterator> iter(db_->NewIterator(read_opts));
+    for (iter->Seek(prefix); iter->Valid(); iter->Next()) {
+      auto key = iter->key();
+      if (!slice_starts_with(key, prefix)) {
+        break;
+      }
+
+      auto parsed =
+          parse_int_field_index_key(std::string_view(key.data(), key.size()), prefix.size());
+      if (parsed.has_value()) {
+        entries->push_back(*parsed);
+      }
+    }
+
+    std::sort(entries->begin(), entries->end(), [](const auto &lhs, const auto &rhs) {
+      if (lhs.value_ != rhs.value_) {
+        return lhs.value_ < rhs.value_;
+      }
+      return lhs.id_ < rhs.id_;
+    });
+
+    return entries;
+  }
+
+  [[nodiscard]] auto build_int_range_blocked_bitset(const IntRangeIndexRange &range,
+                                                    size_t data_num) const -> CachedBlockedBitset {
+    DynamicBitset blocked(data_num);
+    auto entries = range.entries_;
+    auto hit_count = range.end_ - range.begin_;
+
+    if (hit_count == 0) {
+      blocked.set_all();
+      return CachedBlockedBitset{
+          std::make_shared<DynamicBitset>(std::move(blocked)),
+          0,
+      };
+    }
+
+    if (entries->size() == data_num && hit_count > entries->size() / 2) {
+      size_t matched_count = data_num;
+      auto block_id = [&](IDType id) {
+        auto raw_id = static_cast<size_t>(id);
+        if (raw_id < data_num && !blocked.get(raw_id)) {
+          blocked.set(raw_id);
+          --matched_count;
+        }
+      };
+
+      for (size_t i = 0; i < range.begin_; ++i) {
+        block_id((*entries)[i].id_);
+      }
+      for (size_t i = range.end_; i < entries->size(); ++i) {
+        block_id((*entries)[i].id_);
+      }
+
+      return CachedBlockedBitset{
+          std::make_shared<DynamicBitset>(std::move(blocked)),
+          matched_count,
+      };
+    }
+
+    blocked.set_all();
+    size_t matched_count = 0;
+    for (size_t i = range.begin_; i < range.end_; ++i) {
+      auto raw_id = static_cast<size_t>((*entries)[i].id_);
+      if (raw_id < data_num && blocked.get(raw_id)) {
+        blocked.reset(raw_id);
+        ++matched_count;
+      }
+    }
+
+    return CachedBlockedBitset{
+        std::make_shared<DynamicBitset>(std::move(blocked)),
+        matched_count,
+    };
+  }
+
+  void invalidate_range_index_cache() const {
+    std::lock_guard<std::mutex> lock(range_index_cache_mutex_);
+    int_range_indexes_.clear();
+    int_range_bitset_cache_.clear();
   }
 
   static auto parse_data_key(std::string_view key) -> std::optional<IDType> {
@@ -1034,6 +1316,9 @@ class RocksDBStorage {
   RocksDBConfig config_;
   mutable std::atomic<size_t> cached_count_;
   mutable std::mutex write_mutex_;
+  mutable std::mutex range_index_cache_mutex_;
+  mutable std::unordered_map<std::string, std::shared_ptr<const IntRangeIndex>> int_range_indexes_;
+  mutable std::unordered_map<std::string, CachedBlockedBitset> int_range_bitset_cache_;
   bool read_only_{false};
 };
 

--- a/include/utils/index_encoding.hpp
+++ b/include/utils/index_encoding.hpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <string_view>
 
 #include "scalar_data.hpp"
 
@@ -133,12 +134,20 @@ inline auto make_field_prefix(const std::string &field) -> std::string {
  * @brief Extract ID from field index key (last component after underscore)
  */
 template <typename IDType>
-inline auto extract_id_from_key(const std::string &key) -> IDType {
+inline auto extract_id_from_key(std::string_view key) -> IDType {
   auto last_underscore = key.rfind('_');
-  if (last_underscore == std::string::npos) {
+  if (last_underscore == std::string_view::npos) {
     return 0;
   }
-  return static_cast<IDType>(std::stoull(key.substr(last_underscore + 1)));
+  IDType value = 0;
+  for (size_t i = last_underscore + 1; i < key.size(); ++i) {
+    auto ch = key[i];
+    if (ch < '0' || ch > '9') {
+      return 0;
+    }
+    value = static_cast<IDType>((value * 10) + static_cast<IDType>(ch - '0'));
+  }
+  return value;
 }
 
 }  // namespace alaya::index_encoding

--- a/include/utils/metadata_filter_matcher.hpp
+++ b/include/utils/metadata_filter_matcher.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <iterator>
 #include <limits>
 #include <optional>
 #include <stdexcept>
@@ -25,6 +26,8 @@ namespace alaya {
 template <typename IDType>
 class MetadataFilterExecutor {
  public:
+  enum class IndexBuildMode : uint8_t { kEager, kSkip };
+
   struct BlockedBitsetResult {
     explicit BlockedBitsetResult(size_t data_num) : blocked_(data_num) {}
 
@@ -32,24 +35,39 @@ class MetadataFilterExecutor {
     size_t matched_count_ = 0;
   };
 
+  struct IndexedFilterPlan {
+    std::vector<IDType> ids_;
+    bool exact_ = false;
+  };
+
   MetadataFilterExecutor(const MetadataFilter &filter,
                          const RocksDBStorage<IDType> *storage,
-                         size_t data_num)
+                         size_t data_num,
+                         IndexBuildMode index_build_mode = IndexBuildMode::kEager)
       : filter_(filter), storage_(storage), data_num_(data_num), allow_ids_(data_num) {
     if (storage_ == nullptr) {
       throw std::invalid_argument("Storage cannot be null");
     }
 
     collect_required_fields(filter_, required_fields_);
-    build_index_fast_path();
+    if (index_build_mode == IndexBuildMode::kEager) {
+      build_index_fast_path();
+    }
   }
 
   [[nodiscard]] auto filter() const -> const MetadataFilter & { return filter_; }
   [[nodiscard]] auto is_trivially_true() const -> bool { return filter_.is_empty(); }
   [[nodiscard]] auto has_index_fast_path() const -> bool { return has_index_fast_path_; }
+  [[nodiscard]] auto index_fast_path_is_exact() const -> bool { return index_fast_path_exact_; }
   [[nodiscard]] auto indexed_ids() const -> const std::vector<IDType> & { return indexed_ids_; }
   [[nodiscard]] auto indexed_count() const -> size_t { return indexed_ids_.size(); }
   [[nodiscard]] auto data_num() const -> size_t { return data_num_; }
+
+  void materialize_index_fast_path() {
+    if (!has_index_fast_path_) {
+      build_index_fast_path();
+    }
+  }
 
   [[nodiscard]] auto match(IDType id) const -> bool {
     if (filter_.is_empty()) {
@@ -57,7 +75,15 @@ class MetadataFilterExecutor {
     }
 
     if (has_index_fast_path_) {
-      return allow_ids_.get(id);
+      if (static_cast<size_t>(id) >= data_num_) {
+        return false;
+      }
+      if (!allow_ids_.get(id)) {
+        return false;
+      }
+      if (index_fast_path_exact_) {
+        return true;
+      }
     }
 
     std::string raw_value;
@@ -85,13 +111,7 @@ class MetadataFilterExecutor {
     }
 
     if (has_index_fast_path_) {
-      for (size_t i = 0; i < ids.size(); ++i) {
-        if (allow_ids_.get(ids[i])) {
-          ++result.matched_count_;
-        } else {
-          result.blocked_.set(i);
-        }
-      }
+      build_indexed_subset_bitset(ids, result);
       return result;
     }
 
@@ -122,16 +142,22 @@ class MetadataFilterExecutor {
     if (has_index_fast_path_) {
       result.blocked_.set_all();
       for (auto id : indexed_ids_) {
-        result.blocked_.reset(id);
+        if (index_fast_path_exact_) {
+          result.blocked_.reset(id);
+          ++result.matched_count_;
+          continue;
+        }
+
+        if (match(id)) {
+          result.blocked_.reset(id);
+          ++result.matched_count_;
+        }
       }
-      result.matched_count_ = indexed_ids_.size();
       return result;
     }
 
-    // TODO(P0): This path performs O(N) RocksDB reads when the index fast path
-    // is not available (any filter beyond single-condition AND on an indexed
-    // field). For large datasets, this degrades to a full table scan per query.
-    // Future work: support multi-condition index intersection to avoid this.
+    // TODO(P0): This path performs O(N) RocksDB reads when no indexed sub-plan is
+    // available. For large datasets, this degrades to a full table scan per query.
     if (data_num_ > 10000) {
       LOG_WARN(
           "metadata filter: O(N) full-scan fallback for {} records; "
@@ -162,10 +188,121 @@ class MetadataFilterExecutor {
     return result;
   }
 
+  [[nodiscard]] auto build_direct_indexed_blocked_bitset() const
+      -> std::optional<BlockedBitsetResult> {
+    auto condition = simple_direct_index_condition(filter_);
+    if (condition == nullptr) {
+      return std::nullopt;
+    }
+
+    if (auto int_range_result = build_direct_int_range_blocked_bitset(*condition)) {
+      return int_range_result;
+    }
+
+    BlockedBitsetResult result(data_num_);
+    result.blocked_.set_all();
+
+    auto mark_allowed = [&result, this](IDType id) {
+      if (static_cast<size_t>(id) >= data_num_) {
+        return;
+      }
+      if (result.blocked_.get(id)) {
+        result.blocked_.reset(id);
+        ++result.matched_count_;
+      }
+    };
+
+    if (!visit_indexed_ids(*condition, mark_allowed)) {
+      return std::nullopt;
+    }
+    return result;
+  }
+
  private:
+  [[nodiscard]] static auto int_range_bounds(const FilterCondition &cond)
+      -> std::optional<std::pair<int64_t, int64_t>> {
+    switch (cond.op) {
+      case FilterOp::GE:
+        if (std::holds_alternative<int64_t>(cond.value)) {
+          return std::pair{std::get<int64_t>(cond.value), std::numeric_limits<int64_t>::max()};
+        }
+        return std::nullopt;
+      case FilterOp::GT:
+        if (std::holds_alternative<int64_t>(cond.value)) {
+          auto value = std::get<int64_t>(cond.value);
+          if (value == std::numeric_limits<int64_t>::max()) {
+            return std::pair{int64_t{1}, int64_t{0}};
+          }
+          return std::pair{value + 1, std::numeric_limits<int64_t>::max()};
+        }
+        return std::nullopt;
+      case FilterOp::LE:
+        if (std::holds_alternative<int64_t>(cond.value)) {
+          return std::pair{std::numeric_limits<int64_t>::min(), std::get<int64_t>(cond.value)};
+        }
+        return std::nullopt;
+      case FilterOp::LT:
+        if (std::holds_alternative<int64_t>(cond.value)) {
+          auto value = std::get<int64_t>(cond.value);
+          if (value == std::numeric_limits<int64_t>::min()) {
+            return std::pair{int64_t{1}, int64_t{0}};
+          }
+          return std::pair{std::numeric_limits<int64_t>::min(), value - 1};
+        }
+        return std::nullopt;
+      default:
+        return std::nullopt;
+    }
+  }
+
+  [[nodiscard]] auto build_direct_int_range_blocked_bitset(const FilterCondition &cond) const
+      -> std::optional<BlockedBitsetResult> {
+    if (!is_indexed_field(cond.field)) {
+      return std::nullopt;
+    }
+
+    auto bounds = int_range_bounds(cond);
+    if (!bounds.has_value()) {
+      return std::nullopt;
+    }
+
+    auto cached = storage_->get_int_range_blocked_bitset(cond.field,
+                                                         bounds->first,
+                                                         bounds->second,
+                                                         data_num_);
+    if (!cached.has_value() || cached->blocked_ == nullptr) {
+      return std::nullopt;
+    }
+
+    BlockedBitsetResult result(data_num_);
+    result.blocked_ = *cached->blocked_;
+    result.matched_count_ = cached->matched_count_;
+    return result;
+  }
+
   [[nodiscard]] auto is_indexed_field(const std::string &field) const -> bool {
     const auto &indexed_fields = storage_->config().indexed_fields_;
     return std::find(indexed_fields.begin(), indexed_fields.end(), field) != indexed_fields.end();
+  }
+
+  [[nodiscard]] auto lookup_indexed_int_range_ids(const FilterCondition &cond) const
+      -> std::optional<std::vector<IDType>> {
+    auto bounds = int_range_bounds(cond);
+    if (!bounds.has_value()) {
+      return std::nullopt;
+    }
+
+    auto range = storage_->get_int_range_index_range(cond.field, bounds->first, bounds->second);
+    if (!range.has_value()) {
+      return std::nullopt;
+    }
+
+    std::vector<IDType> ids;
+    ids.reserve(range->end_ - range->begin_);
+    for (size_t i = range->begin_; i < range->end_; ++i) {
+      ids.push_back((*range->entries_)[i].id_);
+    }
+    return ids;
   }
 
   [[nodiscard]] auto lookup_indexed_ids(const FilterCondition &cond) const
@@ -189,9 +326,7 @@ class MetadataFilterExecutor {
         return ids;
       case FilterOp::GE:
         if (std::holds_alternative<int64_t>(cond.value)) {
-          return storage_->get_ids_by_int_range(cond.field,
-                                                std::get<int64_t>(cond.value),
-                                                std::numeric_limits<int64_t>::max());
+          return lookup_indexed_int_range_ids(cond);
         }
         if (std::holds_alternative<double>(cond.value)) {
           return storage_->get_ids_by_double_range(cond.field,
@@ -201,13 +336,7 @@ class MetadataFilterExecutor {
         return std::nullopt;
       case FilterOp::GT:
         if (std::holds_alternative<int64_t>(cond.value)) {
-          auto value = std::get<int64_t>(cond.value);
-          if (value == std::numeric_limits<int64_t>::max()) {
-            return std::vector<IDType>{};
-          }
-          return storage_->get_ids_by_int_range(cond.field,
-                                                value + 1,
-                                                std::numeric_limits<int64_t>::max());
+          return lookup_indexed_int_range_ids(cond);
         }
         if (std::holds_alternative<double>(cond.value)) {
           auto value = std::get<double>(cond.value);
@@ -219,9 +348,7 @@ class MetadataFilterExecutor {
         return std::nullopt;
       case FilterOp::LE:
         if (std::holds_alternative<int64_t>(cond.value)) {
-          return storage_->get_ids_by_int_range(cond.field,
-                                                std::numeric_limits<int64_t>::min(),
-                                                std::get<int64_t>(cond.value));
+          return lookup_indexed_int_range_ids(cond);
         }
         if (std::holds_alternative<double>(cond.value)) {
           return storage_->get_ids_by_double_range(cond.field,
@@ -231,13 +358,7 @@ class MetadataFilterExecutor {
         return std::nullopt;
       case FilterOp::LT:
         if (std::holds_alternative<int64_t>(cond.value)) {
-          auto value = std::get<int64_t>(cond.value);
-          if (value == std::numeric_limits<int64_t>::min()) {
-            return std::vector<IDType>{};
-          }
-          return storage_->get_ids_by_int_range(cond.field,
-                                                std::numeric_limits<int64_t>::min(),
-                                                value - 1);
+          return lookup_indexed_int_range_ids(cond);
         }
         if (std::holds_alternative<double>(cond.value)) {
           auto value = std::get<double>(cond.value);
@@ -253,26 +374,383 @@ class MetadataFilterExecutor {
     }
   }
 
-  // TODO(P2): Extend to support multi-condition AND by intersecting indexed ID
-  // sets, and OR by unioning them. Currently only single-condition AND filters
-  // on an indexed field can use the fast path; all other filters fall through
-  // to the O(N) full-scan in build_blocked_bitset().
+  [[nodiscard]] auto simple_direct_index_condition(const MetadataFilter &filter) const
+      -> const FilterCondition * {
+    if (filter.logic_op != LogicOp::AND || filter.conditions.size() != 1 ||
+        !filter.sub_filters.empty()) {
+      return nullptr;
+    }
+    const auto &condition = filter.conditions.front();
+    if (!is_indexed_field(condition.field)) {
+      return nullptr;
+    }
+    return &condition;
+  }
+
+  template <typename Visitor>
+  [[nodiscard]] auto visit_indexed_ids(const FilterCondition &cond, Visitor &&visitor) const
+      -> bool {
+    if (!is_indexed_field(cond.field)) {
+      return false;
+    }
+
+    switch (cond.op) {
+      case FilterOp::EQ:
+        storage_->visit_ids_by_field_value(cond.field, cond.value, visitor);
+        return true;
+      case FilterOp::IN_SET:
+        for (const auto &value : cond.values) {
+          storage_->visit_ids_by_field_value(cond.field, value, visitor);
+        }
+        return true;
+      case FilterOp::GE:
+        if (std::holds_alternative<int64_t>(cond.value)) {
+          storage_->visit_ids_by_int_range(cond.field,
+                                           std::get<int64_t>(cond.value),
+                                           std::numeric_limits<int64_t>::max(),
+                                           visitor);
+          return true;
+        }
+        if (std::holds_alternative<double>(cond.value)) {
+          storage_->visit_ids_by_double_range(cond.field,
+                                              std::get<double>(cond.value),
+                                              std::numeric_limits<double>::max(),
+                                              visitor);
+          return true;
+        }
+        return false;
+      case FilterOp::GT:
+        if (std::holds_alternative<int64_t>(cond.value)) {
+          auto value = std::get<int64_t>(cond.value);
+          if (value == std::numeric_limits<int64_t>::max()) {
+            return true;
+          }
+          storage_->visit_ids_by_int_range(cond.field,
+                                           value + 1,
+                                           std::numeric_limits<int64_t>::max(),
+                                           visitor);
+          return true;
+        }
+        if (std::holds_alternative<double>(cond.value)) {
+          auto value = std::get<double>(cond.value);
+          storage_->visit_ids_by_double_range(cond.field,
+                                              std::nextafter(value,
+                                                             std::numeric_limits<double>::max()),
+                                              std::numeric_limits<double>::max(),
+                                              visitor);
+          return true;
+        }
+        return false;
+      case FilterOp::LE:
+        if (std::holds_alternative<int64_t>(cond.value)) {
+          storage_->visit_ids_by_int_range(cond.field,
+                                           std::numeric_limits<int64_t>::min(),
+                                           std::get<int64_t>(cond.value),
+                                           visitor);
+          return true;
+        }
+        if (std::holds_alternative<double>(cond.value)) {
+          storage_->visit_ids_by_double_range(cond.field,
+                                              std::numeric_limits<double>::lowest(),
+                                              std::get<double>(cond.value),
+                                              visitor);
+          return true;
+        }
+        return false;
+      case FilterOp::LT:
+        if (std::holds_alternative<int64_t>(cond.value)) {
+          auto value = std::get<int64_t>(cond.value);
+          if (value == std::numeric_limits<int64_t>::min()) {
+            return true;
+          }
+          storage_->visit_ids_by_int_range(cond.field,
+                                           std::numeric_limits<int64_t>::min(),
+                                           value - 1,
+                                           visitor);
+          return true;
+        }
+        if (std::holds_alternative<double>(cond.value)) {
+          auto value = std::get<double>(cond.value);
+          storage_->visit_ids_by_double_range(cond.field,
+                                              std::numeric_limits<double>::lowest(),
+                                              std::nextafter(value,
+                                                             std::numeric_limits<double>::lowest()),
+                                              visitor);
+          return true;
+        }
+        return false;
+      default:
+        return false;
+    }
+  }
+
+  void normalize_indexed_ids(std::vector<IDType> &ids) const {
+    ids.erase(std::remove_if(ids.begin(),
+                             ids.end(),
+                             [this](IDType id) {
+                               return static_cast<size_t>(id) >= data_num_;
+                             }),
+              ids.end());
+    std::sort(ids.begin(), ids.end());
+    ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
+  }
+
+  void discard_out_of_range_ids(std::vector<IDType> &ids) const {
+    ids.erase(std::remove_if(ids.begin(),
+                             ids.end(),
+                             [this](IDType id) {
+                               return static_cast<size_t>(id) >= data_num_;
+                             }),
+              ids.end());
+  }
+
+  [[nodiscard]] static auto simple_condition_ids_are_unique(FilterOp op) -> bool {
+    switch (op) {
+      case FilterOp::EQ:
+      case FilterOp::GE:
+      case FilterOp::GT:
+      case FilterOp::LE:
+      case FilterOp::LT:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  [[nodiscard]] auto intersect_ids(const std::vector<IDType> &lhs,
+                                   const std::vector<IDType> &rhs) const -> std::vector<IDType> {
+    std::vector<IDType> result;
+    result.reserve(std::min(lhs.size(), rhs.size()));
+    std::set_intersection(lhs.begin(),
+                          lhs.end(),
+                          rhs.begin(),
+                          rhs.end(),
+                          std::back_inserter(result));
+    return result;
+  }
+
+  [[nodiscard]] auto union_ids(const std::vector<IDType> &lhs, const std::vector<IDType> &rhs) const
+      -> std::vector<IDType> {
+    std::vector<IDType> result;
+    result.reserve(lhs.size() + rhs.size());
+    std::set_union(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), std::back_inserter(result));
+    return result;
+  }
+
+  [[nodiscard]] auto complement_ids(const std::vector<IDType> &ids) const -> std::vector<IDType> {
+    std::vector<IDType> result;
+    result.reserve(data_num_ > ids.size() ? data_num_ - ids.size() : 0);
+
+    size_t cursor = 0;
+    for (size_t raw_id = 0; raw_id < data_num_; ++raw_id) {
+      auto id = static_cast<IDType>(raw_id);
+      while (cursor < ids.size() && ids[cursor] < id) {
+        ++cursor;
+      }
+      if (cursor < ids.size() && ids[cursor] == id) {
+        continue;
+      }
+      result.push_back(id);
+    }
+    return result;
+  }
+
+  [[nodiscard]] auto build_condition_index_plan(const FilterCondition &condition) const
+      -> std::optional<IndexedFilterPlan> {
+    auto ids = lookup_indexed_ids(condition);
+    if (!ids.has_value()) {
+      return std::nullopt;
+    }
+
+    normalize_indexed_ids(*ids);
+    return IndexedFilterPlan{std::move(*ids), true};
+  }
+
+  [[nodiscard]] auto build_simple_condition_index_plan(const FilterCondition &condition) const
+      -> std::optional<IndexedFilterPlan> {
+    auto ids = lookup_indexed_ids(condition);
+    if (!ids.has_value()) {
+      return std::nullopt;
+    }
+
+    if (simple_condition_ids_are_unique(condition.op)) {
+      discard_out_of_range_ids(*ids);
+    } else {
+      normalize_indexed_ids(*ids);
+    }
+    return IndexedFilterPlan{std::move(*ids), true};
+  }
+
+  [[nodiscard]] auto build_index_plan_for_first_not_child(const MetadataFilter &filter) const
+      -> std::optional<IndexedFilterPlan> {
+    if (!filter.conditions.empty()) {
+      return build_condition_index_plan(filter.conditions.front());
+    }
+    if (!filter.sub_filters.empty() && filter.sub_filters.front() != nullptr) {
+      return build_index_plan(*filter.sub_filters.front());
+    }
+    return std::nullopt;
+  }
+
+  [[nodiscard]] auto build_and_index_plan(const MetadataFilter &filter) const
+      -> std::optional<IndexedFilterPlan> {
+    std::optional<std::vector<IDType>> current_ids;
+    bool exact = true;
+
+    auto consume_plan = [&](const std::optional<IndexedFilterPlan> &plan) {
+      if (!plan.has_value()) {
+        exact = false;
+        return;
+      }
+      if (!current_ids.has_value()) {
+        current_ids = plan->ids_;
+      } else {
+        current_ids = intersect_ids(*current_ids, plan->ids_);
+      }
+      exact = exact && plan->exact_;
+    };
+
+    for (const auto &condition : filter.conditions) {
+      consume_plan(build_condition_index_plan(condition));
+    }
+    for (const auto &sub_filter : filter.sub_filters) {
+      if (sub_filter == nullptr) {
+        consume_plan(std::nullopt);
+      } else {
+        consume_plan(build_index_plan(*sub_filter));
+      }
+    }
+
+    if (!current_ids.has_value()) {
+      return std::nullopt;
+    }
+    return IndexedFilterPlan{std::move(*current_ids), exact};
+  }
+
+  [[nodiscard]] auto build_or_index_plan(const MetadataFilter &filter) const
+      -> std::optional<IndexedFilterPlan> {
+    std::vector<IDType> current_ids;
+    bool have_plan = false;
+    bool exact = true;
+
+    auto consume_plan = [&](const std::optional<IndexedFilterPlan> &plan) -> bool {
+      if (!plan.has_value()) {
+        return false;
+      }
+      if (!have_plan) {
+        current_ids = plan->ids_;
+        have_plan = true;
+      } else {
+        current_ids = union_ids(current_ids, plan->ids_);
+      }
+      exact = exact && plan->exact_;
+      return true;
+    };
+
+    for (const auto &condition : filter.conditions) {
+      if (!consume_plan(build_condition_index_plan(condition))) {
+        return std::nullopt;
+      }
+    }
+    for (const auto &sub_filter : filter.sub_filters) {
+      if (sub_filter == nullptr || !consume_plan(build_index_plan(*sub_filter))) {
+        return std::nullopt;
+      }
+    }
+
+    if (!have_plan) {
+      return std::nullopt;
+    }
+    return IndexedFilterPlan{std::move(current_ids), exact};
+  }
+
+  [[nodiscard]] auto build_not_index_plan(const MetadataFilter &filter) const
+      -> std::optional<IndexedFilterPlan> {
+    auto child_plan = build_index_plan_for_first_not_child(filter);
+    if (!child_plan.has_value() || !child_plan->exact_) {
+      return std::nullopt;
+    }
+    return IndexedFilterPlan{complement_ids(child_plan->ids_), true};
+  }
+
+  [[nodiscard]] auto build_index_plan(const MetadataFilter &filter) const
+      -> std::optional<IndexedFilterPlan> {
+    if (filter.is_empty()) {
+      return std::nullopt;
+    }
+
+    if (filter.logic_op == LogicOp::AND && filter.conditions.size() == 1 &&
+        filter.sub_filters.empty()) {
+      return build_simple_condition_index_plan(filter.conditions.front());
+    }
+
+    switch (filter.logic_op) {
+      case LogicOp::AND:
+        return build_and_index_plan(filter);
+      case LogicOp::OR:
+        return build_or_index_plan(filter);
+      case LogicOp::NOT:
+        return build_not_index_plan(filter);
+    }
+    return std::nullopt;
+  }
+
+  void build_indexed_subset_bitset(const std::vector<IDType> &ids,
+                                   BlockedBitsetResult &result) const {
+    if (index_fast_path_exact_) {
+      for (size_t i = 0; i < ids.size(); ++i) {
+        if (static_cast<size_t>(ids[i]) >= data_num_) {
+          result.blocked_.set(i);
+          continue;
+        }
+        if (allow_ids_.get(ids[i])) {
+          ++result.matched_count_;
+        } else {
+          result.blocked_.set(i);
+        }
+      }
+      return;
+    }
+
+    std::vector<IDType> candidate_ids;
+    std::vector<size_t> candidate_positions;
+    candidate_ids.reserve(ids.size());
+    candidate_positions.reserve(ids.size());
+    for (size_t i = 0; i < ids.size(); ++i) {
+      if (static_cast<size_t>(ids[i]) >= data_num_) {
+        result.blocked_.set(i);
+        continue;
+      }
+      if (!allow_ids_.get(ids[i])) {
+        result.blocked_.set(i);
+        continue;
+      }
+      candidate_ids.push_back(ids[i]);
+      candidate_positions.push_back(i);
+    }
+
+    auto raw_values = storage_->batch_get_raw_values(candidate_ids);
+    for (size_t i = 0; i < candidate_ids.size(); ++i) {
+      if (!raw_values[i].empty() && evaluate_raw_value(raw_values[i])) {
+        ++result.matched_count_;
+      } else {
+        result.blocked_.set(candidate_positions[i]);
+      }
+    }
+  }
+
   void build_index_fast_path() {
-    if (filter_.logic_op != LogicOp::AND || filter_.conditions.size() != 1 ||
-        !filter_.sub_filters.empty()) {
+    auto indexed_plan = build_index_plan(filter_);
+    if (!indexed_plan.has_value()) {
       return;
     }
 
-    auto indexed_ids = lookup_indexed_ids(filter_.conditions.front());
-    if (!indexed_ids.has_value()) {
-      return;
-    }
-
-    indexed_ids_ = std::move(*indexed_ids);
+    indexed_ids_ = std::move(indexed_plan->ids_);
     for (auto id : indexed_ids_) {
       allow_ids_.set(id);
     }
     has_index_fast_path_ = true;
+    index_fast_path_exact_ = indexed_plan->exact_;
   }
 
   [[nodiscard]] auto evaluate_raw_value(const std::string &raw_value) const -> bool {
@@ -299,6 +777,7 @@ class MetadataFilterExecutor {
   DynamicBitset allow_ids_;
   std::vector<IDType> indexed_ids_;
   bool has_index_fast_path_ = false;
+  bool index_fast_path_exact_ = false;
 };
 
 }  // namespace alaya

--- a/python/include/index.hpp
+++ b/python/include/index.hpp
@@ -53,6 +53,7 @@
 #include "storage/rocksdb_storage.hpp"
 #include "utils/binary_io.hpp"
 #include "utils/index_encoding.hpp"
+#include "utils/locks.hpp"
 #include "utils/log.hpp"
 #include "utils/metadata_filter.hpp"
 #include "utils/metric_type.hpp"
@@ -257,6 +258,7 @@ class PyIndex : public BasePyIndex {
       return;
     }
 
+    alaya::FileLock snapshot_lock(recovery_manager_->snapshot_lock_path());
     auto snapshot_dir = recovery_manager_->create_snapshot_dir();
     auto snapshot_id = snapshot_dir.filename().string();
 

--- a/python/include/index.hpp
+++ b/python/include/index.hpp
@@ -87,7 +87,7 @@ class PyIndex : public BasePyIndex {
                                       const SearchInfo &search_info,
                                       const MetadataFilter &filter,
                                       bool brute_force_requested,
-                                      std::string *item_ids) const {
+                                      std::string *item_ids) {
     if (materialized_view_manager_
             .try_hybrid_search(query, ids, search_info, filter, brute_force_requested, item_ids)) {
       return;
@@ -130,7 +130,7 @@ class PyIndex : public BasePyIndex {
                                            SearchInfo search_info,
                                            const MetadataFilter &filter,
                                            bool brute_force_requested,
-                                           std::string *item_ids) const -> coro::task<> {
+                                           std::string *item_ids) -> coro::task<> {
     execute_hybrid_search_dispatch(query,
                                    ids,
                                    search_info,

--- a/python/include/index.hpp
+++ b/python/include/index.hpp
@@ -73,6 +73,8 @@ class PyIndex : public BasePyIndex {
   using DistanceType = typename SearchSpaceType::DistanceTypeAlias;
   using BuildSpaceType = typename GraphBuilderType::DistanceSpaceTypeAlias;
   using MaterializedViewManagerType = MaterializedViewManager<SearchSpaceType, BuildSpaceType>;
+  using HybridSearchJobType = GraphHybridSearchJob<SearchSpaceType, BuildSpaceType>;
+  using PreparedHybridSearchPlanType = typename HybridSearchJobType::PreparedHybridSearchPlan;
 
   PyIndex() = delete;
   explicit PyIndex(IndexParams params) : params_(std::move(params)) { initialize_recovery(); }
@@ -1011,8 +1013,14 @@ class PyIndex : public BasePyIndex {
       std::vector<std::vector<IDType>> id_results(query_size, std::vector<IDType>(topk));
       std::vector<std::vector<std::string>> item_id_results(query_size,
                                                             std::vector<std::string>(topk));
+      std::shared_ptr<PreparedHybridSearchPlanType> prepared_plan;
+      auto use_materialized_view = materialized_view_manager_.can_hybrid_search(filter);
       {
         py::gil_scoped_release release;
+        if (!bf && !use_materialized_view) {
+          prepared_plan = std::make_shared<PreparedHybridSearchPlanType>(
+              hybrid_search_job_->prepare_hybrid_search_plan(filter, search_info));
+        }
         auto batch_pool = get_hybrid_batch_pool(num_threads);
         std::vector<std::future<void>> futures;
         futures.reserve(query_size);
@@ -1024,7 +1032,17 @@ class PyIndex : public BasePyIndex {
                                                     search_info,
                                                     filter_ptr = &filter,
                                                     bf,
+                                                    use_materialized_view,
+                                                    prepared_plan,
                                                     item_ids = item_id_results[i].data()]() {
+            if (prepared_plan != nullptr && !use_materialized_view) {
+              hybrid_search_job_->execute_prepared_hybrid_search(cur_query,
+                                                                 ids,
+                                                                 search_info,
+                                                                 *prepared_plan,
+                                                                 item_ids);
+              return;
+            }
             execute_hybrid_search_dispatch(cur_query, ids, search_info, *filter_ptr, bf, item_ids);
           }));
         }

--- a/python/include/materialized_view.hpp
+++ b/python/include/materialized_view.hpp
@@ -7,8 +7,10 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <deque>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -335,6 +337,17 @@ class MaterializedViewManager {
       LOG_INFO("materialized_view: only the first indexed field is partitioned, field={}", field_);
     }
 
+    if (params_->materialized_view_mode_ == "off") {
+      LOG_INFO("materialized_view: disabled, field={}", field_);
+      return;
+    }
+
+    if (params_->materialized_view_mode_ == "lazy") {
+      ready_ = true;
+      LOG_INFO("materialized_view: lazy mode, field={}", field_);
+      return;
+    }
+
     try {
       auto partitions = collect_partition_seeds(*storage);
       if (!partitions.has_value()) {
@@ -354,7 +367,6 @@ class MaterializedViewManager {
       }
 
       partition_lookup_.reserve(partitions->size());
-      partitions_.reserve(partitions->size());
       for (auto &partition_seed : *partitions) {
         auto partition = build_partition(partition_seed.value_,
                                          std::move(partition_seed.encoded_value_),
@@ -382,12 +394,28 @@ class MaterializedViewManager {
     return static_cast<uint32_t>(partitions_.size());
   }
 
+  [[nodiscard]] auto can_hybrid_search(const MetadataFilter &filter) const -> bool {
+    if (!ready_ || filter.is_empty() || search_space_ == nullptr) {
+      return false;
+    }
+
+    if (params_ == nullptr || params_->materialized_view_mode_ == "lazy") {
+      return false;
+    }
+
+    if (!analyze_materialized_view_filter(filter, field_).eligible_) {
+      return false;
+    }
+
+    return search_space_->get_scalar_storage() != nullptr;
+  }
+
   auto try_hybrid_search(const DataType *query,
                          IDType *ids,
                          const SearchInfo &search_info,
                          const MetadataFilter &filter,
                          bool brute_force_requested,
-                         std::string *item_ids) const -> bool {
+                         std::string *item_ids) -> bool {
     if (!ready_ || filter.is_empty() || search_space_ == nullptr) {
       return false;
     }
@@ -418,13 +446,13 @@ class MaterializedViewManager {
 
     size_t selected_partitions = 0;
     for (const auto &value : partition_selection.values_) {
-      auto lookup_it = partition_lookup_.find(index_encoding::encode_value(value));
-      if (lookup_it == partition_lookup_.end()) {
+      auto *partition = get_or_build_partition(value);
+      if (partition == nullptr) {
         continue;
       }
 
       ++selected_partitions;
-      auto partition_results = execute_partition_search(partitions_[lookup_it->second],
+      auto partition_results = execute_partition_search(*partition,
                                                         query,
                                                         search_info,
                                                         filter_executor.get(),
@@ -647,6 +675,12 @@ class MaterializedViewManager {
     }
 
     return partitions;
+  }
+
+  auto collect_partition_seed(const RocksDBStorage<IDType> &storage,
+                              const MetadataValue &value) const -> PartitionSeed {
+    std::vector<IDType> ids = storage.get_ids_by_field_value(field_, value);
+    return PartitionSeed{value, index_encoding::encode_value(value), std::move(ids)};
   }
 
   template <typename ExactDistanceEvaluator>
@@ -872,6 +906,50 @@ class MaterializedViewManager {
     return partition;
   }
 
+  auto get_or_build_partition(const MetadataValue &value) -> Partition * {
+    auto encoded_value = index_encoding::encode_value(value);
+    auto lookup_it = partition_lookup_.find(encoded_value);
+    if (lookup_it != partition_lookup_.end()) {
+      return &partitions_[lookup_it->second];
+    }
+
+    if (params_ == nullptr || params_->materialized_view_mode_ != "lazy") {
+      return nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock(partition_build_mutex_);
+    lookup_it = partition_lookup_.find(encoded_value);
+    if (lookup_it != partition_lookup_.end()) {
+      return &partitions_[lookup_it->second];
+    }
+
+    auto *storage = search_space_ == nullptr ? nullptr : search_space_->get_scalar_storage();
+    if (storage == nullptr) {
+      return nullptr;
+    }
+
+    try {
+      auto partition_seed = collect_partition_seed(*storage, value);
+      if (partition_seed.global_ids_.empty()) {
+        return nullptr;
+      }
+
+      auto partition = build_partition(partition_seed.value_,
+                                       std::move(partition_seed.encoded_value_),
+                                       std::move(partition_seed.global_ids_));
+      auto partition_index = partitions_.size();
+      partitions_.push_back(std::move(partition));
+      partition_lookup_.emplace(encoded_value, partition_index);
+      LOG_INFO("materialized_view: built lazy partition field={}, size={}",
+               field_,
+               partitions_[partition_index].local_to_global_ids_.size());
+      return &partitions_[partition_index];
+    } catch (const std::exception &e) {
+      LOG_ERROR("materialized_view: lazy build failed for field={}, error={}", field_, e.what());
+      return nullptr;
+    }
+  }
+
   auto execute_partition_search(const Partition &partition,
                                 const DataType *query,
                                 const SearchInfo &search_info,
@@ -926,7 +1004,8 @@ class MaterializedViewManager {
   BuildSpacePtr build_space_{nullptr};
   std::string field_;
   std::unordered_map<std::string, size_t> partition_lookup_;
-  std::vector<Partition> partitions_;
+  std::deque<Partition> partitions_;
+  std::mutex partition_build_mutex_;
   uint32_t ef_construction_{200};
   uint32_t build_threads_{1};
   bool ready_{false};

--- a/python/include/params.hpp
+++ b/python/include/params.hpp
@@ -26,6 +26,7 @@ struct IndexParams {
   uint32_t max_nbrs_ = 32;
   uint32_t build_threads_ = 0;
   uint32_t materialized_view_build_threads_ = 0;
+  std::string materialized_view_mode_ = "eager";
   std::string rocksdb_path_ = "";            // Path for RocksDB storage (for scalar data)
   bool has_scalar_data_ = false;             // Whether to enable scalar data storage
   std::vector<std::string> indexed_fields_;  // Fields to create secondary indexes for
@@ -39,6 +40,7 @@ struct IndexParams {
               uint32_t max_nbrs = 32,
               uint32_t build_threads = 0,
               uint32_t materialized_view_build_threads = 0,
+              std::string materialized_view_mode = "eager",
               std::string rocksdb_path = "",
               bool has_scalar_data = false,
               std::vector<std::string> indexed_fields = {})
@@ -51,6 +53,7 @@ struct IndexParams {
         max_nbrs_(max_nbrs),
         build_threads_(build_threads),
         materialized_view_build_threads_(materialized_view_build_threads),
+        materialized_view_mode_(std::move(materialized_view_mode)),
         rocksdb_path_(std::move(rocksdb_path)),
         has_scalar_data_(has_scalar_data),
         indexed_fields_(std::move(indexed_fields)) {}

--- a/python/src/alayalite/schema.py
+++ b/python/src/alayalite/schema.py
@@ -18,6 +18,7 @@ from ._alayalitepy import IndexParams as _IndexParams
 from .common import (
     IDType,
     VectorDType,
+    _assert,
     assert_valid_index_type,
     assert_valid_metric_type,
     assert_valid_quantization_type,
@@ -47,6 +48,7 @@ class IndexParams:
     max_nbrs: int = None
     build_threads: Optional[int] = None
     materialized_view_build_threads: Optional[int] = None
+    materialized_view_mode: str = "eager"
     rocksdb_path: str = ""  # Path for RocksDB storage (for scalar data)
     has_scalar_data: bool = False  # Whether to enable scalar data storage
     indexed_fields: list = None  # Fields to create secondary indexes for (for fast filtering)
@@ -89,6 +91,11 @@ class IndexParams:
         max_nbrs = valid_max_nbrs(self.max_nbrs)
         build_threads = valid_thread_count(self.build_threads)
         materialized_view_build_threads = valid_thread_count(self.materialized_view_build_threads)
+        materialized_view_mode = str(self.materialized_view_mode or "eager").strip().lower()
+        _assert(
+            materialized_view_mode in ("off", "lazy", "eager"),
+            "materialized_view_mode must be one of: 'off', 'lazy', 'eager'",
+        )
 
         return _IndexParams(
             index_type_=native_index_type,
@@ -100,6 +107,7 @@ class IndexParams:
             max_nbrs_=max_nbrs,
             build_threads_=build_threads or 0,
             materialized_view_build_threads_=materialized_view_build_threads or 0,
+            materialized_view_mode_=materialized_view_mode,
             rocksdb_path_=self.rocksdb_path if self.rocksdb_path else "",
             has_scalar_data_=self.has_scalar_data,
             indexed_fields_=self.indexed_fields if self.indexed_fields else [],
@@ -116,6 +124,7 @@ class IndexParams:
             "max_nbrs": self.max_nbrs,
             "build_threads": self.build_threads,
             "materialized_view_build_threads": self.materialized_view_build_threads,
+            "materialized_view_mode": self.materialized_view_mode,
             "rocksdb_path": self.rocksdb_path,
             "has_scalar_data": self.has_scalar_data,
             "indexed_fields": self.indexed_fields if self.indexed_fields else [],
@@ -134,6 +143,7 @@ class IndexParams:
             max_nbrs=data["max_nbrs"],
             build_threads=data.get("build_threads") or None,
             materialized_view_build_threads=data.get("materialized_view_build_threads") or None,
+            materialized_view_mode=data.get("materialized_view_mode", "eager"),
             rocksdb_path=data.get("rocksdb_path", ""),
             has_scalar_data=data.get("has_scalar_data", False),  # Default to False for backward compatibility
             indexed_fields=data.get("indexed_fields", []),  # Default to empty list for backward compatibility
@@ -150,6 +160,7 @@ class IndexParams:
         max_nbrs = None
         build_threads = None
         materialized_view_build_threads = None
+        materialized_view_mode = "eager"
         rocksdb_path = ""
         indexed_fields = None
 
@@ -177,6 +188,8 @@ class IndexParams:
             build_threads = valid_thread_count(kwargs.get("build_threads"))
         if kwargs.get("materialized_view_build_threads") is not None:
             materialized_view_build_threads = valid_thread_count(kwargs.get("materialized_view_build_threads"))
+        if kwargs.get("materialized_view_mode") is not None:
+            materialized_view_mode = str(kwargs.get("materialized_view_mode")).strip().lower()
         if kwargs.get("rocksdb_path") is not None:
             rocksdb_path = str(kwargs.get("rocksdb_path"))
         if kwargs.get("indexed_fields") is not None:
@@ -191,6 +204,7 @@ class IndexParams:
             max_nbrs=max_nbrs,
             build_threads=build_threads,
             materialized_view_build_threads=materialized_view_build_threads,
+            materialized_view_mode=materialized_view_mode,
             rocksdb_path=rocksdb_path,
             indexed_fields=indexed_fields,
         )

--- a/python/src/pybind.cpp
+++ b/python/src/pybind.cpp
@@ -135,6 +135,7 @@ PYBIND11_MODULE(_alayalitepy, m) {
                     uint32_t,
                     uint32_t,
                     std::string,
+                    std::string,
                     bool,
                     std::vector<std::string>>(),
            py::arg("index_type_") = alaya::IndexType::HNSW,
@@ -146,6 +147,7 @@ PYBIND11_MODULE(_alayalitepy, m) {
            py::arg("max_nbrs_") = 32,
            py::arg("build_threads_") = 0,
            py::arg("materialized_view_build_threads_") = 0,
+           py::arg("materialized_view_mode_") = "eager",
            py::arg("rocksdb_path_") = "",
            py::arg("has_scalar_data_") = false,
            py::arg("indexed_fields_") = std::vector<std::string>{})
@@ -159,6 +161,7 @@ PYBIND11_MODULE(_alayalitepy, m) {
       .def_readwrite("build_threads_", &alaya::IndexParams::build_threads_)
       .def_readwrite("materialized_view_build_threads_",
                      &alaya::IndexParams::materialized_view_build_threads_)
+      .def_readwrite("materialized_view_mode_", &alaya::IndexParams::materialized_view_mode_)
       .def_readwrite("rocksdb_path_", &alaya::IndexParams::rocksdb_path_)
       .def_readwrite("has_scalar_data_", &alaya::IndexParams::has_scalar_data_)
       .def_readwrite("indexed_fields_", &alaya::IndexParams::indexed_fields_);

--- a/tests/executor/search_test.cpp
+++ b/tests/executor/search_test.cpp
@@ -73,9 +73,7 @@ struct ScopedTempDbDir {
   std::filesystem::path path_;
 };
 
-auto max_thread_num() -> uint32_t {
-  return configured_thread_limit();
-}
+auto max_thread_num() -> uint32_t { return configured_thread_limit(); }
 
 auto make_test_metadata(uint32_t item_cnt) -> std::vector<ScalarData> {
   std::vector<ScalarData> metadata(item_cnt);
@@ -212,7 +210,8 @@ auto run_parallel_search(SearchJobPtr &search_job, Dataset &ds, uint32_t topk, u
   Timer timer{};
   std::vector<std::vector<uint32_t>> res_pool(ds.query_num_, std::vector<uint32_t>(topk));
   const size_t search_thread_num =
-      std::min<size_t>(cap_thread_count(16), std::max<size_t>(1, static_cast<size_t>(ds.query_num_)));
+      std::min<size_t>(cap_thread_count(16),
+                       std::max<size_t>(1, static_cast<size_t>(ds.query_num_)));
   std::vector<std::thread> tasks(search_thread_num);
 
   auto search_knn = [&](uint32_t i) {
@@ -825,6 +824,44 @@ TEST(GraphHybridSearchJobUnitTest, FilterMatchingAllRowsFallsBackToPlainSearch) 
   space->close_db();
 }
 
+TEST(GraphHybridSearchJobUnitTest, SimpleIndexedBitsetPlanDoesNotMaterializeCandidateIds) {
+  ScopedTempDbDir db_dir("hybrid_direct_bitset");
+  auto space = make_one_dim_scalar_space({10.0F, 11.0F, 12.0F, 0.0F, 1.0F}, db_dir.path_, {"id"});
+  auto graph = make_graph_from_edges({{1, 2}, {2}, {}, {4}, {}});
+  using HybridJobType = GraphHybridSearchJob<RawSpaceWithScalarType>;
+  HybridJobType hybrid_job(space, graph, space);
+
+  MetadataFilter filter;
+  filter.add_ge("id", static_cast<int64_t>(1));
+
+  auto plan =
+      hybrid_job.prepare_hybrid_search_plan(filter, SearchInfo{1, 1, FilterExecHint::kAuto});
+  EXPECT_EQ(plan.mode_, HybridJobType::Mode::kBitsetPrefilter);
+  ASSERT_TRUE(plan.prefilter_result_.has_value());
+  EXPECT_EQ(plan.prefilter_result_->matched_count_, 4U);
+  EXPECT_FALSE(plan.filter_executor_.has_index_fast_path());
+  EXPECT_TRUE(plan.filter_executor_.indexed_ids().empty());
+  space->close_db();
+}
+
+TEST(GraphHybridSearchJobUnitTest, CostModelUsesIndexedExactWhenCandidatesFitWithinEf) {
+  ScopedTempDbDir db_dir("hybrid_cost_model_exact");
+  auto space = make_one_dim_scalar_space({10.0F, 11.0F, 12.0F, 0.0F, 1.0F}, db_dir.path_, {"id"});
+  auto graph = make_graph_from_edges({{1, 2}, {2}, {}, {4}, {}});
+  using HybridJobType = GraphHybridSearchJob<RawSpaceWithScalarType>;
+  HybridJobType hybrid_job(space, graph, space);
+
+  MetadataFilter filter;
+  filter.add_ge("id", static_cast<int64_t>(1));
+
+  auto plan =
+      hybrid_job.prepare_hybrid_search_plan(filter, SearchInfo{1, 5, FilterExecHint::kAuto});
+  EXPECT_EQ(plan.mode_, HybridJobType::Mode::kIndexedExact);
+  EXPECT_TRUE(plan.filter_executor_.has_index_fast_path());
+  EXPECT_EQ(plan.filter_executor_.indexed_count(), 4U);
+  space->close_db();
+}
+
 TEST(GraphHybridSearchJobUnitTest, UnderfilledBitsetPrefilterFallsBackToBruteForce) {
   ScopedTempDbDir db_dir("hybrid_underfilled_bitset");
   auto space = make_one_dim_scalar_space({10.0F, 11.0F, 12.0F, 0.0F, 1.0F}, db_dir.path_, {"id"});
@@ -851,6 +888,53 @@ TEST(GraphHybridSearchJobUnitTest, UnderfilledBitsetPrefilterFallsBackToBruteFor
   EXPECT_EQ(results, brute_force_results);
   EXPECT_EQ(ids[0], 3U);
   EXPECT_EQ(ids[1], 4U);
+  space->close_db();
+}
+
+TEST(GraphHybridSearchJobUnitTest, PreparedPlanReusesIndexedResidualBitset) {
+  ScopedTempDbDir db_dir("hybrid_prepared_plan");
+  auto space = make_one_dim_scalar_space({10.0F, 11.0F, 12.0F, 0.0F, 1.0F}, db_dir.path_, {"id"});
+  auto graph = make_graph_from_edges({
+      {1, 2, 3, 4},
+      {0, 2, 3, 4},
+      {0, 1, 3, 4},
+      {0, 1, 2, 4},
+      {0, 1, 2, 3},
+  });
+  GraphHybridSearchJob<RawSpaceWithScalarType> hybrid_job(space, graph, space);
+
+  MetadataFilter filter;
+  filter.add_ge("id", static_cast<int64_t>(0)).add_eq("group", static_cast<int64_t>(1));
+
+  SearchInfo search_info{1, 5, FilterExecHint::kAuto};
+  auto plan = hybrid_job.prepare_hybrid_search_plan(filter, search_info);
+  EXPECT_EQ(plan.mode_, GraphHybridSearchJob<RawSpaceWithScalarType>::Mode::kBitsetPrefilter);
+  EXPECT_TRUE(plan.prefilter_result_.has_value());
+  EXPECT_TRUE(plan.filter_executor_.has_index_fast_path());
+  EXPECT_FALSE(plan.filter_executor_.index_fast_path_is_exact());
+  EXPECT_EQ(plan.prefilter_result_->matched_count_, 2U);
+
+  std::vector<float> query_near_group_first = {0.1F};
+  std::vector<uint32_t> first_ids(1, std::numeric_limits<uint32_t>::max());
+  std::vector<std::string> first_results(1);
+  hybrid_job.execute_prepared_hybrid_search(query_near_group_first.data(),
+                                            first_ids.data(),
+                                            search_info,
+                                            plan,
+                                            first_results.data());
+  EXPECT_EQ(first_ids[0], 3U);
+  EXPECT_EQ(first_results[0], "id_3");
+
+  std::vector<float> query_near_group_second = {0.9F};
+  std::vector<uint32_t> second_ids(1, std::numeric_limits<uint32_t>::max());
+  std::vector<std::string> second_results(1);
+  hybrid_job.execute_prepared_hybrid_search(query_near_group_second.data(),
+                                            second_ids.data(),
+                                            search_info,
+                                            plan,
+                                            second_results.data());
+  EXPECT_EQ(second_ids[0], 4U);
+  EXPECT_EQ(second_results[0], "id_4");
   space->close_db();
 }
 

--- a/tests/recovery/recovery_test.cpp
+++ b/tests/recovery/recovery_test.cpp
@@ -421,6 +421,52 @@ TEST_F(RecoveryManagerTest, CurrentSnapshotTreatsMalformedManifestAsNoSnapshot) 
   EXPECT_FALSE(mgr.current_snapshot().has_value());
 }
 
+TEST_F(RecoveryManagerTest, RestoreRocksDBSnapshotIsIdempotentForSameSnapshot) {
+  auto mgr = make_manager();
+  mgr.ensure_layout();
+
+  auto snapshot_dir = root_dir_ / "snapshots" / "snapshot-restore";
+  auto snapshot_rocksdb = snapshot_dir / "rocksdb";
+  fs::create_directories(snapshot_rocksdb);
+
+  {
+    std::ofstream current(snapshot_rocksdb / "CURRENT", std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(current.is_open());
+    current << "MANIFEST-000001\n";
+  }
+  {
+    std::ofstream manifest_file(snapshot_rocksdb / "MANIFEST-000001",
+                                std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(manifest_file.is_open());
+    manifest_file << "manifest contents\n";
+  }
+
+  auto manifest = make_manifest("snapshot-restore", 1);
+  manifest.rocksdb_dir_ = "rocksdb";
+
+  mgr.restore_active_rocksdb_from_snapshot(manifest, snapshot_dir);
+  ASSERT_TRUE(fs::exists(active_rocksdb_ / "CURRENT"));
+
+  {
+    std::ofstream lock_file(active_rocksdb_ / "LOCK", std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(lock_file.is_open());
+    lock_file << "reader lock\n";
+  }
+
+  auto staging_path = active_rocksdb_;
+  staging_path += ".restore.tmp";
+  mgr.restore_active_rocksdb_from_snapshot(manifest, snapshot_dir);
+
+  EXPECT_TRUE(fs::exists(active_rocksdb_ / "LOCK"));
+  EXPECT_FALSE(fs::exists(staging_path));
+
+  std::ifstream marker(root_dir_ / "ACTIVE_ROCKSDB_SNAPSHOT");
+  ASSERT_TRUE(marker.is_open());
+  std::string marker_value;
+  std::getline(marker, marker_value);
+  EXPECT_EQ(marker_value, "snapshot-restore");
+}
+
 TEST_F(RecoveryManagerTest, OldSnapshotsRemovedAfterPublish) {
   auto mgr = make_manager();
   mgr.ensure_layout();

--- a/tests/storage/rocksdb_storage_test.cpp
+++ b/tests/storage/rocksdb_storage_test.cpp
@@ -509,7 +509,7 @@ TEST_F(RocksDBStorageTest, SaveCheckpointToInvalidPath) {
 
     fs::path invalid_checkpoint_path = temp_dir_ / "nonexistent_parent/checkpoint";
 
-    EXPECT_NO_THROW(storage.save(invalid_checkpoint_path.string()));
+    EXPECT_THROW(storage.save(invalid_checkpoint_path.string()), std::runtime_error);
     EXPECT_FALSE(fs::exists(invalid_checkpoint_path));
 }
 

--- a/tests/storage/rocksdb_storage_test.cpp
+++ b/tests/storage/rocksdb_storage_test.cpp
@@ -4,7 +4,9 @@
 
 #include <gtest/gtest.h>
 #include <rocksdb/db.h>
+#include <algorithm>
 #include <filesystem>
+#include <limits>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -197,6 +199,37 @@ TEST_F(RocksDBStorageTest, InsertReplacingSameInternalIdCleansOldIndexes) {
     auto new_category_ids = storage.get_ids_by_field_value("category", std::string("new"));
     ASSERT_EQ(new_category_ids.size(), 1U);
     EXPECT_EQ(new_category_ids[0], 7U);
+}
+
+TEST_F(RocksDBStorageTest, FieldIndexesSupportSimpleEqualityAndRangePredicates) {
+    RocksDBConfig indexed_config = config_;
+    indexed_config.indexed_fields_ = {"label", "price"};
+    RocksDBStorage<> storage(indexed_config);
+
+    ASSERT_TRUE(storage.insert(
+        10,
+        ScalarData{"item_10",
+                   "doc10",
+                   {{"label", std::string("target")}, {"price", int64_t(1999)}}}));
+    ASSERT_TRUE(storage.insert(
+        2,
+        ScalarData{"item_02",
+                   "doc02",
+                   {{"label", std::string("target")}, {"price", int64_t(2500)}}}));
+    ASSERT_TRUE(storage.insert(
+        31,
+        ScalarData{"item_31",
+                   "doc31",
+                   {{"label", std::string("other")}, {"price", int64_t(1500)}}}));
+
+    auto target_ids = storage.get_ids_by_field_value("label", std::string("target"));
+    std::sort(target_ids.begin(), target_ids.end());
+    EXPECT_EQ(target_ids, (std::vector<uint32_t>{2, 10}));
+
+    auto cheap_ids =
+        storage.get_ids_by_int_range("price", std::numeric_limits<int64_t>::min(), int64_t(1999));
+    std::sort(cheap_ids.begin(), cheap_ids.end());
+    EXPECT_EQ(cheap_ids, (std::vector<uint32_t>{10, 31}));
 }
 
 TEST_F(RocksDBStorageTest, RemoveOperations) {

--- a/tests/utils/metadata_filter_test.cpp
+++ b/tests/utils/metadata_filter_test.cpp
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-#include "utils/metadata_filter_matcher.hpp"
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <filesystem>
@@ -10,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "utils/metadata_filter_matcher.hpp"
 
 namespace alaya {
 namespace fs = std::filesystem;
@@ -310,6 +310,121 @@ TEST_F(MetadataFilterExecutorTest, FullBitsetUsesIndexFastPathForIndexedFilters)
   expect_mask(result, {false, true, false, true});
 }
 
+TEST_F(MetadataFilterExecutorTest, DirectIndexedBitsetAvoidsMaterializingCandidateIds) {
+  auto storage = make_storage({"category", "age"});
+  using IndexBuildMode = MetadataFilterExecutor<TestID>::IndexBuildMode;
+
+  auto exact_filter = make_single_condition_filter("category", FilterOp::EQ, std::string("books"));
+  MetadataFilterExecutor<TestID> exact_executor(exact_filter,
+                                                storage.get(),
+                                                4,
+                                                IndexBuildMode::kSkip);
+  EXPECT_FALSE(exact_executor.has_index_fast_path());
+  EXPECT_TRUE(exact_executor.indexed_ids().empty());
+
+  auto exact_result = exact_executor.build_direct_indexed_blocked_bitset();
+  ASSERT_TRUE(exact_result.has_value());
+  EXPECT_EQ(exact_result->matched_count_, 2U);
+  expect_mask(*exact_result, {false, true, false, true});
+  EXPECT_FALSE(exact_executor.has_index_fast_path());
+  EXPECT_TRUE(exact_executor.indexed_ids().empty());
+
+  auto range_filter = make_single_condition_filter("age", FilterOp::LT, int64_t(30));
+  MetadataFilterExecutor<TestID> range_executor(range_filter,
+                                                storage.get(),
+                                                4,
+                                                IndexBuildMode::kSkip);
+  auto range_result = range_executor.build_direct_indexed_blocked_bitset();
+  ASSERT_TRUE(range_result.has_value());
+  EXPECT_EQ(range_result->matched_count_, 2U);
+  expect_mask(*range_result, {false, false, true, true});
+}
+
+TEST_F(MetadataFilterExecutorTest, IndexedAndFiltersIntersectCandidateSets) {
+  auto storage = make_storage({"category", "age"});
+
+  MetadataFilter filter;
+  filter.add_eq("category", std::string("books")).add_ge("age", int64_t(30));
+
+  MetadataFilterExecutor<TestID> executor(filter, storage.get(), 4);
+  EXPECT_TRUE(executor.has_index_fast_path());
+  EXPECT_TRUE(executor.index_fast_path_is_exact());
+  EXPECT_EQ(executor.indexed_ids(), (std::vector<TestID>{2}));
+
+  const auto result = executor.build_blocked_bitset();
+  EXPECT_EQ(result.matched_count_, 1U);
+  expect_mask(result, {true, true, false, true});
+}
+
+TEST_F(MetadataFilterExecutorTest, IndexedOrFiltersUnionCandidateSets) {
+  auto storage = make_storage({"category", "age"});
+
+  MetadataFilter filter;
+  filter.logic_op = LogicOp::OR;
+  filter.add_eq("category", std::string("games")).add_ge("age", int64_t(40));
+
+  MetadataFilterExecutor<TestID> executor(filter, storage.get(), 4);
+  EXPECT_TRUE(executor.has_index_fast_path());
+  EXPECT_TRUE(executor.index_fast_path_is_exact());
+  EXPECT_EQ(executor.indexed_ids(), (std::vector<TestID>{1, 3}));
+
+  const auto result = executor.build_blocked_bitset();
+  EXPECT_EQ(result.matched_count_, 2U);
+  expect_mask(result, {true, false, true, false});
+}
+
+TEST_F(MetadataFilterExecutorTest, IndexedNotFiltersComplementCandidateSet) {
+  auto storage = make_storage({"category"});
+
+  MetadataFilter filter;
+  filter.logic_op = LogicOp::NOT;
+  filter.add_eq("category", std::string("books"));
+
+  MetadataFilterExecutor<TestID> executor(filter, storage.get(), 4);
+  EXPECT_TRUE(executor.has_index_fast_path());
+  EXPECT_TRUE(executor.index_fast_path_is_exact());
+  EXPECT_EQ(executor.indexed_ids(), (std::vector<TestID>{1, 3}));
+
+  const auto result = executor.build_blocked_bitset();
+  EXPECT_EQ(result.matched_count_, 2U);
+  expect_mask(result, {true, false, true, false});
+}
+
+TEST_F(MetadataFilterExecutorTest, IndexedAndWithResidualEvaluatesOnlyCandidateSet) {
+  auto storage = make_storage({"category"});
+
+  MetadataFilter filter;
+  filter.add_eq("category", std::string("books"));
+  filter.conditions.push_back(make_condition("title", FilterOp::CONTAINS, std::string("notes")));
+
+  MetadataFilterExecutor<TestID> executor(filter, storage.get(), 4);
+  EXPECT_TRUE(executor.has_index_fast_path());
+  EXPECT_FALSE(executor.index_fast_path_is_exact());
+  EXPECT_EQ(executor.indexed_ids(), (std::vector<TestID>{0, 2}));
+  EXPECT_FALSE(executor.match(0));
+  EXPECT_TRUE(executor.match(2));
+
+  const auto result = executor.build_blocked_bitset();
+  EXPECT_EQ(result.matched_count_, 1U);
+  expect_mask(result, {true, true, false, true});
+}
+
+TEST_F(MetadataFilterExecutorTest, OrWithUnindexedBranchFallsBackToRawEvaluation) {
+  auto storage = make_storage({"category"});
+
+  MetadataFilter filter;
+  filter.logic_op = LogicOp::OR;
+  filter.add_eq("category", std::string("books"));
+  filter.conditions.push_back(make_condition("title", FilterOp::CONTAINS, std::string("gamma")));
+
+  MetadataFilterExecutor<TestID> executor(filter, storage.get(), 4);
+  EXPECT_FALSE(executor.has_index_fast_path());
+
+  const auto result = executor.build_blocked_bitset();
+  EXPECT_EQ(result.matched_count_, 3U);
+  expect_mask(result, {false, true, false, false});
+}
+
 TEST_F(MetadataFilterExecutorTest, IntegerRangeFiltersUseIndexFastPathAndHandleEdges) {
   auto storage = make_storage({"age"});
 
@@ -322,8 +437,8 @@ TEST_F(MetadataFilterExecutorTest, IntegerRangeFiltersUseIndexFastPathAndHandleE
   MetadataFilterExecutor<TestID> gt_executor(gt_filter, storage.get(), 4);
   EXPECT_EQ(gt_executor.indexed_ids(), (std::vector<TestID>{2, 3}));
 
-  auto gt_max_filter = make_single_condition_filter(
-      "age", FilterOp::GT, std::numeric_limits<int64_t>::max());
+  auto gt_max_filter =
+      make_single_condition_filter("age", FilterOp::GT, std::numeric_limits<int64_t>::max());
   MetadataFilterExecutor<TestID> gt_max_executor(gt_max_filter, storage.get(), 4);
   EXPECT_TRUE(gt_max_executor.has_index_fast_path());
   EXPECT_TRUE(gt_max_executor.indexed_ids().empty());
@@ -337,8 +452,8 @@ TEST_F(MetadataFilterExecutorTest, IntegerRangeFiltersUseIndexFastPathAndHandleE
   MetadataFilterExecutor<TestID> lt_executor(lt_filter, storage.get(), 4);
   EXPECT_EQ(lt_executor.indexed_ids(), (std::vector<TestID>{0, 1}));
 
-  auto lt_min_filter = make_single_condition_filter(
-      "age", FilterOp::LT, std::numeric_limits<int64_t>::min());
+  auto lt_min_filter =
+      make_single_condition_filter("age", FilterOp::LT, std::numeric_limits<int64_t>::min());
   MetadataFilterExecutor<TestID> lt_min_executor(lt_min_filter, storage.get(), 4);
   EXPECT_TRUE(lt_min_executor.has_index_fast_path());
   EXPECT_TRUE(lt_min_executor.indexed_ids().empty());


### PR DESCRIPTION
## Description

  This PR stabilizes local installation and restores wheel/test reliability across macOS, Windows, and Linux.

  It fixes Conan compiler detection during editable/`uv` builds so `make install` no longer fails when `CC`/`CXX` include flags, removes an unavailable macOS Conan `libomp` dependency in favor of system/Homebrew OpenMP resolution, fixes Windows-specific build issues caused by the `IN` macro and non-portable `uint64_t` formatting, and updates a recovery test annotation so older Python versions used in CI can collect the test suite correctly.

  It also adds focused unit tests to improve coverage for `platform.hpp`, `Log.hpp`, and `platform_fs.hpp`.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Performance improvement
  - [ ] Code refactoring
  - [ ] Documentation update
  - [x] CI/CD changes

  ## Changes Made

  - Normalize `CC`/`CXX` handling before Conan profile detection in editable builds to fix `make install`
  - Preserve the intended host C++ standard during Conan dependency resolution
  - Remove Conan `libomp` usage for macOS wheel builds and rely on system/Homebrew OpenMP discovery
  - Replace non-portable `uint64_t` hex formatting with `PRIx64`
  - Rename internal metadata filter enum values to avoid Windows `IN` macro conflicts while preserving Python API names
  - Update recovery test typing to stay compatible with older Python versions used in Linux wheel jobs
  - Add targeted unit tests covering logging helpers, platform allocation helpers, and platform filesystem helpers

  ## Testing

  Describe how you tested your changes:

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [x] Manual testing performed

  ```bash
  make install
  python scripts/conan_build/conan_install.py --project-dir . --build-type Release
  cmake --build build --target log_test metadata_filter_test index_encoding_test -j2
  ctest --test-dir build --output-on-failure -R '^utils_test_log$'
  ctest --test-dir build --output-on-failure -R 'utils_test_(metadata_filter|index_encoding)$'
  python3 -m py_compile python/tests/test_recovery.py
  uv run pytest python/tests/test_recovery.py -q
```

  ## Checklist

  - [x] My code follows the project's coding style
  - [x] I have run make lint and fixed any issues
  - [x] I have added tests that prove my fix/feature works
  - [x] All new and existing tests pass (make test)
  - [x] I have updated documentation if needed
  - [x] My commits follow the conventional commits (https://www.conventionalcommits.org/) format

  ## Screenshots (if applicable)
<img width="332" height="227" alt="image" src="https://github.com/user-attachments/assets/cc67a01e-75b7-4811-a22d-4188df7364dc" />


  ## Additional Notes

  This PR includes the commits after d59e038cd5fd0f4c2d665001c2652154872ffb75 and keeps the platform-specific wheel fixes split into
  separate conventional commits for easier review.

  The GitHub Actions Node.js 20 deprecation notice is unrelated to the actual wheel build failures addressed here.