### PR TITLE
chore(repo): require scope in commit messages and PR titles

### DIFF
--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -24,8 +24,9 @@ jobs       :
     - uses: actions/checkout@v4
     - uses: gsactions/commit-message-checker@v2
       with:
-        pattern: '^(feat|fix|docs|style|refactor|chore|perf|test|build|ci|revert)(\(\S+\))?: .+'
-        error: Invalid commit type
+        pattern: '^(feat|fix|docs|style|refactor|chore|perf|test|build|ci|revert)\(\S+\): .+'
+        error: 'Commit message must follow Conventional Commits with a required (scope), e.g. feat(laser): warmup fix. See
+          CONTRIBUTING.md.'
         excludeDescription: 'true'
         excludeTitle: 'false'
         checkAllCommitMessages: 'true'

--- a/.github/workflows/pr-title-checker.yaml
+++ b/.github/workflows/pr-title-checker.yaml
@@ -1,0 +1,42 @@
+---
+name       : PR Title Checker
+
+# Validates PR titles against Conventional Commits. Because PRs are
+# squash-merged, the PR title becomes the commit message on `main`, so this is
+# the real enforcement point — local commit-msg hooks only catch developers who
+# installed pre-commit.
+#
+# Enforcement is intentionally loose on scope content: a scope is required, but
+# its value is not whitelisted. See CONTRIBUTING.md for recommended scope
+# names and conventions. Keep the type list in sync with
+# .pre-commit-config.yaml.
+
+on         :
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs       :
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+    - uses: amannn/action-semantic-pull-request@v6
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        types: |
+          feat
+          fix
+          docs
+          style
+          refactor
+          perf
+          test
+          build
+          ci
+          chore
+          revert
+        requireScope: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,20 @@ repos:
   hooks:
   - id: conventional-pre-commit
     stages: [commit-msg]
-    args: [--strict, feat, fix, docs, style, refactor, chore, perf, test, build, ci, revert]
+    args:
+    - --strict
+    - --force-scope
+    - feat
+    - fix
+    - docs
+    - style
+    - refactor
+    - chore
+    - perf
+    - test
+    - build
+    - ci
+    - revert
 
 #===========================================================================
 #                            TYPOS CHECK

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,12 +86,17 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/) specifica
 ### Commit Message Format
 
 ```
-<type>: <description>
+<type>(<scope>): <description>
 
 [optional body]
 
 [optional footer]
 ```
+
+The `(<scope>)` segment is **required**. The CI and local `commit-msg` hook
+will reject any commit or PR title that omits it. The *content* of the scope is
+not whitelisted — see [Scopes](#scopes) below for the recommended names and
+the conventions for cross-cutting changes.
 
 ### Allowed Types
 
@@ -109,13 +114,101 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/) specifica
 | `chore` | Other changes (dependencies, etc.) |
 | `revert` | Revert a previous commit |
 
+The allowed types are enforced by `conventional-pre-commit` (see
+`.pre-commit-config.yaml`). A commit with any other type will be rejected.
+
+### Scopes
+
+Scopes name the **module** the change touches. The CI only verifies that *some*
+scope is present — it does not constrain the scope value. The lists below are
+**recommended** names; please reuse them rather than inventing new spellings,
+so `git log --grep` and changelog tooling stay useful.
+
+When in doubt, use the directory name as the scope. That keeps the mapping
+mechanical and unambiguous.
+
+#### Recommended scopes
+
+C++ core (`include/`):
+
+| Scope | Path |
+|-------|------|
+| `index` | `include/index/` (general graph indices, e.g. HNSW, Vamana) |
+| `disk` | `include/index/disk/` |
+| `laser` | `include/index/graph/laser/` |
+| `executor` | `include/executor/` |
+| `recovery` | `include/recovery/` |
+| `simd` | `include/simd/` |
+| `space` | `include/space/` |
+| `storage` | `include/storage/` |
+| `utils` | `include/utils/` |
+
+Python and apps:
+
+| Scope | Path |
+|-------|------|
+| `python` | `python/src/alayalite/` (Python SDK, bindings) |
+| `bench` | `python/src/alayalite/bench/`, `python/tests/bench/` |
+| `app` | `app/` |
+| `examples` | `examples/` |
+
+Build / CI / docs (use as a narrowing scope):
+
+| Scope | Use for |
+|-------|---------|
+| `cmake` | CMake configuration changes (`build(cmake): ...`) |
+| `conan` | Conan dependency or recipe changes |
+| `cibuildwheel` | Wheel-build workflow tweaks |
+| `readme` | Top-level README updates |
+
+Cross-cutting / repo-wide (use one of these when no module dominates):
+
+| Scope | Use for |
+|-------|---------|
+| `deps` | Dependency bumps (`chore(deps):`, `build(deps):`) — matches Dependabot's default |
+| `repo` | Repository-wide chores: top-level configs, `.gitignore`, license, governance |
+| `release` | Version bumps, changelog, release tagging |
+
+#### Multiple scopes
+
+When a single logical change genuinely spans 2–3 modules, list them
+comma-separated in **alphabetical order**, no spaces:
+
+```
+feat(disk,laser,python): expose batch_search through Python bindings
+```
+
+If the list would grow beyond 3 scopes, the change is no longer localized —
+pick the most representative single scope, or use a cross-cutting scope like
+`repo`.
+
 ### Examples
 
