### PR TITLE
chore(recovery): harden WAL snapshot handling

### DIFF
--- a/include/index/graph/qg/qg_builder.hpp
+++ b/include/index/graph/qg/qg_builder.hpp
@@ -139,7 +139,7 @@ class QGBuilder {
     LOG_INFO("Searching for new neighbor candidates...");
     ALAYA_OMP_PARALLEL_FOR_DYNAMIC
     for (int64_t i = 0; i < static_cast<int64_t>(num_nodes_); ++i) {
-      IDType cur_id = static_cast<IDType>(i);
+      auto cur_id = static_cast<IDType>(i);
       auto tid = platform::openmp_thread_num();
       CandidateList candidates;
       HashBasedBooleanSet &vis = visited_list_[tid];
@@ -173,13 +173,14 @@ class QGBuilder {
     ALAYA_OMP_PARALLEL_FOR_DYNAMIC
     for (int64_t data_id = 0; data_id < static_cast<int64_t>(num_nodes_);
          ++data_id) {  // for every vertex
-      for (const auto &nei : new_neighbors_[data_id]) {
+      auto current_id = static_cast<IDType>(data_id);
+      for (const auto &nei : new_neighbors_[static_cast<size_t>(data_id)]) {
         auto dst = nei.id_;
         bool dup = false;
-        CandidateList &dst_neighbors = new_neighbors_[dst];
-        std::lock_guard lock(locks[dst]);
+        CandidateList &dst_neighbors = new_neighbors_[static_cast<size_t>(dst)];
+        std::lock_guard lock(locks[static_cast<size_t>(dst)]);
         for (auto &dst_nei : dst_neighbors) {
-          if (dst_nei.id_ == data_id) {
+          if (dst_nei.id_ == current_id) {
             dup = true;
             break;
           }

--- a/include/recovery/recovery_manager.hpp
+++ b/include/recovery/recovery_manager.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <filesystem>  // NOLINT(build/c++17)
 #include <fstream>
 #include <optional>
@@ -21,6 +20,13 @@ namespace alaya::recovery {
 
 namespace fs = std::filesystem;
 
+/**
+ * @brief Coordinates snapshot metadata, WAL replay and RocksDB checkpoint restoration.
+ *
+ * RecoveryManager owns the recovery directory layout under root_dir. It publishes snapshots through
+ * an atomic CURRENT pointer, delegates mutation durability to WriteAheadLog and restores the active
+ * RocksDB directory from snapshot checkpoints when needed.
+ */
 class RecoveryManager {
  public:
   RecoveryManager(fs::path root_dir, fs::path active_rocksdb_path)
@@ -39,13 +45,20 @@ class RecoveryManager {
     fs::create_directories(snapshots_dir_);
   }
 
+  /**
+   * @brief Calculates the next operation id from the current snapshot and WAL contents.
+   *
+   * The snapshot applied-through id gives the lower bound, and scanning the WAL advances it to the
+   * largest operation id seen in prepared or committed frames so new operations keep increasing
+   * monotonically after restart.
+   */
   [[nodiscard]] auto next_operation_id() const -> uint64_t {
     uint64_t max_seen = 0;
     auto manifest = current_snapshot();
     if (manifest.has_value()) {
-      max_seen = manifest->applied_through_op_id;
+      max_seen = manifest->applied_through_op_id_;
     }
-    wal_.replayable_records(0, &max_seen);
+    (void)wal_.replayable_records(0, &max_seen);
     return max_seen + 1;
   }
 
@@ -62,19 +75,32 @@ class RecoveryManager {
   // TODO(P2): Graph save and RocksDB checkpoint are not atomic. A crash between
   // them creates an inconsistent snapshot. Consider a two-phase commit protocol
   // where both components are written before the CURRENT pointer is updated.
+  /**
+   * @brief Publishes a completed snapshot and makes it the recovery CURRENT target.
+   *
+   * The manifest and CURRENT pointer are written atomically, then the WAL is truncated because all
+   * operations through the manifest are represented in the snapshot. Older snapshot directories are
+   * cleaned up after the new snapshot is visible.
+   */
   auto publish_snapshot(const SnapshotManifest &manifest, const fs::path &snapshot_dir) const
       -> void {
     ensure_layout();
     auto manifest_path = snapshot_dir / "manifest.txt";
     write_text_atomically(manifest_path, manifest.serialize());
-    write_text_atomically(current_path_, manifest.snapshot_id + "\n");
+    write_text_atomically(current_path_, manifest.snapshot_id_ + "\n");
     LOG_INFO("recovery: published snapshot id={} applied_through={}",
-             manifest.snapshot_id,
-             manifest.applied_through_op_id);
+             manifest.snapshot_id_,
+             manifest.applied_through_op_id_);
     wal_.truncate();
-    remove_old_snapshots(manifest.snapshot_id);
+    remove_old_snapshots(manifest.snapshot_id_);
   }
 
+  /**
+   * @brief Loads the manifest for the snapshot named by the CURRENT pointer.
+   *
+   * Missing recovery state, unreadable files and empty CURRENT contents are treated as no snapshot
+   * being available, allowing callers to fall back to WAL-only recovery or a fresh layout.
+   */
   [[nodiscard]] auto current_snapshot() const -> std::optional<SnapshotManifest> {
     if (!enabled() || !fs::exists(current_path_)) {
       return std::nullopt;
@@ -107,7 +133,7 @@ class RecoveryManager {
     if (!manifest.has_value()) {
       return std::nullopt;
     }
-    return snapshots_dir_ / manifest->snapshot_id;
+    return snapshots_dir_ / manifest->snapshot_id_;
   }
 
   [[nodiscard]] auto replayable_records(uint64_t applied_through,
@@ -124,9 +150,16 @@ class RecoveryManager {
 
   auto sync_wal() const -> void { wal_.sync(); }
 
+  /**
+   * @brief Replaces the active RocksDB directory with the checkpoint stored in a snapshot.
+   *
+   * If RocksDB recovery is not configured or the snapshot does not include a checkpoint, the method
+   * exits without modifying the active directory. Existing active contents are removed before the
+   * checkpoint is copied into place.
+   */
   auto restore_active_rocksdb_from_snapshot(const SnapshotManifest &manifest,
                                             const fs::path &snapshot_dir) const -> void {
-    if (active_rocksdb_path_.empty() || manifest.rocksdb_dir.empty()) {
+    if (active_rocksdb_path_.empty() || manifest.rocksdb_dir_.empty()) {
       return;
     }
 
@@ -145,6 +178,12 @@ class RecoveryManager {
   }
 
  private:
+  /**
+   * @brief Removes stale snapshot directories after a new snapshot is published.
+   *
+   * The currently published snapshot is preserved while all other directories under the snapshot
+   * root are best-effort deleted with warnings for failures.
+   */
   auto remove_old_snapshots(const std::string &current_snapshot_id) const -> void {
     if (!fs::exists(snapshots_dir_)) {
       return;
@@ -194,6 +233,12 @@ class RecoveryManager {
     return buffer.str();
   }
 
+  /**
+   * @brief Writes text through a temporary file and atomically replaces the target path.
+   *
+   * The temporary file is flushed and synced before replacement, then the parent directory is
+   * synced so snapshot manifests and CURRENT pointer updates survive process or system crashes.
+   */
   static auto write_text_atomically(const fs::path &path, const std::string &content) -> void {
     fs::create_directories(path.parent_path());
     auto tmp_path = path;
@@ -214,6 +259,12 @@ class RecoveryManager {
     platform::sync_directory(path.parent_path());
   }
 
+  /**
+   * @brief Recursively copies a snapshot checkpoint directory into the active target directory.
+   *
+   * Directories are recreated and regular files are overwritten at the destination, followed by a
+   * directory sync to make the restored checkpoint durable.
+   */
   static auto copy_directory_recursive(const fs::path &source, const fs::path &target) -> void {
     fs::create_directories(target);
     for (const auto &entry : fs::recursive_directory_iterator(source)) {
@@ -229,11 +280,11 @@ class RecoveryManager {
     platform::sync_directory(target);
   }
 
-  fs::path root_dir_;
-  fs::path snapshots_dir_;
-  fs::path current_path_;
-  WriteAheadLog wal_;
-  fs::path active_rocksdb_path_;
+  fs::path root_dir_;             ///< Recovery metadata root; empty disables recovery.
+  fs::path snapshots_dir_;        ///< Directory that stores snapshot subdirectories.
+  fs::path current_path_;         ///< Atomic pointer file for the current snapshot id.
+  WriteAheadLog wal_;             ///< WAL for mutations not yet covered by a snapshot.
+  fs::path active_rocksdb_path_;  ///< Live RocksDB directory restored from checkpoints.
 };
 
 }  // namespace alaya::recovery

--- a/include/recovery/snapshot_manifest.hpp
+++ b/include/recovery/snapshot_manifest.hpp
@@ -14,31 +14,43 @@ namespace alaya::recovery {
 
 namespace fs = std::filesystem;
 
+/**
+ * @brief Persistent metadata describing one published recovery snapshot.
+ *
+ * The manifest is stored as line-oriented key=value text inside each snapshot directory. Paths are
+ * relative to the snapshot directory so the whole snapshot tree can be moved as one unit.
+ */
 struct SnapshotManifest {
-  uint32_t format_version{1};
-  std::string snapshot_id{};
-  std::string reason{};
-  uint64_t applied_through_op_id{0};
-  uint64_t created_unix_ms{0};
-  std::string graph_file{};
-  std::string data_file{};
-  std::string quant_file{};
-  std::string rocksdb_dir{};
+  uint32_t format_version_{1};         ///< Manifest text format version.
+  std::string snapshot_id_;            ///< Snapshot directory id stored in CURRENT.
+  std::string reason_;                 ///< Human-readable snapshot trigger.
+  uint64_t applied_through_op_id_{0};  ///< Highest operation id represented by this snapshot.
+  uint64_t created_unix_ms_{0};        ///< Snapshot creation timestamp in Unix milliseconds.
+  std::string graph_file_;             ///< Relative graph file path.
+  std::string data_file_;              ///< Relative vector data file path.
+  std::string quant_file_;             ///< Relative quantizer file path.
+  std::string rocksdb_dir_;            ///< Relative RocksDB checkpoint directory path.
 
   [[nodiscard]] auto serialize() const -> std::string {
     std::ostringstream output;
-    output << "format_version=" << format_version << '\n';
-    output << "snapshot_id=" << snapshot_id << '\n';
-    output << "reason=" << reason << '\n';
-    output << "applied_through_op_id=" << applied_through_op_id << '\n';
-    output << "created_unix_ms=" << created_unix_ms << '\n';
-    output << "graph_file=" << graph_file << '\n';
-    output << "data_file=" << data_file << '\n';
-    output << "quant_file=" << quant_file << '\n';
-    output << "rocksdb_dir=" << rocksdb_dir << '\n';
+    output << "format_version=" << format_version_ << '\n';
+    output << "snapshot_id=" << snapshot_id_ << '\n';
+    output << "reason=" << reason_ << '\n';
+    output << "applied_through_op_id=" << applied_through_op_id_ << '\n';
+    output << "created_unix_ms=" << created_unix_ms_ << '\n';
+    output << "graph_file=" << graph_file_ << '\n';
+    output << "data_file=" << data_file_ << '\n';
+    output << "quant_file=" << quant_file_ << '\n';
+    output << "rocksdb_dir=" << rocksdb_dir_ << '\n';
     return output.str();
   }
 
+  /**
+   * @brief Parses a text manifest into a SnapshotManifest object.
+   *
+   * Unknown lines are ignored for forward compatibility, while required snapshot identity must be
+   * present. Numeric fields are converted from their persisted decimal representation.
+   */
   static auto deserialize(const std::string &raw) -> std::optional<SnapshotManifest> {
     SnapshotManifest manifest;
     std::istringstream input(raw);
@@ -51,26 +63,26 @@ struct SnapshotManifest {
       auto key = line.substr(0, delimiter);
       auto value = line.substr(delimiter + 1);
       if (key == "format_version") {
-        manifest.format_version = static_cast<uint32_t>(std::stoul(value));
+        manifest.format_version_ = static_cast<uint32_t>(std::stoul(value));
       } else if (key == "snapshot_id") {
-        manifest.snapshot_id = value;
+        manifest.snapshot_id_ = value;
       } else if (key == "reason") {
-        manifest.reason = value;
+        manifest.reason_ = value;
       } else if (key == "applied_through_op_id") {
-        manifest.applied_through_op_id = std::stoull(value);
+        manifest.applied_through_op_id_ = std::stoull(value);
       } else if (key == "created_unix_ms") {
-        manifest.created_unix_ms = std::stoull(value);
+        manifest.created_unix_ms_ = std::stoull(value);
       } else if (key == "graph_file") {
-        manifest.graph_file = value;
+        manifest.graph_file_ = value;
       } else if (key == "data_file") {
-        manifest.data_file = value;
+        manifest.data_file_ = value;
       } else if (key == "quant_file") {
-        manifest.quant_file = value;
+        manifest.quant_file_ = value;
       } else if (key == "rocksdb_dir") {
-        manifest.rocksdb_dir = value;
+        manifest.rocksdb_dir_ = value;
       }
     }
-    if (manifest.snapshot_id.empty()) {
+    if (manifest.snapshot_id_.empty()) {
       return std::nullopt;
     }
     return manifest;
@@ -83,19 +95,19 @@ struct SnapshotManifest {
   }
 
   [[nodiscard]] auto graph_path(const fs::path &snapshot_dir) const -> std::string {
-    return graph_file.empty() ? std::string() : (snapshot_dir / graph_file).string();
+    return graph_file_.empty() ? std::string() : (snapshot_dir / graph_file_).string();
   }
 
   [[nodiscard]] auto data_path(const fs::path &snapshot_dir) const -> std::string {
-    return data_file.empty() ? std::string() : (snapshot_dir / data_file).string();
+    return data_file_.empty() ? std::string() : (snapshot_dir / data_file_).string();
   }
 
   [[nodiscard]] auto quant_path(const fs::path &snapshot_dir) const -> std::string {
-    return quant_file.empty() ? std::string() : (snapshot_dir / quant_file).string();
+    return quant_file_.empty() ? std::string() : (snapshot_dir / quant_file_).string();
   }
 
   [[nodiscard]] auto rocksdb_path(const fs::path &snapshot_dir) const -> fs::path {
-    return rocksdb_dir.empty() ? fs::path{} : snapshot_dir / rocksdb_dir;
+    return rocksdb_dir_.empty() ? fs::path{} : snapshot_dir / rocksdb_dir_;
   }
 };
 

--- a/include/recovery/snapshot_manifest.hpp
+++ b/include/recovery/snapshot_manifest.hpp
@@ -4,15 +4,48 @@
 
 #pragma once
 
+#include <charconv>
 #include <chrono>
 #include <filesystem>  // NOLINT(build/c++17)
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
+#include <system_error>
 
 namespace alaya::recovery {
 
 namespace fs = std::filesystem;
+
+namespace detail {
+
+inline auto parse_uint64_decimal(std::string_view value, uint64_t &out) -> bool {
+  if (value.empty()) {
+    return false;
+  }
+  uint64_t parsed = 0;
+  const auto *begin = value.data();
+  const auto *end = begin + value.size();
+  auto [ptr, ec] = std::from_chars(begin, end, parsed, 10);
+  if (ec != std::errc() || ptr != end) {
+    return false;
+  }
+  out = parsed;
+  return true;
+}
+
+inline auto parse_uint32_decimal(std::string_view value, uint32_t &out) -> bool {
+  uint64_t parsed = 0;
+  if (!parse_uint64_decimal(value, parsed) ||
+      parsed > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())) {
+    return false;
+  }
+  out = static_cast<uint32_t>(parsed);
+  return true;
+}
+
+}  // namespace detail
 
 /**
  * @brief Persistent metadata describing one published recovery snapshot.
@@ -56,6 +89,9 @@ struct SnapshotManifest {
     std::istringstream input(raw);
     std::string line;
     while (std::getline(input, line)) {
+      if (!line.empty() && line.back() == '\r') {
+        line.pop_back();
+      }
       auto delimiter = line.find('=');
       if (delimiter == std::string::npos) {
         continue;
@@ -63,15 +99,21 @@ struct SnapshotManifest {
       auto key = line.substr(0, delimiter);
       auto value = line.substr(delimiter + 1);
       if (key == "format_version") {
-        manifest.format_version_ = static_cast<uint32_t>(std::stoul(value));
+        if (!detail::parse_uint32_decimal(value, manifest.format_version_)) {
+          return std::nullopt;
+        }
       } else if (key == "snapshot_id") {
         manifest.snapshot_id_ = value;
       } else if (key == "reason") {
         manifest.reason_ = value;
       } else if (key == "applied_through_op_id") {
-        manifest.applied_through_op_id_ = std::stoull(value);
+        if (!detail::parse_uint64_decimal(value, manifest.applied_through_op_id_)) {
+          return std::nullopt;
+        }
       } else if (key == "created_unix_ms") {
-        manifest.created_unix_ms_ = std::stoull(value);
+        if (!detail::parse_uint64_decimal(value, manifest.created_unix_ms_)) {
+          return std::nullopt;
+        }
       } else if (key == "graph_file") {
         manifest.graph_file_ = value;
       } else if (key == "data_file") {

--- a/include/recovery/write_ahead_log.hpp
+++ b/include/recovery/write_ahead_log.hpp
@@ -239,6 +239,33 @@ class WriteAheadLog {
     uint64_t payload_size_{0};                           ///< Payload byte count after header.
   };
 
+  [[nodiscard]] static auto parse_frame_type(uint8_t frame_type) -> std::optional<WalFrameType> {
+    switch (frame_type) {
+      case static_cast<uint8_t>(WalFrameType::kPrepare):
+        return WalFrameType::kPrepare;
+      case static_cast<uint8_t>(WalFrameType::kCommit):
+        return WalFrameType::kCommit;
+      default:
+        return std::nullopt;
+    }
+  }
+
+  [[nodiscard]] static auto parse_mutation_type(uint8_t mutation_type)
+      -> std::optional<MutationType> {
+    switch (mutation_type) {
+      case static_cast<uint8_t>(MutationType::kInsert):
+        return MutationType::kInsert;
+      case static_cast<uint8_t>(MutationType::kUpsert):
+        return MutationType::kUpsert;
+      case static_cast<uint8_t>(MutationType::kRemoveByItemId):
+        return MutationType::kRemoveByItemId;
+      case static_cast<uint8_t>(MutationType::kRemoveByInternalId):
+        return MutationType::kRemoveByInternalId;
+      default:
+        return std::nullopt;
+    }
+  }
+
   [[nodiscard]] static auto payload_size_is_plausible(std::ifstream &input,
                                                       uintmax_t wal_file_size,
                                                       uint64_t payload_size) -> bool {
@@ -374,9 +401,19 @@ class WriteAheadLog {
       LOG_WARN("Unsupported WAL version: {}", version);
       return std::nullopt;
     }
+    const auto parsed_frame_type = parse_frame_type(frame_type);
+    if (!parsed_frame_type.has_value()) {
+      LOG_WARN("Invalid WAL frame type: {}", static_cast<unsigned>(frame_type));
+      return std::nullopt;
+    }
+    const auto parsed_mutation_type = parse_mutation_type(mutation_type);
+    if (!parsed_mutation_type.has_value()) {
+      LOG_WARN("Invalid WAL mutation type: {}", static_cast<unsigned>(mutation_type));
+      return std::nullopt;
+    }
     return FrameHeader{
-        .frame_type_ = static_cast<WalFrameType>(frame_type),
-        .mutation_type_ = static_cast<MutationType>(mutation_type),
+        .frame_type_ = parsed_frame_type.value(),
+        .mutation_type_ = parsed_mutation_type.value(),
         .op_id_ = op_id,
         .payload_size_ = payload_size,
     };

--- a/include/recovery/write_ahead_log.hpp
+++ b/include/recovery/write_ahead_log.hpp
@@ -5,18 +5,17 @@
 #pragma once
 
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>  // NOLINT(build/c++17)
 #include <fstream>
 #include <mutex>
 #include <optional>
-#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
+#include "utils/binary_io.hpp"
 #include "utils/log.hpp"
 #include "utils/platform_fs.hpp"
 
@@ -24,137 +23,57 @@ namespace alaya::recovery {
 
 namespace fs = std::filesystem;
 
-constexpr uint32_t kWalFrameMagic = 0x414C5752U;    // ALWR
-constexpr uint32_t kWalTrailerMagic = 0x5752414CU;  // WRAL
-constexpr uint8_t kWalFormatVersion = 1;
+constexpr uint32_t kWalFrameMagic = 0x48454144U;    ///< WAL frame prefix magic, "HEAD".
+constexpr uint32_t kWalTrailerMagic = 0x5441494CU;  ///< WAL frame trailer magic, "TAIL".
+constexpr uint8_t kWalFormatVersion = 1;            ///< Current on-disk WAL frame version.
 
+/**
+ * @brief Identifies whether a WAL frame starts or commits a mutation.
+ *
+ * Recovery only replays records that have both a PREPARE frame with payload and a matching COMMIT
+ * frame, which avoids applying half-written operations after a crash.
+ */
 enum class WalFrameType : uint8_t {
-  PREPARE = 1,
-  COMMIT = 2,
+  kPrepare = 1,  ///< Contains the full mutation payload before commit.
+  kCommit = 2,   ///< Marks the prepared operation as committed and re-playable.
 };
 
+/**
+ * @brief Logical mutation category stored with a WAL record.
+ *
+ * The mutation type lets recovery route a replayed payload to the same insert, upsert or delete
+ * path that originally produced the operation.
+ */
 enum class MutationType : uint8_t {
-  INSERT = 1,
-  UPSERT = 2,
-  REMOVE_BY_ITEM_ID = 3,
-  REMOVE_BY_INTERNAL_ID = 4,
+  kInsert = 1,              ///< Insert a new vector/scalar record.
+  kUpsert = 2,              ///< Insert or replace a vector/scalar record.
+  kRemoveByItemId = 3,      ///< Delete by external item id.
+  kRemoveByInternalId = 4,  ///< Delete by internal storage id.
 };
 
+/**
+ * @brief In-memory representation of one durable mutation from the WAL.
+ *
+ * PREPARE frames carry the serialized payload, while COMMIT frames validate that the prepared
+ * operation became durable. Replayed records are returned with their original operation id and
+ * mutation type.
+ */
 struct WalRecord {
-  uint64_t op_id{0};
-  MutationType mutation_type{MutationType::INSERT};
-  std::vector<char> payload{};
+  uint64_t op_id_{0};                                  ///< Monotonic operation id.
+  MutationType mutation_type_{MutationType::kInsert};  ///< Mutation category for replay.
+  std::vector<char> payload_;                          ///< Opaque serialized mutation payload.
 };
 
-class BinaryWriter {
- public:
-  auto write_u8(uint8_t value) -> void { write_pod(value); }
-  auto write_u32(uint32_t value) -> void { write_pod(value); }
-  auto write_u64(uint64_t value) -> void { write_pod(value); }
+using BinaryReader = binary_io::BinaryReader;
+using BinaryWriter = binary_io::BinaryWriter;
 
-  auto write_bytes(const char *data, size_t size) -> void {
-    if (size == 0) {
-      return;
-    }
-    buffer_.insert(buffer_.end(), data, data + size);
-  }
-
-  auto write_string(const std::string &value) -> void {
-    write_u64(static_cast<uint64_t>(value.size()));
-    write_bytes(value.data(), value.size());
-  }
-
-  auto write_blob(const std::vector<char> &value) -> void {
-    write_u64(static_cast<uint64_t>(value.size()));
-    write_bytes(value.data(), value.size());
-  }
-
-  auto write_blob(const std::string &value) -> void {
-    write_u64(static_cast<uint64_t>(value.size()));
-    write_bytes(value.data(), value.size());
-  }
-
-  template <typename T>
-  auto write_vector_blob(const T *data, size_t element_count) -> void {
-    auto bytes = static_cast<uint64_t>(element_count * sizeof(T));
-    write_u64(bytes);
-    write_bytes(reinterpret_cast<const char *>(data), static_cast<size_t>(bytes));
-  }
-
-  [[nodiscard]] auto finish() && -> std::vector<char> { return std::move(buffer_); }
-
- private:
-  template <typename T>
-  auto write_pod(const T &value) -> void {
-    auto *ptr = reinterpret_cast<const char *>(&value);
-    buffer_.insert(buffer_.end(), ptr, ptr + sizeof(T));
-  }
-
-  std::vector<char> buffer_{};
-};
-
-class BinaryReader {
- public:
-  BinaryReader(const char *data, size_t size) : data_(data), size_(size) {}
-
-  auto read_u8() -> std::optional<uint8_t> { return read_pod<uint8_t>(); }
-  auto read_u32() -> std::optional<uint32_t> { return read_pod<uint32_t>(); }
-  auto read_u64() -> std::optional<uint64_t> { return read_pod<uint64_t>(); }
-
-  auto read_string() -> std::optional<std::string> {
-    auto size = read_u64();
-    if (!size.has_value()) {
-      return std::nullopt;
-    }
-    if (remaining() < size.value()) {
-      return std::nullopt;
-    }
-    std::string value(data_ + offset_, data_ + offset_ + static_cast<size_t>(size.value()));
-    offset_ += static_cast<size_t>(size.value());
-    return value;
-  }
-
-  auto read_blob() -> std::optional<std::vector<char>> {
-    auto size = read_u64();
-    if (!size.has_value()) {
-      return std::nullopt;
-    }
-    if (remaining() < size.value()) {
-      return std::nullopt;
-    }
-    std::vector<char> value(data_ + offset_, data_ + offset_ + static_cast<size_t>(size.value()));
-    offset_ += static_cast<size_t>(size.value());
-    return value;
-  }
-
-  auto read_fixed_blob(size_t size) -> std::optional<std::vector<char>> {
-    if (remaining() < size) {
-      return std::nullopt;
-    }
-    std::vector<char> value(data_ + offset_, data_ + offset_ + size);
-    offset_ += size;
-    return value;
-  }
-
-  [[nodiscard]] auto remaining() const -> size_t { return size_ - offset_; }
-
- private:
-  template <typename T>
-  auto read_pod() -> std::optional<T> {
-    if (remaining() < sizeof(T)) {
-      return std::nullopt;
-    }
-    T value{};
-    std::memcpy(&value, data_ + offset_, sizeof(T));
-    offset_ += sizeof(T);
-    return value;
-  }
-
-  const char *data_{nullptr};
-  size_t size_{0};
-  size_t offset_{0};
-};
-
+/**
+ * @brief Append-only write-ahead log used to recover operations after crashes.
+ *
+ * The log stores each operation as PREPARE plus COMMIT frames. Replay scans complete frames,
+ * validates their prepare/commit pairing and returns only committed records newer than the active
+ * snapshot.
+ */
 class WriteAheadLog {
  public:
   explicit WriteAheadLog(fs::path path) : path_(std::move(path)) {}
@@ -172,11 +91,12 @@ class WriteAheadLog {
   auto operator=(WriteAheadLog &&) -> WriteAheadLog & = delete;
 
   auto append_prepare(const WalRecord &record) const -> void {
-    append_frame(WalFrameType::PREPARE, record);
+    append_frame(WalFrameType::kPrepare, record);
   }
 
   auto append_commit(uint64_t op_id, MutationType mutation_type) const -> void {
-    append_frame(WalFrameType::COMMIT, WalRecord{op_id, mutation_type, {}});
+    append_frame(WalFrameType::kCommit,
+                 WalRecord{.op_id_ = op_id, .mutation_type_ = mutation_type, .payload_ = {}});
   }
 
   auto truncate() const -> void {
@@ -199,6 +119,17 @@ class WriteAheadLog {
     platform::sync_file(path_);
   }
 
+  /**
+   * @brief Reads the WAL and returns durable committed records that have not been applied yet.
+   *
+   * PREPARE frames are held until a matching COMMIT frame is seen. Truncated or corrupted tail
+   * frames stop replay after logging a warning, preserving all complete committed records that were
+   * written before the damaged section.
+   *
+   * @param applied_through Highest operation id already covered by the active snapshot.
+   * @param max_seen_op_id Optional output for the largest operation id observed while scanning.
+   * @return Committed WAL records sorted by operation id.
+   */
   [[nodiscard]] auto replayable_records(uint64_t applied_through,
                                         uint64_t *max_seen_op_id = nullptr) const
       -> std::vector<WalRecord> {
@@ -232,8 +163,8 @@ class WriteAheadLog {
         break;
       }
 
-      std::vector<char> payload(header->payload_size);
-      if (header->payload_size > 0) {
+      std::vector<char> payload(header->payload_size_);
+      if (header->payload_size_ > 0) {
         input.read(payload.data(), static_cast<std::streamsize>(payload.size()));
         if (!input) {
           LOG_WARN("WAL truncated while reading payload at {}", path_.string());
@@ -248,24 +179,25 @@ class WriteAheadLog {
         break;
       }
 
-      max_op_id = std::max(max_op_id, header->op_id);
-      if (header->frame_type == WalFrameType::PREPARE) {
-        pending[header->op_id] =
-            WalRecord{header->op_id, header->mutation_type, std::move(payload)};
+      max_op_id = std::max(max_op_id, header->op_id_);
+      if (header->frame_type_ == WalFrameType::kPrepare) {
+        pending[header->op_id_] = WalRecord{.op_id_ = header->op_id_,
+                                            .mutation_type_ = header->mutation_type_,
+                                            .payload_ = std::move(payload)};
         continue;
       }
 
-      auto pending_it = pending.find(header->op_id);
+      auto pending_it = pending.find(header->op_id_);
       if (pending_it == pending.end()) {
-        LOG_WARN("WAL commit without prepare: op_id={}", header->op_id);
+        LOG_WARN("WAL commit without prepare: op_id={}", header->op_id_);
         continue;
       }
-      if (pending_it->second.mutation_type != header->mutation_type) {
-        LOG_WARN("WAL prepare/commit mutation mismatch: op_id={}", header->op_id);
+      if (pending_it->second.mutation_type_ != header->mutation_type_) {
+        LOG_WARN("WAL prepare/commit mutation mismatch: op_id={}", header->op_id_);
         pending.erase(pending_it);
         continue;
       }
-      if (header->op_id > applied_through) {
+      if (header->op_id_ > applied_through) {
         committed.push_back(std::move(pending_it->second));
       }
       pending.erase(pending_it);
@@ -274,18 +206,18 @@ class WriteAheadLog {
     if (max_seen_op_id != nullptr) {
       *max_seen_op_id = max_op_id;
     }
-    std::sort(committed.begin(), committed.end(), [](const WalRecord &lhs, const WalRecord &rhs) {
-      return lhs.op_id < rhs.op_id;
+    std::ranges::sort(committed, [](const WalRecord &lhs, const WalRecord &rhs) {
+      return lhs.op_id_ < rhs.op_id_;
     });
     return committed;
   }
 
  private:
   struct FrameHeader {
-    WalFrameType frame_type{WalFrameType::PREPARE};
-    MutationType mutation_type{MutationType::INSERT};
-    uint64_t op_id{0};
-    uint64_t payload_size{0};
+    WalFrameType frame_type_{WalFrameType::kPrepare};    ///< PREPARE payload or COMMIT marker.
+    MutationType mutation_type_{MutationType::kInsert};  ///< Mutation category from the frame.
+    uint64_t op_id_{0};                                  ///< Operation id for frame pairing.
+    uint64_t payload_size_{0};                           ///< Payload byte count after header.
   };
 
   auto ensure_stream_open() const -> void {
@@ -298,6 +230,13 @@ class WriteAheadLog {
     }
   }
 
+  /**
+   * @brief Serializes and appends one WAL frame for a PREPARE or COMMIT operation.
+   *
+   * The full frame is assembled into a contiguous buffer before writing so the header, payload and
+   * trailer are emitted together. COMMIT frames are fsynced to make the commit boundary durable for
+   * crash recovery.
+   */
   auto append_frame(WalFrameType frame_type, const WalRecord &record) const -> void {
     std::lock_guard<std::mutex> lock(wal_mutex_);
     ensure_stream_open();
@@ -307,7 +246,8 @@ class WriteAheadLog {
     constexpr size_t kHeaderSize =
         sizeof(uint32_t) + sizeof(uint8_t) * 4 + sizeof(uint64_t) + sizeof(uint64_t);
     constexpr size_t kTrailerSize = sizeof(uint32_t);
-    uint64_t payload_size = static_cast<uint64_t>(record.payload.size());
+    auto payload_size = static_cast<uint64_t>(record.payload_.size());
+
     std::vector<char> buf(kHeaderSize + static_cast<size_t>(payload_size) + kTrailerSize);
     char *ptr = buf.data();
 
@@ -317,16 +257,18 @@ class WriteAheadLog {
     };
 
     write_pod(kWalFrameMagic);
+
     write_pod(kWalFormatVersion);
     write_pod(static_cast<uint8_t>(frame_type));
-    write_pod(static_cast<uint8_t>(record.mutation_type));
+    write_pod(static_cast<uint8_t>(record.mutation_type_));
     write_pod(static_cast<uint8_t>(0));  // reserved
-    write_pod(record.op_id);
+    write_pod(record.op_id_);
     write_pod(payload_size);
     if (payload_size > 0) {
-      std::memcpy(ptr, record.payload.data(), static_cast<size_t>(payload_size));
+      std::memcpy(ptr, record.payload_.data(), static_cast<size_t>(payload_size));
       ptr += static_cast<size_t>(payload_size);
     }
+
     write_pod(kWalTrailerMagic);
 
     wal_stream_.write(buf.data(), static_cast<std::streamsize>(buf.size()));
@@ -335,11 +277,17 @@ class WriteAheadLog {
     // Only fsync on COMMIT frames. PREPARE frames are durable enough after
     // flush — a crash between PREPARE and COMMIT leaves an uncommitted record
     // that is correctly skipped during replay.
-    if (frame_type == WalFrameType::COMMIT) {
+    if (frame_type == WalFrameType::kCommit) {
       platform::sync_file(path_);
     }
   }
 
+  /**
+   * @brief Reads and validates the fixed-size WAL frame header from the input stream.
+   *
+   * The reader returns std::nullopt on EOF, truncated headers, unexpected magic values or
+   * unsupported format versions so the replay loop can stop at the last complete valid frame.
+   */
   [[nodiscard]] static auto read_frame_header(std::ifstream &input) -> std::optional<FrameHeader> {
     uint32_t magic = 0;
     input.read(reinterpret_cast<char *>(&magic), sizeof(magic));
@@ -377,16 +325,16 @@ class WriteAheadLog {
       return std::nullopt;
     }
     return FrameHeader{
-        static_cast<WalFrameType>(frame_type),
-        static_cast<MutationType>(mutation_type),
-        op_id,
-        payload_size,
+        .frame_type_ = static_cast<WalFrameType>(frame_type),
+        .mutation_type_ = static_cast<MutationType>(mutation_type),
+        .op_id_ = op_id,
+        .payload_size_ = payload_size,
     };
   }
 
-  fs::path path_;
-  mutable std::mutex wal_mutex_;
-  mutable std::ofstream wal_stream_;
+  fs::path path_;                     ///< Filesystem path of the WAL file.
+  mutable std::mutex wal_mutex_;      ///< Guards appends, flushes, truncation and stream state.
+  mutable std::ofstream wal_stream_;  ///< Lazily opened append stream for WAL frames.
 };
 
 }  // namespace alaya::recovery

--- a/include/recovery/write_ahead_log.hpp
+++ b/include/recovery/write_ahead_log.hpp
@@ -9,8 +9,10 @@
 #include <cstring>
 #include <filesystem>  // NOLINT(build/c++17)
 #include <fstream>
+#include <limits>
 #include <mutex>
 #include <optional>
+#include <stdexcept>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -23,9 +25,10 @@ namespace alaya::recovery {
 
 namespace fs = std::filesystem;
 
-constexpr uint32_t kWalFrameMagic = 0x48454144U;    ///< WAL frame prefix magic, "HEAD".
-constexpr uint32_t kWalTrailerMagic = 0x5441494CU;  ///< WAL frame trailer magic, "TAIL".
-constexpr uint8_t kWalFormatVersion = 1;            ///< Current on-disk WAL frame version.
+constexpr uint32_t kWalFrameMagic = 0x48454144U;     ///< WAL frame prefix magic, "HEAD".
+constexpr uint32_t kWalTrailerMagic = 0x5441494CU;   ///< WAL frame trailer magic, "TAIL".
+constexpr uint8_t kWalFormatVersion = 1;             ///< Current on-disk WAL frame version.
+constexpr uint64_t kMaxWalPayloadSize = 1ULL << 30;  ///< Maximum accepted WAL payload bytes.
 
 /**
  * @brief Identifies whether a WAL frame starts or commits a mutation.
@@ -155,6 +158,15 @@ class WriteAheadLog {
     if (!input.is_open()) {
       throw std::runtime_error("Failed to open WAL file at " + path_.string());
     }
+    std::error_code file_size_ec;
+    const auto wal_file_size = fs::file_size(path_, file_size_ec);
+    if (file_size_ec) {
+      LOG_WARN("Failed to stat WAL file at {}: {}", path_.string(), file_size_ec.message());
+      if (max_seen_op_id != nullptr) {
+        *max_seen_op_id = applied_through;
+      }
+      return committed;
+    }
 
     uint64_t max_op_id = applied_through;
     while (true) {
@@ -162,8 +174,15 @@ class WriteAheadLog {
       if (!header.has_value()) {
         break;
       }
+      if (!payload_size_is_plausible(input, wal_file_size, header->payload_size_)) {
+        LOG_WARN("WAL payload size is invalid: op_id={} payload_size={} path={}",
+                 header->op_id_,
+                 header->payload_size_,
+                 path_.string());
+        break;
+      }
 
-      std::vector<char> payload(header->payload_size_);
+      std::vector<char> payload(static_cast<size_t>(header->payload_size_));
       if (header->payload_size_ > 0) {
         input.read(payload.data(), static_cast<std::streamsize>(payload.size()));
         if (!input) {
@@ -220,6 +239,34 @@ class WriteAheadLog {
     uint64_t payload_size_{0};                           ///< Payload byte count after header.
   };
 
+  [[nodiscard]] static auto payload_size_is_plausible(std::ifstream &input,
+                                                      uintmax_t wal_file_size,
+                                                      uint64_t payload_size) -> bool {
+    if (payload_size > kMaxWalPayloadSize) {
+      return false;
+    }
+    if (payload_size > static_cast<uint64_t>(std::numeric_limits<std::streamsize>::max())) {
+      return false;
+    }
+    if (payload_size > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+      return false;
+    }
+
+    const auto payload_start = input.tellg();
+    if (payload_start == std::ifstream::pos_type(-1)) {
+      return false;
+    }
+    const auto payload_offset = static_cast<uintmax_t>(payload_start);
+    if (payload_offset > wal_file_size) {
+      return false;
+    }
+
+    constexpr uintmax_t kTrailerSize = sizeof(uint32_t);
+    const auto remaining_bytes = wal_file_size - payload_offset;
+    return remaining_bytes >= kTrailerSize &&
+           static_cast<uintmax_t>(payload_size) <= remaining_bytes - kTrailerSize;
+  }
+
   auto ensure_stream_open() const -> void {
     if (!wal_stream_.is_open()) {
       fs::create_directories(path_.parent_path());
@@ -247,6 +294,9 @@ class WriteAheadLog {
         sizeof(uint32_t) + sizeof(uint8_t) * 4 + sizeof(uint64_t) + sizeof(uint64_t);
     constexpr size_t kTrailerSize = sizeof(uint32_t);
     auto payload_size = static_cast<uint64_t>(record.payload_.size());
+    if (payload_size > kMaxWalPayloadSize) {
+      throw std::runtime_error("WAL payload exceeds maximum frame size");
+    }
 
     std::vector<char> buf(kHeaderSize + static_cast<size_t>(payload_size) + kTrailerSize);
     char *ptr = buf.data();

--- a/include/space/sq4_space.hpp
+++ b/include/space/sq4_space.hpp
@@ -80,8 +80,8 @@ class SQ4Space {
       : capacity_(capacity),
         dim_(dim),
         metric_(metric),
-        config_(std::move(config)),
-        quantizer_(dim) {
+        quantizer_(dim),
+        config_(std::move(config)) {
     data_size_ = ((dim + 1) / 2) * sizeof(uint8_t);
     data_storage_.init(data_size_, capacity);
     set_metric_function();

--- a/include/space/sq8_space.hpp
+++ b/include/space/sq8_space.hpp
@@ -79,8 +79,8 @@ class SQ8Space {
       : capacity_(capacity),
         dim_(dim),
         metric_(metric),
-        config_(std::move(config)),
-        quantizer_(dim) {
+        quantizer_(dim),
+        config_(std::move(config)) {
     data_size_ = dim_ * sizeof(uint8_t);
     data_storage_.init(data_size_, capacity);
     set_metric_function();

--- a/include/utils/binary_io.hpp
+++ b/include/utils/binary_io.hpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace alaya::binary_io {
+
+/**
+ * @brief Small helper for building length-prefixed binary payloads.
+ *
+ * Values are appended in host byte order. Strings and blobs are stored as an unsigned 64-bit byte
+ * length followed by the raw bytes.
+ */
+class BinaryWriter {
+ public:
+  auto write_u8(uint8_t value) -> void { write_pod(value); }
+  auto write_u32(uint32_t value) -> void { write_pod(value); }
+  auto write_u64(uint64_t value) -> void { write_pod(value); }
+
+  auto write_bytes(const char *data, size_t size) -> void {
+    if (size == 0) {
+      return;
+    }
+    buffer_.insert(buffer_.end(), data, data + size);
+  }
+
+  auto write_string(const std::string &value) -> void {
+    write_u64(static_cast<uint64_t>(value.size()));
+    write_bytes(value.data(), value.size());
+  }
+
+  auto write_blob(const std::vector<char> &value) -> void {
+    write_u64(static_cast<uint64_t>(value.size()));
+    write_bytes(value.data(), value.size());
+  }
+
+  auto write_blob(const std::string &value) -> void {
+    write_u64(static_cast<uint64_t>(value.size()));
+    write_bytes(value.data(), value.size());
+  }
+
+  template <typename T>
+  auto write_vector_blob(const T *data, size_t element_count) -> void {
+    auto bytes = static_cast<uint64_t>(element_count * sizeof(T));
+    write_u64(bytes);
+    write_bytes(reinterpret_cast<const char *>(data), static_cast<size_t>(bytes));
+  }
+
+  [[nodiscard]] auto finish() && -> std::vector<char> { return std::move(buffer_); }
+
+ private:
+  template <typename T>
+  auto write_pod(const T &value) -> void {
+    auto *ptr = reinterpret_cast<const char *>(&value);
+    buffer_.insert(buffer_.end(), ptr, ptr + sizeof(T));
+  }
+
+  std::vector<char> buffer_;  ///< Accumulated serialized bytes returned by finish().
+};
+
+/**
+ * @brief Bounds-checked reader for payloads produced by BinaryWriter.
+ *
+ * Each read advances the internal offset only after enough bytes are available. Failed reads return
+ * std::nullopt so callers can reject truncated or malformed payloads.
+ */
+class BinaryReader {
+ public:
+  BinaryReader(const char *data, size_t size) : data_(data), size_(size) {}
+
+  auto read_u8() -> std::optional<uint8_t> { return read_pod<uint8_t>(); }
+  auto read_u32() -> std::optional<uint32_t> { return read_pod<uint32_t>(); }
+  auto read_u64() -> std::optional<uint64_t> { return read_pod<uint64_t>(); }
+
+  auto read_string() -> std::optional<std::string> {
+    auto size = read_u64();
+    if (!size.has_value()) {
+      return std::nullopt;
+    }
+    if (remaining() < size.value()) {
+      return std::nullopt;
+    }
+    std::string value(data_ + offset_, data_ + offset_ + static_cast<size_t>(size.value()));
+    offset_ += static_cast<size_t>(size.value());
+    return value;
+  }
+
+  auto read_blob() -> std::optional<std::vector<char>> {
+    auto size = read_u64();
+    if (!size.has_value()) {
+      return std::nullopt;
+    }
+    if (remaining() < size.value()) {
+      return std::nullopt;
+    }
+    std::vector<char> value(data_ + offset_, data_ + offset_ + static_cast<size_t>(size.value()));
+    offset_ += static_cast<size_t>(size.value());
+    return value;
+  }
+
+  auto read_fixed_blob(size_t size) -> std::optional<std::vector<char>> {
+    if (remaining() < size) {
+      return std::nullopt;
+    }
+    std::vector<char> value(data_ + offset_, data_ + offset_ + size);
+    offset_ += size;
+    return value;
+  }
+
+  [[nodiscard]] auto remaining() const -> size_t { return size_ - offset_; }
+
+ private:
+  template <typename T>
+  auto read_pod() -> std::optional<T> {
+    if (remaining() < sizeof(T)) {
+      return std::nullopt;
+    }
+    T value{};
+    std::memcpy(&value, data_ + offset_, sizeof(T));
+    offset_ += sizeof(T);
+    return value;
+  }
+
+  const char *data_{nullptr};  ///< Non-owning serialized payload pointer.
+  size_t size_{0};             ///< Total available bytes in data_.
+  size_t offset_{0};           ///< Current read offset in bytes.
+};
+
+}  // namespace alaya::binary_io

--- a/python/include/index.hpp
+++ b/python/include/index.hpp
@@ -50,6 +50,7 @@
 #include "space/sq4_space.hpp"
 #include "space/sq8_space.hpp"
 #include "storage/rocksdb_storage.hpp"
+#include "utils/binary_io.hpp"
 #include "utils/index_encoding.hpp"
 #include "utils/log.hpp"
 #include "utils/metadata_filter.hpp"
@@ -157,10 +158,10 @@ class PyIndex : public BasePyIndex {
                                                                params_.rocksdb_path_));
 
     uint64_t max_seen_op_id = 0;
-    recovery_manager_->replayable_records(0, &max_seen_op_id);
+    (void)recovery_manager_->replayable_records(0, &max_seen_op_id);
     auto manifest = recovery_manager_->current_snapshot();
     if (manifest.has_value()) {
-      last_committed_recovery_op_id_ = manifest->applied_through_op_id;
+      last_committed_recovery_op_id_ = manifest->applied_through_op_id_;
     }
     last_seen_recovery_op_id_ = std::max(max_seen_op_id, last_committed_recovery_op_id_);
     next_recovery_op_id_ = last_seen_recovery_op_id_ + 1;
@@ -289,14 +290,14 @@ class PyIndex : public BasePyIndex {
     }
 
     alaya::recovery::SnapshotManifest manifest;
-    manifest.snapshot_id = snapshot_id;
-    manifest.reason = std::string(reason);
-    manifest.applied_through_op_id = last_committed_recovery_op_id_;
-    manifest.created_unix_ms = alaya::recovery::SnapshotManifest::current_unix_ms();
-    manifest.graph_file = graph_file;
-    manifest.data_file = data_file;
-    manifest.quant_file = quant_file;
-    manifest.rocksdb_dir = rocksdb_dir;
+    manifest.snapshot_id_ = snapshot_id;
+    manifest.reason_ = std::string(reason);
+    manifest.applied_through_op_id_ = last_committed_recovery_op_id_;
+    manifest.created_unix_ms_ = alaya::recovery::SnapshotManifest::current_unix_ms();
+    manifest.graph_file_ = graph_file;
+    manifest.data_file_ = data_file;
+    manifest.quant_file_ = quant_file;
+    manifest.rocksdb_dir_ = rocksdb_dir;
 
     recovery_manager_->publish_snapshot(manifest, snapshot_dir);
   }
@@ -305,7 +306,7 @@ class PyIndex : public BasePyIndex {
                                                 uint32_t ef,
                                                 const ScalarData &scalar_data) const
       -> std::vector<char> {
-    alaya::recovery::BinaryWriter writer;
+    alaya::binary_io::BinaryWriter writer;
     writer.write_u32(ef);
     writer.write_vector_blob(data, static_cast<size_t>(data_dim_));
     writer.write_blob(scalar_data.serialize());
@@ -314,13 +315,13 @@ class PyIndex : public BasePyIndex {
 
   [[nodiscard]] auto encode_remove_item_payload(const std::string &item_id) const
       -> std::vector<char> {
-    alaya::recovery::BinaryWriter writer;
+    alaya::binary_io::BinaryWriter writer;
     writer.write_string(item_id);
     return std::move(writer).finish();
   }
 
   [[nodiscard]] auto encode_remove_internal_payload(IDType internal_id) const -> std::vector<char> {
-    alaya::recovery::BinaryWriter writer;
+    alaya::binary_io::BinaryWriter writer;
     writer.write_u64(static_cast<uint64_t>(internal_id));
     return std::move(writer).finish();
   }
@@ -394,11 +395,11 @@ class PyIndex : public BasePyIndex {
   }
 
   auto replay_record(const alaya::recovery::WalRecord &record) -> void {
-    alaya::recovery::BinaryReader reader(record.payload.data(), record.payload.size());
+    alaya::binary_io::BinaryReader reader(record.payload_.data(), record.payload_.size());
 
-    switch (record.mutation_type) {
-      case alaya::recovery::MutationType::INSERT:
-      case alaya::recovery::MutationType::UPSERT: {
+    switch (record.mutation_type_) {
+      case alaya::recovery::MutationType::kInsert:
+      case alaya::recovery::MutationType::kUpsert: {
         auto ef = reader.read_u32();
         auto vector_blob = reader.read_blob();
         auto scalar_blob = reader.read_blob();
@@ -413,14 +414,14 @@ class PyIndex : public BasePyIndex {
         std::vector<DataType> vector(data_dim_);
         std::memcpy(vector.data(), vector_blob->data(), vector_blob->size());
 
-        if (record.mutation_type == alaya::recovery::MutationType::INSERT) {
+        if (record.mutation_type_ == alaya::recovery::MutationType::kInsert) {
           insert_nondurable(vector.data(), ef.value(), &scalar_data);
         } else {
           upsert_nondurable(vector.data(), ef.value(), scalar_data);
         }
         break;
       }
-      case alaya::recovery::MutationType::REMOVE_BY_ITEM_ID: {
+      case alaya::recovery::MutationType::kRemoveByItemId: {
         auto item_id = reader.read_string();
         if (!item_id.has_value()) {
           throw std::runtime_error("Invalid WAL remove-by-item-id payload");
@@ -432,7 +433,7 @@ class PyIndex : public BasePyIndex {
         }
         break;
       }
-      case alaya::recovery::MutationType::REMOVE_BY_INTERNAL_ID: {
+      case alaya::recovery::MutationType::kRemoveByInternalId: {
         auto internal_id = reader.read_u64();
         if (!internal_id.has_value()) {
           throw std::runtime_error("Invalid WAL remove-by-id payload");
@@ -457,7 +458,7 @@ class PyIndex : public BasePyIndex {
         recovery_manager_->replayable_records(applied_through, &last_seen_recovery_op_id_);
     for (const auto &record : records) {
       replay_record(record);
-      last_committed_recovery_op_id_ = std::max(last_committed_recovery_op_id_, record.op_id);
+      last_committed_recovery_op_id_ = std::max(last_committed_recovery_op_id_, record.op_id_);
     }
     if (!records.empty()) {
       LOG_INFO("recovery: replayed {} committed mutations", records.size());
@@ -515,9 +516,9 @@ class PyIndex : public BasePyIndex {
         resolved_index_path = manifest->graph_path(snapshot_dir.value());
         resolved_data_path = manifest->data_path(snapshot_dir.value());
         resolved_quant_path = manifest->quant_path(snapshot_dir.value());
-        applied_through = manifest->applied_through_op_id;
+        applied_through = manifest->applied_through_op_id_;
         LOG_INFO("recovery: loading snapshot id={} applied_through={}",
-                 manifest->snapshot_id,
+                 manifest->snapshot_id_,
                  applied_through);
       }
     }
@@ -693,10 +694,10 @@ class PyIndex : public BasePyIndex {
       auto op_id = next_recovery_op_id_++;
       recovery_manager_->append_prepare(
           {op_id,
-           alaya::recovery::MutationType::INSERT,
+           alaya::recovery::MutationType::kInsert,
            encode_insert_like_payload(insert_data_ptr, ef, scalar_data)});
       auto inserted_id = insert_nondurable(insert_data_ptr, ef, &scalar_data);
-      recovery_manager_->append_commit(op_id, alaya::recovery::MutationType::INSERT);
+      recovery_manager_->append_commit(op_id, alaya::recovery::MutationType::kInsert);
       last_committed_recovery_op_id_ = op_id;
       last_seen_recovery_op_id_ = std::max(last_seen_recovery_op_id_, op_id);
       return inserted_id;
@@ -719,10 +720,10 @@ class PyIndex : public BasePyIndex {
       auto op_id = next_recovery_op_id_++;
       recovery_manager_->append_prepare(
           {op_id,
-           alaya::recovery::MutationType::UPSERT,
+           alaya::recovery::MutationType::kUpsert,
            encode_insert_like_payload(insert_data_ptr, ef, scalar_data)});
       auto upserted_id = upsert_nondurable(insert_data_ptr, ef, scalar_data);
-      recovery_manager_->append_commit(op_id, alaya::recovery::MutationType::UPSERT);
+      recovery_manager_->append_commit(op_id, alaya::recovery::MutationType::kUpsert);
       last_committed_recovery_op_id_ = op_id;
       last_seen_recovery_op_id_ = std::max(last_seen_recovery_op_id_, op_id);
       return upserted_id;
@@ -735,10 +736,10 @@ class PyIndex : public BasePyIndex {
     if (recovery_manager_ != nullptr) {
       auto op_id = next_recovery_op_id_++;
       recovery_manager_->append_prepare({op_id,
-                                         alaya::recovery::MutationType::REMOVE_BY_INTERNAL_ID,
+                                         alaya::recovery::MutationType::kRemoveByInternalId,
                                          encode_remove_internal_payload(id)});
       remove_nondurable(id);
-      recovery_manager_->append_commit(op_id, alaya::recovery::MutationType::REMOVE_BY_INTERNAL_ID);
+      recovery_manager_->append_commit(op_id, alaya::recovery::MutationType::kRemoveByInternalId);
       last_committed_recovery_op_id_ = op_id;
       last_seen_recovery_op_id_ = std::max(last_seen_recovery_op_id_, op_id);
       return;
@@ -750,10 +751,10 @@ class PyIndex : public BasePyIndex {
     if (recovery_manager_ != nullptr) {
       auto op_id = next_recovery_op_id_++;
       recovery_manager_->append_prepare({op_id,
-                                         alaya::recovery::MutationType::REMOVE_BY_ITEM_ID,
+                                         alaya::recovery::MutationType::kRemoveByItemId,
                                          encode_remove_item_payload(item_id)});
       remove_nondurable(item_id);
-      recovery_manager_->append_commit(op_id, alaya::recovery::MutationType::REMOVE_BY_ITEM_ID);
+      recovery_manager_->append_commit(op_id, alaya::recovery::MutationType::kRemoveByItemId);
       last_committed_recovery_op_id_ = op_id;
       last_seen_recovery_op_id_ = std::max(last_seen_recovery_op_id_, op_id);
       return;

--- a/python/tests/client/test_rabitq_search.py
+++ b/python/tests/client/test_rabitq_search.py
@@ -14,6 +14,8 @@ from alayalite import Client
 from alayalite.index import Index
 from alayalite.utils import calc_gt, calc_recall
 
+RABITQ_TEST_SEED = 12345
+
 
 def calc_gt_ip(data, query, topk):
     """Calculate ground truth using inner product (higher is better)."""
@@ -33,6 +35,10 @@ class TestAlayaLiteRaBitQSearch(unittest.TestCase):
         # Set RocksDB directory to temp_dir for isolation
         os.environ["ALAYALITE_ROCKSDB_DIR"] = os.path.join(self.temp_dir, "RocksDB")
         self.client = Client(url=self.temp_dir)
+        self.rng = np.random.default_rng(RABITQ_TEST_SEED)
+
+    def random_vectors(self, shape):
+        return self.rng.random(shape).astype(np.float32)
 
     def tearDown(self):
         """Clean up temp directories after each test."""
@@ -41,8 +47,8 @@ class TestAlayaLiteRaBitQSearch(unittest.TestCase):
 
     def test_rabitq_search_solo(self):
         index = self.client.create_index(name="rabitq_index", metric="l2", quantization_type="rabitq")
-        vectors = np.random.rand(1000, 128).astype(np.float32)
-        single_query = np.random.rand(128).astype(np.float32)
+        vectors = self.random_vectors((1000, 128))
+        single_query = self.random_vectors(128)
         index.fit(vectors)
         result = index.search(single_query, 10, 400).reshape(1, -1)
         gt = calc_gt(vectors, single_query.reshape(1, -1), 10)
@@ -51,8 +57,8 @@ class TestAlayaLiteRaBitQSearch(unittest.TestCase):
 
     def test_rabitq_batch_search(self):
         index = self.client.create_index(name="rabitq_index", metric="l2", quantization_type="rabitq")
-        vectors = np.random.rand(1000, 128).astype(np.float32)
-        queries = np.random.rand(10, 128).astype(np.float32)
+        vectors = self.random_vectors((1000, 128))
+        queries = self.random_vectors((10, 128))
         index.fit(vectors)
         result = index.batch_search(queries, 10, 400)
         gt = calc_gt(vectors, queries, 10)
@@ -61,8 +67,8 @@ class TestAlayaLiteRaBitQSearch(unittest.TestCase):
 
     def test_rabitq_batch_search_with_distance_unsupported(self):
         index = self.client.create_index(name="rabitq_index", metric="l2", quantization_type="rabitq")
-        vectors = np.random.rand(256, 128).astype(np.float32)
-        queries = np.random.rand(4, 128).astype(np.float32)
+        vectors = self.random_vectors((256, 128))
+        queries = self.random_vectors((4, 128))
         index.fit(vectors)
 
         with self.assertRaises(RuntimeError):
@@ -70,8 +76,8 @@ class TestAlayaLiteRaBitQSearch(unittest.TestCase):
 
     def test_rabitq_save_load(self):
         index = self.client.create_index(name="rabitq_index", metric="l2", quantization_type="rabitq")
-        vectors = np.random.rand(1000, 128).astype(np.float32)
-        queries = np.random.rand(10, 128).astype(np.float32)
+        vectors = self.random_vectors((1000, 128))
+        queries = self.random_vectors((10, 128))
         index.fit(vectors)
         result = index.batch_search(queries, 10, 400)
         gt = calc_gt(vectors, queries, 10)
@@ -87,8 +93,8 @@ class TestAlayaLiteRaBitQSearch(unittest.TestCase):
 
     def test_rabitq_search_solo_ip(self):
         index = self.client.create_index(name="rabitq_ip_index", metric="ip", quantization_type="rabitq")
-        vectors = np.random.rand(1000, 128).astype(np.float32)
-        single_query = np.random.rand(128).astype(np.float32)
+        vectors = self.random_vectors((1000, 128))
+        single_query = self.random_vectors(128)
         index.fit(vectors)
         result = index.search(single_query, 10, 400).reshape(1, -1)
         gt = calc_gt_ip(vectors, single_query.reshape(1, -1), 10)
@@ -97,8 +103,8 @@ class TestAlayaLiteRaBitQSearch(unittest.TestCase):
 
     def test_rabitq_batch_search_ip(self):
         index = self.client.create_index(name="rabitq_ip_index", metric="ip", quantization_type="rabitq")
-        vectors = np.random.rand(1000, 128).astype(np.float32)
-        queries = np.random.rand(10, 128).astype(np.float32)
+        vectors = self.random_vectors((1000, 128))
+        queries = self.random_vectors((10, 128))
         index.fit(vectors)
         result = index.batch_search(queries, 10, 400)
         gt = calc_gt_ip(vectors, queries, 10)
@@ -107,8 +113,8 @@ class TestAlayaLiteRaBitQSearch(unittest.TestCase):
 
     def test_rabitq_save_load_ip(self):
         index = self.client.create_index(name="rabitq_ip_index", metric="ip", quantization_type="rabitq")
-        vectors = np.random.rand(1000, 128).astype(np.float32)
-        queries = np.random.rand(10, 128).astype(np.float32)
+        vectors = self.random_vectors((1000, 128))
+        queries = self.random_vectors((10, 128))
         index.fit(vectors)
         result = index.batch_search(queries, 10, 400)
         gt = calc_gt_ip(vectors, queries, 10)
@@ -124,8 +130,8 @@ class TestAlayaLiteRaBitQSearch(unittest.TestCase):
     def test_invalid_parameters(self):
         """Test that ef < k raises an error."""
         index = self.client.create_index(name="rabitq_index", metric="l2", quantization_type="rabitq")
-        vectors = np.random.rand(1000, 128).astype(np.float32)
-        query = np.random.rand(128).astype(np.float32)
+        vectors = self.random_vectors((1000, 128))
+        query = self.random_vectors(128)
         index.fit(vectors)
 
         # ef < k should throw exception

--- a/tests/recovery/recovery_test.cpp
+++ b/tests/recovery/recovery_test.cpp
@@ -39,6 +39,24 @@ static auto write_pod(std::ofstream &output, const T &value) -> void {
   output.write(reinterpret_cast<const char *>(&value), sizeof(value));
 }
 
+static auto write_raw_wal_frame(std::ofstream &output,
+                                uint8_t frame_type,
+                                uint8_t mutation_type,
+                                uint64_t op_id,
+                                const std::vector<char> &payload = {}) -> void {
+  write_pod(output, kWalFrameMagic);
+  write_pod(output, kWalFormatVersion);
+  write_pod(output, frame_type);
+  write_pod(output, mutation_type);
+  write_pod(output, static_cast<uint8_t>(0));
+  write_pod(output, op_id);
+  write_pod(output, static_cast<uint64_t>(payload.size()));
+  if (!payload.empty()) {
+    output.write(payload.data(), static_cast<std::streamsize>(payload.size()));
+  }
+  write_pod(output, kWalTrailerMagic);
+}
+
 // ---------------------------------------------------------------------------
 // WalTest
 // ---------------------------------------------------------------------------
@@ -228,6 +246,41 @@ TEST_F(WalTest, RejectsAbsurdPayloadSizeBeforeAllocating) {
     write_pod(output, static_cast<uint8_t>(0));
     write_pod(output, uint64_t{99});
     write_pod(output, std::numeric_limits<uint64_t>::max());
+  }
+
+  WriteAheadLog wal(wal_path_);
+  std::vector<WalRecord> records;
+  EXPECT_NO_THROW(records = wal.replayable_records(0));
+  EXPECT_TRUE(records.empty());
+}
+
+TEST_F(WalTest, RejectsInvalidFrameTypeBeforeReplay) {
+  {
+    WriteAheadLog wal(wal_path_);
+    wal.append_prepare({7, MutationType::kInsert, make_payload("prepared")});
+  }
+  {
+    std::ofstream output(wal_path_, std::ios::binary | std::ios::app);
+    ASSERT_TRUE(output.is_open());
+    write_raw_wal_frame(output, 99, static_cast<uint8_t>(MutationType::kInsert), 7, {});
+  }
+
+  WriteAheadLog wal(wal_path_);
+  std::vector<WalRecord> records;
+  EXPECT_NO_THROW(records = wal.replayable_records(0));
+  EXPECT_TRUE(records.empty());
+}
+
+TEST_F(WalTest, RejectsInvalidMutationTypeBeforeReplay) {
+  {
+    std::ofstream output(wal_path_, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(output.is_open());
+    write_raw_wal_frame(output,
+                        static_cast<uint8_t>(WalFrameType::kPrepare),
+                        99,
+                        8,
+                        make_payload("invalid-mutation"));
+    write_raw_wal_frame(output, static_cast<uint8_t>(WalFrameType::kCommit), 99, 8, {});
   }
 
   WriteAheadLog wal(wal_path_);

--- a/tests/recovery/recovery_test.cpp
+++ b/tests/recovery/recovery_test.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <set>
 #include <string>
 #include <thread>
@@ -31,6 +32,11 @@ static auto make_payload(const std::string &content) -> std::vector<char> {
 
 static auto payload_string(const WalRecord &record) -> std::string {
   return {record.payload_.begin(), record.payload_.end()};
+}
+
+template <typename T>
+static auto write_pod(std::ofstream &output, const T &value) -> void {
+  output.write(reinterpret_cast<const char *>(&value), sizeof(value));
 }
 
 // ---------------------------------------------------------------------------
@@ -211,6 +217,25 @@ TEST_F(WalTest, MaxSeenOpIdTracksHighest) {
   EXPECT_EQ(max_seen, 5U);
 }
 
+TEST_F(WalTest, RejectsAbsurdPayloadSizeBeforeAllocating) {
+  {
+    std::ofstream output(wal_path_, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(output.is_open());
+    write_pod(output, kWalFrameMagic);
+    write_pod(output, kWalFormatVersion);
+    write_pod(output, static_cast<uint8_t>(WalFrameType::kPrepare));
+    write_pod(output, static_cast<uint8_t>(MutationType::kInsert));
+    write_pod(output, static_cast<uint8_t>(0));
+    write_pod(output, uint64_t{99});
+    write_pod(output, std::numeric_limits<uint64_t>::max());
+  }
+
+  WriteAheadLog wal(wal_path_);
+  std::vector<WalRecord> records;
+  EXPECT_NO_THROW(records = wal.replayable_records(0));
+  EXPECT_TRUE(records.empty());
+}
+
 // ---------------------------------------------------------------------------
 // SnapshotManifestTest
 // ---------------------------------------------------------------------------
@@ -246,6 +271,22 @@ TEST(SnapshotManifestTest, DeserializeRejectsEmptySnapshotId) {
   std::string raw = "format_version=1\nsnapshot_id=\nreason=test\n";
   auto result = SnapshotManifest::deserialize(raw);
   EXPECT_FALSE(result.has_value());
+}
+
+TEST(SnapshotManifestTest, DeserializeRejectsMalformedNumericFields) {
+  const std::string base =
+      "snapshot_id=snapshot-123\nreason=test\napplied_through_op_id=1\ncreated_unix_ms=2\n";
+
+  EXPECT_FALSE(SnapshotManifest::deserialize("format_version=abc\n" + base).has_value());
+  EXPECT_FALSE(SnapshotManifest::deserialize("format_version=1\nsnapshot_id=snapshot-123\n"
+                                             "applied_through_op_id=-1\ncreated_unix_ms=2\n")
+                   .has_value());
+  EXPECT_FALSE(SnapshotManifest::deserialize("format_version=1\nsnapshot_id=snapshot-123\n"
+                                             "applied_through_op_id=1x\ncreated_unix_ms=2\n")
+                   .has_value());
+  EXPECT_FALSE(SnapshotManifest::deserialize("format_version=4294967296\nsnapshot_id=snapshot-123\n"
+                                             "applied_through_op_id=1\ncreated_unix_ms=2\n")
+                   .has_value());
 }
 
 // ---------------------------------------------------------------------------
@@ -305,6 +346,26 @@ TEST_F(RecoveryManagerTest, PublishAndReadBackSnapshot) {
   auto current_dir = mgr.current_snapshot_dir();
   ASSERT_TRUE(current_dir.has_value());
   EXPECT_EQ(*current_dir, snapshot_dir);
+}
+
+TEST_F(RecoveryManagerTest, CurrentSnapshotTreatsMalformedManifestAsNoSnapshot) {
+  auto mgr = make_manager();
+  mgr.ensure_layout();
+
+  auto snapshot_dir = root_dir_ / "snapshots" / "snapshot-bad";
+  fs::create_directories(snapshot_dir);
+  {
+    std::ofstream current(root_dir_ / "CURRENT", std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(current.is_open());
+    current << "snapshot-bad\n";
+  }
+  {
+    std::ofstream manifest(snapshot_dir / "manifest.txt", std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(manifest.is_open());
+    manifest << "format_version=abc\nsnapshot_id=snapshot-bad\n";
+  }
+
+  EXPECT_FALSE(mgr.current_snapshot().has_value());
 }
 
 TEST_F(RecoveryManagerTest, OldSnapshotsRemovedAfterPublish) {

--- a/tests/recovery/recovery_test.cpp
+++ b/tests/recovery/recovery_test.cpp
@@ -30,7 +30,7 @@ static auto make_payload(const std::string &content) -> std::vector<char> {
 }
 
 static auto payload_string(const WalRecord &record) -> std::string {
-  return {record.payload.begin(), record.payload.end()};
+  return {record.payload_.begin(), record.payload_.end()};
 }
 
 // ---------------------------------------------------------------------------
@@ -62,20 +62,20 @@ class WalTest : public ::testing::Test {
 
 TEST_F(WalTest, PrepareAndCommitRoundtrip) {
   WriteAheadLog wal(wal_path_);
-  WalRecord record{1, MutationType::INSERT, make_payload("hello")};
+  WalRecord record{1, MutationType::kInsert, make_payload("hello")};
   wal.append_prepare(record);
-  wal.append_commit(1, MutationType::INSERT);
+  wal.append_commit(1, MutationType::kInsert);
 
   auto records = wal.replayable_records(0);
   ASSERT_EQ(records.size(), 1U);
-  EXPECT_EQ(records[0].op_id, 1U);
-  EXPECT_EQ(records[0].mutation_type, MutationType::INSERT);
+  EXPECT_EQ(records[0].op_id_, 1U);
+  EXPECT_EQ(records[0].mutation_type_, MutationType::kInsert);
   EXPECT_EQ(payload_string(records[0]), "hello");
 }
 
 TEST_F(WalTest, PrepareWithoutCommitNotReplayable) {
   WriteAheadLog wal(wal_path_);
-  wal.append_prepare({1, MutationType::INSERT, make_payload("orphan")});
+  wal.append_prepare({1, MutationType::kInsert, make_payload("orphan")});
 
   auto records = wal.replayable_records(0);
   EXPECT_TRUE(records.empty());
@@ -85,38 +85,38 @@ TEST_F(WalTest, MixedCommittedAndUncommitted) {
   WriteAheadLog wal(wal_path_);
 
   // Commit ops 1 and 3, leave op 2 uncommitted
-  wal.append_prepare({1, MutationType::INSERT, make_payload("op1")});
-  wal.append_commit(1, MutationType::INSERT);
+  wal.append_prepare({1, MutationType::kInsert, make_payload("op1")});
+  wal.append_commit(1, MutationType::kInsert);
 
-  wal.append_prepare({2, MutationType::UPSERT, make_payload("op2")});
+  wal.append_prepare({2, MutationType::kUpsert, make_payload("op2")});
   // no commit for op 2
 
-  wal.append_prepare({3, MutationType::REMOVE_BY_ITEM_ID, make_payload("op3")});
-  wal.append_commit(3, MutationType::REMOVE_BY_ITEM_ID);
+  wal.append_prepare({3, MutationType::kRemoveByItemId, make_payload("op3")});
+  wal.append_commit(3, MutationType::kRemoveByItemId);
 
   auto records = wal.replayable_records(0);
   ASSERT_EQ(records.size(), 2U);
-  EXPECT_EQ(records[0].op_id, 1U);
-  EXPECT_EQ(records[1].op_id, 3U);
+  EXPECT_EQ(records[0].op_id_, 1U);
+  EXPECT_EQ(records[1].op_id_, 3U);
 }
 
 TEST_F(WalTest, AppliedThroughFiltersOlderRecords) {
   WriteAheadLog wal(wal_path_);
 
   for (uint64_t i = 1; i <= 3; ++i) {
-    wal.append_prepare({i, MutationType::INSERT, make_payload("op" + std::to_string(i))});
-    wal.append_commit(i, MutationType::INSERT);
+    wal.append_prepare({i, MutationType::kInsert, make_payload("op" + std::to_string(i))});
+    wal.append_commit(i, MutationType::kInsert);
   }
 
   auto records = wal.replayable_records(2);
   ASSERT_EQ(records.size(), 1U);
-  EXPECT_EQ(records[0].op_id, 3U);
+  EXPECT_EQ(records[0].op_id_, 3U);
 }
 
 TEST_F(WalTest, TruncatedWalHandledGracefully) {
   WriteAheadLog wal(wal_path_);
-  wal.append_prepare({1, MutationType::INSERT, make_payload("data")});
-  wal.append_commit(1, MutationType::INSERT);
+  wal.append_prepare({1, MutationType::kInsert, make_payload("data")});
+  wal.append_commit(1, MutationType::kInsert);
 
   // Corrupt the file by removing the last 4 bytes (trailer)
   {
@@ -148,8 +148,8 @@ TEST_F(WalTest, ConcurrentWritesDoNotCorrupt) {
         for (int i = 0; i < kOpsPerThread; ++i) {
           uint64_t op_id = static_cast<uint64_t>(t * 1000 + i + 1);
           auto payload = make_payload("t" + std::to_string(t) + "_" + std::to_string(i));
-          wal.append_prepare({op_id, MutationType::INSERT, payload});
-          wal.append_commit(op_id, MutationType::INSERT);
+          wal.append_prepare({op_id, MutationType::kInsert, payload});
+          wal.append_commit(op_id, MutationType::kInsert);
         }
       });
     }
@@ -168,15 +168,15 @@ TEST_F(WalTest, ConcurrentWritesDoNotCorrupt) {
   // Verify all unique op_ids are present
   std::set<uint64_t> op_ids;
   for (const auto &rec : records) {
-    op_ids.insert(rec.op_id);
+    op_ids.insert(rec.op_id_);
   }
   EXPECT_EQ(op_ids.size(), static_cast<size_t>(kThreads * kOpsPerThread));
 }
 
 TEST_F(WalTest, TruncateRemovesWalFile) {
   WriteAheadLog wal(wal_path_);
-  wal.append_prepare({1, MutationType::INSERT, make_payload("data")});
-  wal.append_commit(1, MutationType::INSERT);
+  wal.append_prepare({1, MutationType::kInsert, make_payload("data")});
+  wal.append_commit(1, MutationType::kInsert);
   ASSERT_TRUE(fs::exists(wal_path_));
 
   wal.truncate();
@@ -186,28 +186,28 @@ TEST_F(WalTest, TruncateRemovesWalFile) {
   EXPECT_TRUE(records.empty());
 
   // Can write new records after truncation
-  wal.append_prepare({2, MutationType::UPSERT, make_payload("new")});
-  wal.append_commit(2, MutationType::UPSERT);
+  wal.append_prepare({2, MutationType::kUpsert, make_payload("new")});
+  wal.append_commit(2, MutationType::kUpsert);
 
   records = wal.replayable_records(0);
   ASSERT_EQ(records.size(), 1U);
-  EXPECT_EQ(records[0].op_id, 2U);
+  EXPECT_EQ(records[0].op_id_, 2U);
 }
 
 TEST_F(WalTest, MaxSeenOpIdTracksHighest) {
   WriteAheadLog wal(wal_path_);
 
   // Committed op 3
-  wal.append_prepare({3, MutationType::INSERT, make_payload("op3")});
-  wal.append_commit(3, MutationType::INSERT);
+  wal.append_prepare({3, MutationType::kInsert, make_payload("op3")});
+  wal.append_commit(3, MutationType::kInsert);
 
   // Uncommitted op 5 (prepare only)
-  wal.append_prepare({5, MutationType::UPSERT, make_payload("op5")});
+  wal.append_prepare({5, MutationType::kUpsert, make_payload("op5")});
 
   uint64_t max_seen = 0;
   auto records = wal.replayable_records(0, &max_seen);
   ASSERT_EQ(records.size(), 1U);
-  EXPECT_EQ(records[0].op_id, 3U);
+  EXPECT_EQ(records[0].op_id_, 3U);
   EXPECT_EQ(max_seen, 5U);
 }
 
@@ -217,29 +217,29 @@ TEST_F(WalTest, MaxSeenOpIdTracksHighest) {
 
 TEST(SnapshotManifestTest, SerializeDeserializeRoundtrip) {
   SnapshotManifest original;
-  original.format_version = 1;
-  original.snapshot_id = "snapshot-123456";
-  original.reason = "test_reason";
-  original.applied_through_op_id = 42;
-  original.created_unix_ms = 1700000000000ULL;
-  original.graph_file = "graph.bin";
-  original.data_file = "data.bin";
-  original.quant_file = "quant.bin";
-  original.rocksdb_dir = "rocksdb";
+  original.format_version_ = 1;
+  original.snapshot_id_ = "snapshot-123456";
+  original.reason_ = "test_reason";
+  original.applied_through_op_id_ = 42;
+  original.created_unix_ms_ = 1700000000000ULL;
+  original.graph_file_ = "graph.bin";
+  original.data_file_ = "data.bin";
+  original.quant_file_ = "quant.bin";
+  original.rocksdb_dir_ = "rocksdb";
 
   auto serialized = original.serialize();
   auto deserialized = SnapshotManifest::deserialize(serialized);
 
   ASSERT_TRUE(deserialized.has_value());
-  EXPECT_EQ(deserialized->format_version, original.format_version);
-  EXPECT_EQ(deserialized->snapshot_id, original.snapshot_id);
-  EXPECT_EQ(deserialized->reason, original.reason);
-  EXPECT_EQ(deserialized->applied_through_op_id, original.applied_through_op_id);
-  EXPECT_EQ(deserialized->created_unix_ms, original.created_unix_ms);
-  EXPECT_EQ(deserialized->graph_file, original.graph_file);
-  EXPECT_EQ(deserialized->data_file, original.data_file);
-  EXPECT_EQ(deserialized->quant_file, original.quant_file);
-  EXPECT_EQ(deserialized->rocksdb_dir, original.rocksdb_dir);
+  EXPECT_EQ(deserialized->format_version_, original.format_version_);
+  EXPECT_EQ(deserialized->snapshot_id_, original.snapshot_id_);
+  EXPECT_EQ(deserialized->reason_, original.reason_);
+  EXPECT_EQ(deserialized->applied_through_op_id_, original.applied_through_op_id_);
+  EXPECT_EQ(deserialized->created_unix_ms_, original.created_unix_ms_);
+  EXPECT_EQ(deserialized->graph_file_, original.graph_file_);
+  EXPECT_EQ(deserialized->data_file_, original.data_file_);
+  EXPECT_EQ(deserialized->quant_file_, original.quant_file_);
+  EXPECT_EQ(deserialized->rocksdb_dir_, original.rocksdb_dir_);
 }
 
 TEST(SnapshotManifestTest, DeserializeRejectsEmptySnapshotId) {
@@ -277,10 +277,10 @@ class RecoveryManagerTest : public ::testing::Test {
 
   auto make_manifest(const std::string &snapshot_id, uint64_t applied_through) -> SnapshotManifest {
     SnapshotManifest manifest;
-    manifest.snapshot_id = snapshot_id;
-    manifest.reason = "test";
-    manifest.applied_through_op_id = applied_through;
-    manifest.created_unix_ms = SnapshotManifest::current_unix_ms();
+    manifest.snapshot_id_ = snapshot_id;
+    manifest.reason_ = "test";
+    manifest.applied_through_op_id_ = applied_through;
+    manifest.created_unix_ms_ = SnapshotManifest::current_unix_ms();
     return manifest;
   }
 
@@ -299,8 +299,8 @@ TEST_F(RecoveryManagerTest, PublishAndReadBackSnapshot) {
 
   auto current = mgr.current_snapshot();
   ASSERT_TRUE(current.has_value());
-  EXPECT_EQ(current->snapshot_id, manifest.snapshot_id);
-  EXPECT_EQ(current->applied_through_op_id, 10U);
+  EXPECT_EQ(current->snapshot_id_, manifest.snapshot_id_);
+  EXPECT_EQ(current->applied_through_op_id_, 10U);
 
   auto current_dir = mgr.current_snapshot_dir();
   ASSERT_TRUE(current_dir.has_value());
@@ -334,7 +334,7 @@ TEST_F(RecoveryManagerTest, OldSnapshotsRemovedAfterPublish) {
 
   auto current = mgr.current_snapshot();
   ASSERT_TRUE(current.has_value());
-  EXPECT_EQ(current->snapshot_id, manifest_b.snapshot_id);
+  EXPECT_EQ(current->snapshot_id_, manifest_b.snapshot_id_);
 }
 
 TEST_F(RecoveryManagerTest, WalTruncatedAfterPublish) {
@@ -342,9 +342,9 @@ TEST_F(RecoveryManagerTest, WalTruncatedAfterPublish) {
   mgr.ensure_layout();
 
   // Write some WAL records
-  WalRecord record{1, MutationType::INSERT, make_payload("test")};
+  WalRecord record{1, MutationType::kInsert, make_payload("test")};
   mgr.append_prepare(record);
-  mgr.append_commit(1, MutationType::INSERT);
+  mgr.append_commit(1, MutationType::kInsert);
 
   auto before = mgr.replayable_records(0);
   ASSERT_EQ(before.size(), 1U);
@@ -367,8 +367,8 @@ TEST_F(RecoveryManagerTest, NextOperationIdReflectsState) {
   EXPECT_EQ(mgr.next_operation_id(), 1U);
 
   // Write a WAL record
-  mgr.append_prepare({5, MutationType::INSERT, make_payload("data")});
-  mgr.append_commit(5, MutationType::INSERT);
+  mgr.append_prepare({5, MutationType::kInsert, make_payload("data")});
+  mgr.append_commit(5, MutationType::kInsert);
 
   // next_operation_id should be 6
   EXPECT_EQ(mgr.next_operation_id(), 6U);

--- a/tests/space/sq8_space_test.cpp
+++ b/tests/space/sq8_space_test.cpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <memory>
 #include <string_view>
+#include <vector>
 #include "utils/log.hpp"
 #include "utils/metadata_filter.hpp"
 #include "utils/scalar_data.hpp"
@@ -85,8 +86,8 @@ TEST_F(SQ8SpaceTest, SaveAndLoad) {
 TEST_F(SQ8SpaceTest, QueryComputerWithQuery) {
   float data[8] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
   space_->fit(reinterpret_cast<float *>(data), 2);
-  float query[4] = {1.0, 2.0, 3.0, 4.0};
-  auto query_computer = space_->get_query_computer(query);
+  std::vector<float> query{1.0, 2.0, 3.0, 4.0};
+  auto query_computer = space_->get_query_computer(query.data());
   EXPECT_GE(query_computer(1), 64);
 }
 
@@ -132,7 +133,8 @@ TEST_F(SQ8SpaceTest, HandleFileErrors) {
 
 class SQ8SpaceMetadataTest : public ::testing::Test {
  protected:
-  using SpaceType = SQ8Space<float, float, uint32_t, SequentialStorage<uint8_t, uint32_t>, ScalarData>;
+  using SpaceType =
+      SQ8Space<float, float, uint32_t, SequentialStorage<uint8_t, uint32_t>, ScalarData>;
 
   void SetUp() override {
     dim_ = 4;
@@ -161,7 +163,8 @@ class SQ8SpaceMetadataTest : public ::testing::Test {
       meta["category"] = static_cast<int64_t>(i % 5);
       meta["timestamp"] = static_cast<double>(i) * 100.0;
       meta["description"] = std::string("description_") + std::to_string(i);
-      metadata[i] = ScalarData("item_" + std::to_string(i), "doc_content_" + std::to_string(i), meta);
+      metadata[i] =
+          ScalarData("item_" + std::to_string(i), "doc_content_" + std::to_string(i), meta);
     }
     return metadata;
   }
@@ -212,8 +215,10 @@ TEST_F(SQ8SpaceMetadataTest, GetMetadata) {
     EXPECT_EQ(retrieved.item_id, metadata[i].item_id);
     EXPECT_EQ(retrieved.document, metadata[i].document);
     EXPECT_EQ(std::get<int64_t>(retrieved.metadata.at("category")), static_cast<int64_t>(i % 5));
-    EXPECT_DOUBLE_EQ(std::get<double>(retrieved.metadata.at("timestamp")), static_cast<double>(i) * 100.0);
-    EXPECT_EQ(std::get<std::string>(retrieved.metadata.at("description")), "description_" + std::to_string(i));
+    EXPECT_DOUBLE_EQ(std::get<double>(retrieved.metadata.at("timestamp")),
+                     static_cast<double>(i) * 100.0);
+    EXPECT_EQ(std::get<std::string>(retrieved.metadata.at("description")),
+              "description_" + std::to_string(i));
   }
 }
 
@@ -240,7 +245,8 @@ TEST_F(SQ8SpaceMetadataTest, SaveAndLoadWithMetadata) {
       EXPECT_EQ(retrieved.item_id, metadata[i].item_id);
       EXPECT_EQ(retrieved.document, metadata[i].document);
       EXPECT_EQ(std::get<int64_t>(retrieved.metadata.at("category")), static_cast<int64_t>(i % 5));
-      EXPECT_DOUBLE_EQ(std::get<double>(retrieved.metadata.at("timestamp")), static_cast<double>(i) * 100.0);
+      EXPECT_DOUBLE_EQ(std::get<double>(retrieved.metadata.at("timestamp")),
+                       static_cast<double>(i) * 100.0);
     }
   }
 }
@@ -290,7 +296,8 @@ TEST_F(SQ8SpaceMetadataTest, MetadataCorrectness) {
     auto retrieved = space_->get_scalar_data(i);
     EXPECT_EQ(retrieved.item_id, "item_" + std::to_string(i));
     EXPECT_EQ(std::get<int64_t>(retrieved.metadata.at("category")), static_cast<int64_t>(i % 5));
-    EXPECT_DOUBLE_EQ(std::get<double>(retrieved.metadata.at("timestamp")), static_cast<double>(i) * 100.0);
+    EXPECT_DOUBLE_EQ(std::get<double>(retrieved.metadata.at("timestamp")),
+                     static_cast<double>(i) * 100.0);
   }
 }
 
@@ -316,7 +323,7 @@ TEST_F(SQ8SpaceMetadataTest, GetScalarDataWithEmptyFilter) {
   config.db_path_ = db_path_;
   space_ = std::make_shared<SpaceType>(capacity_, dim_, metric_, config);
 
-  float data[20] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+  float data[20] = {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0,
                     11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0};
   auto metadata = make_test_metadata(5);
   space_->fit(data, 5, metadata.data());
@@ -332,7 +339,7 @@ TEST_F(SQ8SpaceMetadataTest, GetScalarDataWithEqFilter) {
   config.db_path_ = db_path_;
   space_ = std::make_shared<SpaceType>(capacity_, dim_, metric_, config);
 
-  float data[20] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+  float data[20] = {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0,
                     11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0};
   auto metadata = make_test_metadata(5);
   space_->fit(data, 5, metadata.data());
@@ -353,7 +360,7 @@ TEST_F(SQ8SpaceMetadataTest, GetScalarDataWithGtFilter) {
   config.db_path_ = db_path_;
   space_ = std::make_shared<SpaceType>(capacity_, dim_, metric_, config);
 
-  float data[20] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+  float data[20] = {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0,
                     11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0};
   auto metadata = make_test_metadata(5);
   space_->fit(data, 5, metadata.data());
@@ -372,7 +379,7 @@ TEST_F(SQ8SpaceMetadataTest, GetScalarDataWithLimit) {
   config.db_path_ = db_path_;
   space_ = std::make_shared<SpaceType>(capacity_, dim_, metric_, config);
 
-  float data[20] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+  float data[20] = {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0,
                     11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0};
   auto metadata = make_test_metadata(5);
   space_->fit(data, 5, metadata.data());
@@ -388,7 +395,7 @@ TEST_F(SQ8SpaceMetadataTest, GetScalarDataWithOrFilter) {
   config.db_path_ = db_path_;
   space_ = std::make_shared<SpaceType>(capacity_, dim_, metric_, config);
 
-  float data[20] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+  float data[20] = {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0,
                     11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0};
   auto metadata = make_test_metadata(5);
   space_->fit(data, 5, metadata.data());


### PR DESCRIPTION
## Description

Harden WAL snapshot handling and clean up diagnostics found while building the branch.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] CI/CD changes

## Changes Made

- Extract reusable binary read/write helpers into `include/utils/binary_io.hpp`
- Normalize WAL snapshot/recovery data naming and update related recovery tests
- Fix build diagnostics in graph builder, SQ spaces, and query pool helpers
- Keep recovery changes split from unrelated diagnostic cleanup commits

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

```bash
make -j
git diff --check origin/v1.0.0..HEAD