+Single scope (most common):
+
 ```bash
-feat: add SQ4 quantization support
-fix: resolve memory leak in graph search
-docs: update installation instructions
-refactor: simplify distance calculation logic
+feat(laser): warmup path fix and PCA write optimization
+fix(index): correct neighbor pruning in Vamana build
+perf(simd): vectorize L2 distance for AVX-512
+test(bench): consolidate benchmark smoke tests
+docs(laser): document RaBitQ tuning knobs
+```
+
+Multiple scopes (alphabetical, comma-separated):
+
+```bash
+feat(disk,laser,python): expose batch_search through Python bindings
+refactor(space,utils): extract shared metric helpers
+```
+
+Cross-cutting / repo-wide:
+
+```bash
+chore(deps): bump pybind11 to 2.13.6
+build(cmake): enable LTO for release builds
+ci(cibuildwheel): skip Python 3.8 on Windows
+docs(readme): update installation instructions
+chore(repo): add CODE_OF_CONDUCT and templates
 ```
 
 ## Pull Request Process
@@ -131,10 +224,16 @@ refactor: simplify distance calculation logic
 
 ### PR Title Format
 
-Follow the same convention as commit messages:
+Follow the same convention as commit messages, including the optional scope:
+
 ```
-feat: add support for cosine similarity metric
+feat(space): add support for cosine similarity metric
+fix(disk): correct page eviction under concurrent search
+docs: add community documentation and templates
 ```
+
+The PR title becomes the squash-merge commit on `main`, so the scope rules
+above apply to it directly.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,16 +224,16 @@ chore(repo): add CODE_OF_CONDUCT and templates
 
 ### PR Title Format
 
-Follow the same convention as commit messages, including the optional scope:
+Follow the same convention as commit messages, including the required scope:
 
 ```
 feat(space): add support for cosine similarity metric
 fix(disk): correct page eviction under concurrent search
-docs: add community documentation and templates
+docs(repo): add community documentation and templates
 ```
 
-The PR title becomes the squash-merge commit on `main`, so the scope rules
-above apply to it directly.
+The PR title becomes the squash-merge commit on the base branch, so the scope
+rules above apply to it directly.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

Enforce a `(scope)` segment on every commit message and PR title, while keeping the *content* of the scope free-form so new modules don't get blocked by stale CI config.

- **`.pre-commit-config.yaml`** — `conventional-pre-commit` gains `--force-scope`. Local `git commit` now rejects any message missing a scope.
- **`.github/workflows/pr-title-checker.yaml`** (new) — `amannn/action-semantic-pull-request@v6` validates PR titles on `pull_request_target`. Because PRs are squash-merged into `v1.0.0`, the PR title becomes the commit message, making this the real enforcement point — local hooks only catch developers who installed pre-commit.
- **`CONTRIBUTING.md`** — documents the new requirement, lists recommended scope names mapped to source directories (`index`, `disk`, `laser`, `simd`, `python`, `bench`, …), and provides meta-scopes (`deps`, `repo`, `release`) for cross-cutting changes.

Why no scope whitelist: hard-listing scopes means every new module's first PR has to also patch `.pre-commit-config.yaml` and the workflow. The recommended-list in `CONTRIBUTING.md` is the soft-convention layer; review can catch typos like `feat(Laser)` vs `feat(laser)`.

## Test plan

- [x] Verified `conventional-pre-commit --strict --force-scope` against 6 cases: `feat(laser): ...`, `feat(disk,laser,python): ...`, `chore(deps): ...`, `feat(novel-scope): ...` all pass; `feat: ...` and `chore: ...` (no scope) both fail.
- [x] `pre-commit run yamlfmt` and `check-yaml` pass on the modified `.pre-commit-config.yaml` and the new workflow.
- [x] Confirmed multi-scope `feat(disk,laser,python):` works in both tools (conventional-pre-commit's regex accepts comma delimiters; amannn `validatePrTitle.js` calls `.split(',')` on the captured scope).
- [ ] **First-PR caveat**: `pull_request_target` runs the workflow from the *base* branch (`v1.0.0`), so this PR itself will not trigger PR-title validation. Validation activates for every subsequent PR after this lands.

## Notes for reviewers

- This deliberately changes commit-message rules going forward; existing history is left untouched.
- If you want to require the new check for merge, add `Validate PR title` to the branch protection rules for `v1.0.0` after this lands.