### PR TITLE
fix(storage): enforce unique scalar item ids

### DIFF
--- a/include/executor/jobs/graph_update_job.hpp
+++ b/include/executor/jobs/graph_update_job.hpp
@@ -79,6 +79,7 @@ class GraphUpdateJob {
 
   auto insert_and_update(DataType *query, uint32_t ef, const ScalarData *scalar_data = nullptr)
       -> IDType {
+    validate_scalar_insertable(scalar_data);
     uint32_t search_size = graph_->max_nbrs_;
     std::vector<IDType> search_results(search_size, static_cast<IDType>(-1));
 
@@ -193,6 +194,23 @@ class GraphUpdateJob {
 
  private:
   static constexpr auto invalid_id() -> IDType { return std::numeric_limits<IDType>::max(); }
+
+  void validate_scalar_insertable(const ScalarData *scalar_data) const {
+    if constexpr (DistanceSpaceType::has_scalar_data) {
+      if (scalar_data == nullptr || scalar_data->item_id.empty()) {
+        return;
+      }
+      auto *storage = space_->get_scalar_storage();
+      if (storage == nullptr) {
+        throw std::runtime_error("Scalar storage is not initialized");
+      }
+      if (!storage->item_id_available(scalar_data->item_id)) {
+        throw std::runtime_error("Duplicate item_id: " + scalar_data->item_id);
+      }
+    } else {
+      (void)scalar_data;
+    }
+  }
 
   auto insert_search_space(DataType *query, const ScalarData *scalar_data) -> IDType {
     if constexpr (DistanceSpaceType::has_scalar_data) {

--- a/include/recovery/recovery_manager.hpp
+++ b/include/recovery/recovery_manager.hpp
@@ -72,9 +72,11 @@ class RecoveryManager {
     return snapshot_dir;
   }
 
-  // TODO(P2): Graph save and RocksDB checkpoint are not atomic. A crash between
-  // them creates an inconsistent snapshot. Consider a two-phase commit protocol
-  // where both components are written before the CURRENT pointer is updated.
+  // TODO(P2): The snapshot directory is only published after graph files and the RocksDB
+  // checkpoint are written, so a process crash before CURRENT is updated leaves the old snapshot
+  // active. Remaining risk: component writes are not durably staged as a unit, RocksDB checkpoint
+  // failures are not surfaced to the publisher, and there is no READY marker or checksum proving
+  // that every component reached stable storage before CURRENT is advanced.
   /**
    * @brief Publishes a completed snapshot and makes it the recovery CURRENT target.
    *

--- a/include/storage/rocksdb_storage.hpp
+++ b/include/storage/rocksdb_storage.hpp
@@ -23,11 +23,13 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -220,12 +222,33 @@ class RocksDBStorage {
    * @return true on success
    */
   auto insert(IDType id, const ScalarData &data) -> bool {
+    std::lock_guard<std::mutex> lock(write_mutex_);
     ensure_writable("insert");
     std::string key = data_key(id);
+    std::string old_serialized;
+    std::string resolved_key;
+    std::optional<ScalarData> old_data;
+    bool replacing_existing = get_data_value(id, &old_serialized, &resolved_key);
+    if (replacing_existing) {
+      old_data = ScalarData::deserialize(old_serialized.data(), old_serialized.size());
+    }
+
+    if (!item_id_available_for_locked(data.item_id, id)) {
+      LOG_ERROR("Failed to insert ScalarData for ID {}: duplicate item_id '{}'", id, data.item_id);
+      return false;
+    }
+
     auto serialized = data.serialize();
     rocksdb::Slice value_slice(serialized.data(), serialized.size());
 
     rocksdb::WriteBatch batch;
+    if (old_data.has_value()) {
+      if (resolved_key != key) {
+        batch.Delete(resolved_key);
+      }
+      delete_item_id_index_if_owned(batch, old_data->item_id, id);
+      remove_field_indexes(batch, id, *old_data);
+    }
     batch.Put(key, value_slice);
 
     // Add secondary index: item_id -> internal_id
@@ -244,7 +267,9 @@ class RocksDBStorage {
       return false;
     }
 
-    ++cached_count_;
+    if (!replacing_existing) {
+      ++cached_count_;
+    }
     return true;
   }
 
@@ -261,27 +286,70 @@ class RocksDBStorage {
    */
   template <typename Iterator>
   auto batch_insert(IDType start_id, Iterator begin, Iterator end) -> bool {
+    std::lock_guard<std::mutex> lock(write_mutex_);
     ensure_writable("batch_insert");
-    rocksdb::WriteBatch batch;
-    IDType current_id = start_id;
-    size_t count = 0;
+    struct PendingRecord {
+      IDType id;
+      ScalarData data;
+      std::optional<ScalarData> old_data;
+      std::string resolved_key;
+    };
 
-    for (auto it = begin; it != end; ++it, ++current_id) {
-      std::string key = data_key(current_id);
-      auto serialized = it->serialize();
+    std::vector<PendingRecord> records;
+    std::unordered_map<std::string, IDType> batch_item_ids;
+
+    IDType preflight_id = start_id;
+    for (auto it = begin; it != end; ++it, ++preflight_id) {
+      PendingRecord record{preflight_id, *it, std::nullopt, {}};
+
+      if (!record.data.item_id.empty()) {
+        if (!batch_item_ids.emplace(record.data.item_id, preflight_id).second) {
+          LOG_ERROR("Batch insert failed: duplicate item_id '{}' in batch", record.data.item_id);
+          return false;
+        }
+      }
+
+      std::string serialized;
+      if (get_data_value(preflight_id, &serialized, &record.resolved_key)) {
+        record.old_data = ScalarData::deserialize(serialized.data(), serialized.size());
+      }
+      records.push_back(std::move(record));
+    }
+
+    for (const auto &record : records) {
+      if (!item_id_available_for_locked(record.data.item_id, record.id)) {
+        LOG_ERROR("Batch insert failed: duplicate item_id '{}'", record.data.item_id);
+        return false;
+      }
+    }
+
+    rocksdb::WriteBatch batch;
+    size_t inserted_count = 0;
+
+    for (const auto &record : records) {
+      std::string key = data_key(record.id);
+      if (record.old_data.has_value()) {
+        if (record.resolved_key != key) {
+          batch.Delete(record.resolved_key);
+        }
+        delete_item_id_index_if_owned(batch, record.old_data->item_id, record.id);
+        remove_field_indexes(batch, record.id, *record.old_data);
+      } else {
+        ++inserted_count;
+      }
+
+      auto serialized = record.data.serialize();
       batch.Put(key, rocksdb::Slice(serialized.data(), serialized.size()));
 
       // Add secondary index
-      if (!it->item_id.empty()) {
-        std::string idx_key = item_id_index_key(it->item_id);
-        rocksdb::Slice id_slice(reinterpret_cast<const char *>(&current_id), sizeof(IDType));
+      if (!record.data.item_id.empty()) {
+        std::string idx_key = item_id_index_key(record.data.item_id);
+        rocksdb::Slice id_slice(reinterpret_cast<const char *>(&record.id), sizeof(IDType));
         batch.Put(idx_key, id_slice);
       }
 
       // Add field indexes for indexed fields
-      add_field_indexes(batch, current_id, *it);
-
-      ++count;
+      add_field_indexes(batch, record.id, record.data);
     }
 
     rocksdb::Status status = db_->Write(rocksdb::WriteOptions(), &batch);
@@ -290,7 +358,7 @@ class RocksDBStorage {
       return false;
     }
 
-    cached_count_ += count;
+    cached_count_ += inserted_count;
     return true;
   }
 
@@ -298,6 +366,7 @@ class RocksDBStorage {
    * @brief Remove ScalarData by ID
    */
   auto remove(IDType id) -> bool {
+    std::lock_guard<std::mutex> lock(write_mutex_);
     ensure_writable("remove");
 
     std::string serialized;
@@ -312,9 +381,7 @@ class RocksDBStorage {
     rocksdb::WriteBatch batch;
     batch.Delete(resolved_key);
 
-    if (!data.item_id.empty()) {
-      batch.Delete(item_id_index_key(data.item_id));
-    }
+    delete_item_id_index_if_owned(batch, data.item_id, id);
 
     // Remove field indexes
     remove_field_indexes(batch, id, data);
@@ -335,6 +402,7 @@ class RocksDBStorage {
    * @brief Update ScalarData
    */
   auto update(IDType id, const ScalarData &data) -> bool {
+    std::lock_guard<std::mutex> lock(write_mutex_);
     ensure_writable("update");
 
     std::string serialized_value;
@@ -344,6 +412,10 @@ class RocksDBStorage {
       return false;
     }
     auto old_data = ScalarData::deserialize(serialized_value.data(), serialized_value.size());
+    if (!item_id_available_for_locked(data.item_id, id)) {
+      LOG_ERROR("Failed to update ID {}: duplicate item_id '{}'", id, data.item_id);
+      return false;
+    }
 
     rocksdb::WriteBatch batch;
 
@@ -357,9 +429,7 @@ class RocksDBStorage {
 
     // Update secondary index if item_id changed
     if (old_data.item_id != data.item_id) {
-      if (!old_data.item_id.empty()) {
-        batch.Delete(item_id_index_key(old_data.item_id));
-      }
+      delete_item_id_index_if_owned(batch, old_data.item_id, id);
       if (!data.item_id.empty()) {
         rocksdb::Slice id_slice(reinterpret_cast<const char *>(&id), sizeof(IDType));
         batch.Put(item_id_index_key(data.item_id), id_slice);
@@ -394,6 +464,16 @@ class RocksDBStorage {
     IDType id;
     std::memcpy(&id, value.data(), sizeof(IDType));
     return id;
+  }
+
+  [[nodiscard]] auto item_id_available(const std::string &item_id,
+                                       std::optional<IDType> allowed_id = std::nullopt) const
+      -> bool {
+    if (item_id.empty()) {
+      return true;
+    }
+    auto existing = find_by_item_id(item_id);
+    return !existing.has_value() || (allowed_id.has_value() && *existing == *allowed_id);
   }
 
   /**
@@ -823,6 +903,23 @@ class RocksDBStorage {
 
   static auto count_key() -> std::string { return "__COUNT__"; }
 
+  [[nodiscard]] auto item_id_available_for_locked(const std::string &item_id,
+                                                  IDType allowed_id) const -> bool {
+    return item_id_available(item_id, std::optional<IDType>{allowed_id});
+  }
+
+  void delete_item_id_index_if_owned(rocksdb::WriteBatch &batch,
+                                     const std::string &item_id,
+                                     IDType owner_id) const {
+    if (item_id.empty()) {
+      return;
+    }
+    auto existing = find_by_item_id(item_id);
+    if (existing.has_value() && *existing == owner_id) {
+      batch.Delete(item_id_index_key(item_id));
+    }
+  }
+
   /**
    * @brief Add field indexes for indexed fields
    */
@@ -854,6 +951,7 @@ class RocksDBStorage {
   std::unique_ptr<rocksdb::DB> db_ = nullptr;
   RocksDBConfig config_;
   mutable std::atomic<size_t> cached_count_;
+  mutable std::mutex write_mutex_;
   bool read_only_{false};
 };
 

--- a/include/storage/rocksdb_storage.hpp
+++ b/include/storage/rocksdb_storage.hpp
@@ -143,32 +143,12 @@ class RocksDBStorage {
    */
   [[nodiscard]] auto batch_get_raw_values(const std::vector<IDType> &ids) const
       -> std::vector<std::string> {
-    std::vector<rocksdb::Slice> keys;
-    std::vector<std::string> key_strings;
-    keys.reserve(ids.size());
-    key_strings.reserve(ids.size());
-
-    for (auto id : ids) {
-      key_strings.push_back(data_key(id));
-      keys.emplace_back(key_strings.back());
+    auto stored_values = batch_get_data_values(ids);
+    std::vector<std::string> values;
+    values.reserve(stored_values.size());
+    for (auto &stored_value : stored_values) {
+      values.push_back(stored_value.found ? std::move(stored_value.value) : std::string{});
     }
-
-    std::vector<std::string> values(ids.size());
-    std::vector<rocksdb::Status> statuses = db_->MultiGet(rocksdb::ReadOptions(), keys, &values);
-
-    for (size_t i = 0; i < statuses.size(); ++i) {
-      if (!statuses[i].ok()) {
-        values[i].clear();
-        auto legacy_key = legacy_data_key(ids[i]);
-        if (legacy_key != key_strings[i]) {
-          rocksdb::Status fallback = db_->Get(rocksdb::ReadOptions(), legacy_key, &values[i]);
-          if (!fallback.ok()) {
-            values[i].clear();
-          }
-        }
-      }
-    }
-
     return values;
   }
 
@@ -246,7 +226,7 @@ class RocksDBStorage {
       if (resolved_key != key) {
         batch.Delete(resolved_key);
       }
-      delete_item_id_index_if_owned(batch, old_data->item_id, id);
+      delete_item_id_index(batch, old_data->item_id);
       remove_field_indexes(batch, id, *old_data);
     }
     batch.Put(key, value_slice);
@@ -297,27 +277,41 @@ class RocksDBStorage {
 
     std::vector<PendingRecord> records;
     std::unordered_map<std::string, IDType> batch_item_ids;
+    std::vector<IDType> preflight_ids;
+    std::vector<std::string> preflight_item_ids;
 
     IDType preflight_id = start_id;
     for (auto it = begin; it != end; ++it, ++preflight_id) {
       PendingRecord record{preflight_id, *it, std::nullopt, {}};
+      preflight_ids.push_back(preflight_id);
 
       if (!record.data.item_id.empty()) {
         if (!batch_item_ids.emplace(record.data.item_id, preflight_id).second) {
           LOG_ERROR("Batch insert failed: duplicate item_id '{}' in batch", record.data.item_id);
           return false;
         }
+        preflight_item_ids.push_back(record.data.item_id);
       }
 
-      std::string serialized;
-      if (get_data_value(preflight_id, &serialized, &record.resolved_key)) {
-        record.old_data = ScalarData::deserialize(serialized.data(), serialized.size());
-      }
       records.push_back(std::move(record));
     }
 
+    auto existing_records = batch_get_data_values(preflight_ids);
+    for (size_t i = 0; i < records.size(); ++i) {
+      if (existing_records[i].found) {
+        records[i].resolved_key = std::move(existing_records[i].resolved_key);
+        records[i].old_data = ScalarData::deserialize(existing_records[i].value.data(),
+                                                      existing_records[i].value.size());
+      }
+    }
+
+    auto existing_item_owners = batch_find_item_id_owners(preflight_item_ids);
     for (const auto &record : records) {
-      if (!item_id_available_for_locked(record.data.item_id, record.id)) {
+      if (record.data.item_id.empty()) {
+        continue;
+      }
+      auto existing = existing_item_owners.find(record.data.item_id);
+      if (existing != existing_item_owners.end() && existing->second != record.id) {
         LOG_ERROR("Batch insert failed: duplicate item_id '{}'", record.data.item_id);
         return false;
       }
@@ -332,7 +326,7 @@ class RocksDBStorage {
         if (record.resolved_key != key) {
           batch.Delete(record.resolved_key);
         }
-        delete_item_id_index_if_owned(batch, record.old_data->item_id, record.id);
+        delete_item_id_index(batch, record.old_data->item_id);
         remove_field_indexes(batch, record.id, *record.old_data);
       } else {
         ++inserted_count;
@@ -381,7 +375,7 @@ class RocksDBStorage {
     rocksdb::WriteBatch batch;
     batch.Delete(resolved_key);
 
-    delete_item_id_index_if_owned(batch, data.item_id, id);
+    delete_item_id_index(batch, data.item_id);
 
     // Remove field indexes
     remove_field_indexes(batch, id, data);
@@ -429,7 +423,7 @@ class RocksDBStorage {
 
     // Update secondary index if item_id changed
     if (old_data.item_id != data.item_id) {
-      delete_item_id_index_if_owned(batch, old_data.item_id, id);
+      delete_item_id_index(batch, old_data.item_id);
       if (!data.item_id.empty()) {
         rocksdb::Slice id_slice(reinterpret_cast<const char *>(&id), sizeof(IDType));
         batch.Put(item_id_index_key(data.item_id), id_slice);
@@ -748,6 +742,12 @@ class RocksDBStorage {
   using UnsignedIDType = std::make_unsigned_t<IDType>;
   static constexpr size_t kSortableDigits = std::numeric_limits<UnsignedIDType>::digits10 + 1;
 
+  struct StoredValue {
+    bool found{false};
+    std::string value;
+    std::string resolved_key;
+  };
+
   static auto data_key(IDType id) -> std::string {
     auto digits = std::to_string(static_cast<UnsignedIDType>(id));
     if (digits.size() >= kSortableDigits) {
@@ -804,6 +804,93 @@ class RocksDBStorage {
       *resolved_key = std::move(fallback_key);
     }
     return true;
+  }
+
+  [[nodiscard]] auto batch_get_data_values(const std::vector<IDType> &ids) const
+      -> std::vector<StoredValue> {
+    std::vector<StoredValue> results(ids.size());
+    std::vector<std::string> primary_key_strings;
+    std::vector<rocksdb::Slice> primary_keys;
+    primary_key_strings.reserve(ids.size());
+    primary_keys.reserve(ids.size());
+
+    for (auto id : ids) {
+      primary_key_strings.push_back(data_key(id));
+      primary_keys.emplace_back(primary_key_strings.back());
+    }
+
+    std::vector<std::string> primary_values(ids.size());
+    auto primary_statuses = db_->MultiGet(rocksdb::ReadOptions(), primary_keys, &primary_values);
+
+    std::vector<size_t> fallback_indexes;
+    std::vector<std::string> fallback_key_strings;
+    std::vector<rocksdb::Slice> fallback_keys;
+    fallback_indexes.reserve(ids.size());
+    fallback_key_strings.reserve(ids.size());
+    fallback_keys.reserve(ids.size());
+
+    for (size_t i = 0; i < primary_statuses.size(); ++i) {
+      if (primary_statuses[i].ok()) {
+        results[i].found = true;
+        results[i].value = std::move(primary_values[i]);
+        results[i].resolved_key = primary_key_strings[i];
+        continue;
+      }
+
+      auto fallback_key = legacy_data_key(ids[i]);
+      if (fallback_key == primary_key_strings[i]) {
+        continue;
+      }
+      fallback_indexes.push_back(i);
+      fallback_key_strings.push_back(std::move(fallback_key));
+      fallback_keys.emplace_back(fallback_key_strings.back());
+    }
+
+    if (fallback_keys.empty()) {
+      return results;
+    }
+
+    std::vector<std::string> fallback_values(fallback_keys.size());
+    auto fallback_statuses = db_->MultiGet(rocksdb::ReadOptions(), fallback_keys, &fallback_values);
+    for (size_t i = 0; i < fallback_statuses.size(); ++i) {
+      if (!fallback_statuses[i].ok()) {
+        continue;
+      }
+      auto result_index = fallback_indexes[i];
+      results[result_index].found = true;
+      results[result_index].value = std::move(fallback_values[i]);
+      results[result_index].resolved_key = fallback_key_strings[i];
+    }
+    return results;
+  }
+
+  [[nodiscard]] auto batch_find_item_id_owners(const std::vector<std::string> &item_ids) const
+      -> std::unordered_map<std::string, IDType> {
+    std::unordered_map<std::string, IDType> owners;
+    if (item_ids.empty()) {
+      return owners;
+    }
+
+    std::vector<std::string> key_strings;
+    std::vector<rocksdb::Slice> keys;
+    key_strings.reserve(item_ids.size());
+    keys.reserve(item_ids.size());
+    for (const auto &item_id : item_ids) {
+      key_strings.push_back(item_id_index_key(item_id));
+      keys.emplace_back(key_strings.back());
+    }
+
+    std::vector<std::string> values(item_ids.size());
+    auto statuses = db_->MultiGet(rocksdb::ReadOptions(), keys, &values);
+    for (size_t i = 0; i < statuses.size(); ++i) {
+      if (!statuses[i].ok() || values[i].size() != sizeof(IDType)) {
+        continue;
+      }
+      IDType owner_id;
+      std::memcpy(&owner_id, values[i].data(), sizeof(IDType));
+      owners.emplace(item_ids[i], owner_id);
+    }
+    return owners;
   }
 
   void initialize_db() {
@@ -908,16 +995,11 @@ class RocksDBStorage {
     return item_id_available(item_id, std::optional<IDType>{allowed_id});
   }
 
-  void delete_item_id_index_if_owned(rocksdb::WriteBatch &batch,
-                                     const std::string &item_id,
-                                     IDType owner_id) const {
+  void delete_item_id_index(rocksdb::WriteBatch &batch, const std::string &item_id) const {
     if (item_id.empty()) {
       return;
     }
-    auto existing = find_by_item_id(item_id);
-    if (existing.has_value() && *existing == owner_id) {
-      batch.Delete(item_id_index_key(item_id));
-    }
+    batch.Delete(item_id_index_key(item_id));
   }
 
   /**

--- a/python/include/index.hpp
+++ b/python/include/index.hpp
@@ -335,6 +335,23 @@ class PyIndex : public BasePyIndex {
     return inserted_id;
   }
 
+  void validate_insert_item_id_available(const ScalarData &scalar_data) const {
+    if constexpr (SearchSpaceType::has_scalar_data) {
+      if (scalar_data.item_id.empty() || search_space_ == nullptr) {
+        return;
+      }
+      auto *storage = search_space_->get_scalar_storage();
+      if (storage == nullptr) {
+        throw std::runtime_error("Scalar storage is not initialized");
+      }
+      if (!storage->item_id_available(scalar_data.item_id)) {
+        throw std::runtime_error("Duplicate item_id: " + scalar_data.item_id);
+      }
+    } else {
+      (void)scalar_data;
+    }
+  }
+
   auto remove_nondurable(IDType id) -> void {
     if (update_job_ == nullptr) {
       throw std::runtime_error("incremental updates are not supported for the current index type");
@@ -685,6 +702,7 @@ class PyIndex : public BasePyIndex {
     auto insert_data_ptr = static_cast<DataType *>(insert_data.request().ptr);
     MetadataMap meta_map = pydict_to_metadata_map(metadata);
     ScalarData scalar_data{item_id, document, meta_map};
+    validate_insert_item_id_available(scalar_data);
 
     // TODO(P2): RocksDB has its own internal WAL and the custom WAL must stay
     // in sync. If the process crashes between insert_nondurable (RocksDB write)

--- a/python/include/parse.hpp
+++ b/python/include/parse.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <unordered_set>
 #include <vector>
 
 #include "executor/search_info.hpp"
@@ -115,6 +116,7 @@ inline auto build_scalar_data_vec(const py::list &item_ids,
 
   py::list docs = documents.is_none() ? py::list() : documents.cast<py::list>();
   py::list metas = metadata_list.is_none() ? py::list() : metadata_list.cast<py::list>();
+  std::unordered_set<std::string> seen_item_ids;
 
   for (size_t i = 0; i < count; i++) {
     MetadataMap meta_map;
@@ -123,6 +125,9 @@ inline auto build_scalar_data_vec(const py::list &item_ids,
     }
     std::string doc = (i < docs.size()) ? docs[i].cast<std::string>() : "";
     auto item_id_str = py::str(item_ids[i]).cast<std::string>();
+    if (!item_id_str.empty() && !seen_item_ids.insert(item_id_str).second) {
+      throw std::runtime_error("Duplicate item_id: " + item_id_str);
+    }
     scalar_data_vec.emplace_back(item_id_str, doc, std::move(meta_map));
   }
   return scalar_data_vec;

--- a/python/tests/client/test_collection.py
+++ b/python/tests/client/test_collection.py
@@ -64,6 +64,42 @@ class TestCollection(unittest.TestCase):
         result = self.collection.filter_query({})
         self.assertEqual(len(result["id"]), 2)
 
+    def test_initial_insert_rejects_duplicate_item_id(self):
+        """First-batch insert should reject duplicate non-empty item IDs before building."""
+        items = [
+            ("dup", "Document 1", np.array([0.1, 0.2, 0.3], dtype=np.float32), {"category": "A"}),
+            ("dup", "Document 2", np.array([0.4, 0.5, 0.6], dtype=np.float32), {"category": "B"}),
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "Duplicate item_id: dup"):
+            self.collection.insert(items)
+
+    def test_incremental_insert_rejects_duplicate_item_id_and_keeps_original(self):
+        """Incremental insert should not mutate graph/vector/scalar state on duplicate item_id."""
+        self.collection.insert([("item_a", "Original", np.array([0.1, 0.2, 0.3], dtype=np.float32), {"category": "A"})])
+
+        with self.assertRaisesRegex(RuntimeError, "Duplicate item_id: item_a"):
+            self.collection.insert(
+                [("item_a", "Duplicate", np.array([0.4, 0.5, 0.6], dtype=np.float32), {"category": "B"})]
+            )
+
+        result = self.collection.get_by_id(["item_a"])
+        self.assertEqual(result["document"], ["Original"])
+        self.assertEqual(result["metadata"], [{"category": "A"}])
+        self.assertEqual(len(self.collection.filter_query({})["id"]), 1)
+
+    def test_fit_rejects_duplicate_item_id(self):
+        """Columnar fit should reject duplicate non-empty item IDs."""
+        vectors = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype=np.float32)
+
+        with self.assertRaisesRegex(RuntimeError, "Duplicate item_id: dup"):
+            self.collection.fit(
+                vectors,
+                item_ids=["dup", "dup"],
+                documents=["Document 1", "Document 2"],
+                metadata_list=[{"category": "A"}, {"category": "B"}],
+            )
+
     def test_get_cpp_index_before_first_insert_has_actionable_error(self):
         """Accessing the native index before first insert should explain how to initialize it."""
         with self.assertRaisesRegex(RuntimeError, "Call insert\\(\\) with the first batch of data first"):

--- a/python/tests/client/test_collection.py
+++ b/python/tests/client/test_collection.py
@@ -88,17 +88,16 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(result["metadata"], [{"category": "A"}])
         self.assertEqual(len(self.collection.filter_query({})["id"]), 1)
 
-    def test_fit_rejects_duplicate_item_id(self):
-        """Columnar fit should reject duplicate non-empty item IDs."""
+    def test_initial_insert_rejects_duplicate_columnar_item_id(self):
+        """Collection insert should reject duplicate non-empty item IDs from columnar inputs."""
         vectors = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype=np.float32)
+        item_ids = ["dup", "dup"]
+        documents = ["Document 1", "Document 2"]
+        metadata_list = [{"category": "A"}, {"category": "B"}]
+        items = list(zip(item_ids, documents, vectors, metadata_list))
 
         with self.assertRaisesRegex(RuntimeError, "Duplicate item_id: dup"):
-            self.collection.fit(
-                vectors,
-                item_ids=["dup", "dup"],
-                documents=["Document 1", "Document 2"],
-                metadata_list=[{"category": "A"}, {"category": "B"}],
-            )
+            self.collection.insert(items)
 
     def test_get_cpp_index_before_first_insert_has_actionable_error(self):
         """Accessing the native index before first insert should explain how to initialize it."""

--- a/tests/storage/rocksdb_storage_test.cpp
+++ b/tests/storage/rocksdb_storage_test.cpp
@@ -127,6 +127,78 @@ TEST_F(RocksDBStorageTest, UpdateOperations) {
     EXPECT_EQ(std::get<int64_t>(retrieved.metadata.at("version")), 2);
 }
 
+TEST_F(RocksDBStorageTest, InsertRejectsDuplicateItemIdAndKeepsOriginalRecord) {
+    RocksDBStorage<> storage(config_);
+
+    ASSERT_TRUE(storage.insert(0, ScalarData{"dup", "original", {{"version", int64_t(1)}}}));
+
+    EXPECT_FALSE(storage.insert(1, ScalarData{"dup", "duplicate", {{"version", int64_t(2)}}}));
+
+    EXPECT_EQ(storage.count(), 1U);
+    EXPECT_TRUE(storage.is_valid(0));
+    EXPECT_FALSE(storage.is_valid(1));
+    EXPECT_EQ(storage[0].document, "original");
+
+    auto owner = storage.find_by_item_id("dup");
+    ASSERT_TRUE(owner.has_value());
+    EXPECT_EQ(owner.value(), 0U);
+}
+
+TEST_F(RocksDBStorageTest, EmptyItemIdsAreNotUniqueKeys) {
+    RocksDBStorage<> storage(config_);
+
+    EXPECT_TRUE(storage.insert(0, ScalarData{"", "first", {}}));
+    EXPECT_TRUE(storage.insert(1, ScalarData{"", "second", {}}));
+
+    EXPECT_EQ(storage.count(), 2U);
+    EXPECT_TRUE(storage[0].item_id.empty());
+    EXPECT_TRUE(storage[1].item_id.empty());
+}
+
+TEST_F(RocksDBStorageTest, UpdateRejectsItemIdOwnedByAnotherRecord) {
+    RocksDBStorage<> storage(config_);
+
+    ASSERT_TRUE(storage.insert(0, ScalarData{"item_a", "doc a", {}}));
+    ASSERT_TRUE(storage.insert(1, ScalarData{"item_b", "doc b", {}}));
+
+    EXPECT_FALSE(storage.update(1, ScalarData{"item_a", "doc b updated", {}}));
+
+    EXPECT_EQ(storage.count(), 2U);
+    EXPECT_EQ(storage[1].item_id, "item_b");
+    EXPECT_EQ(storage[1].document, "doc b");
+
+    auto item_a_owner = storage.find_by_item_id("item_a");
+    auto item_b_owner = storage.find_by_item_id("item_b");
+    ASSERT_TRUE(item_a_owner.has_value());
+    ASSERT_TRUE(item_b_owner.has_value());
+    EXPECT_EQ(item_a_owner.value(), 0U);
+    EXPECT_EQ(item_b_owner.value(), 1U);
+}
+
+TEST_F(RocksDBStorageTest, InsertReplacingSameInternalIdCleansOldIndexes) {
+    RocksDBConfig indexed_config = config_;
+    indexed_config.indexed_fields_ = {"category"};
+    RocksDBStorage<> storage(indexed_config);
+
+    ASSERT_TRUE(storage.insert(
+        7, ScalarData{"old_item", "old doc", {{"category", std::string("old")}}}));
+
+    EXPECT_TRUE(storage.insert(
+        7, ScalarData{"new_item", "new doc", {{"category", std::string("new")}}}));
+
+    EXPECT_EQ(storage.count(), 1U);
+    EXPECT_FALSE(storage.find_by_item_id("old_item").has_value());
+
+    auto new_owner = storage.find_by_item_id("new_item");
+    ASSERT_TRUE(new_owner.has_value());
+    EXPECT_EQ(new_owner.value(), 7U);
+
+    EXPECT_TRUE(storage.get_ids_by_field_value("category", std::string("old")).empty());
+    auto new_category_ids = storage.get_ids_by_field_value("category", std::string("new"));
+    ASSERT_EQ(new_category_ids.size(), 1U);
+    EXPECT_EQ(new_category_ids[0], 7U);
+}
+
 TEST_F(RocksDBStorageTest, RemoveOperations) {
     RocksDBStorage<> storage(config_);
 
@@ -213,6 +285,41 @@ TEST_F(RocksDBStorageTest, BatchInsertWithOffset) {
     EXPECT_EQ(storage[1].item_id, "id_002");
     EXPECT_EQ(storage[2].item_id, "id_003");
     EXPECT_EQ(storage[3].item_id, "id_004");
+}
+
+TEST_F(RocksDBStorageTest, BatchInsertRejectsDuplicateItemIdsBeforeWriting) {
+    RocksDBStorage<> storage(config_);
+
+    std::vector<ScalarData> duplicate_batch = {
+        {"dup", "doc1", {}},
+        {"dup", "doc2", {}},
+    };
+
+    EXPECT_FALSE(storage.batch_insert(0, duplicate_batch.begin(), duplicate_batch.end()));
+    EXPECT_EQ(storage.count(), 0U);
+    EXPECT_FALSE(storage.is_valid(0));
+    EXPECT_FALSE(storage.is_valid(1));
+    EXPECT_FALSE(storage.find_by_item_id("dup").has_value());
+}
+
+TEST_F(RocksDBStorageTest, BatchInsertRejectsExistingItemIdBeforeWritingAnyRecord) {
+    RocksDBStorage<> storage(config_);
+
+    ASSERT_TRUE(storage.insert(0, ScalarData{"taken", "existing", {}}));
+    std::vector<ScalarData> batch = {
+        {"fresh", "fresh doc", {}},
+        {"taken", "duplicate doc", {}},
+    };
+
+    EXPECT_FALSE(storage.batch_insert(1, batch.begin(), batch.end()));
+    EXPECT_EQ(storage.count(), 1U);
+    EXPECT_FALSE(storage.is_valid(1));
+    EXPECT_FALSE(storage.is_valid(2));
+    EXPECT_FALSE(storage.find_by_item_id("fresh").has_value());
+
+    auto taken_owner = storage.find_by_item_id("taken");
+    ASSERT_TRUE(taken_owner.has_value());
+    EXPECT_EQ(taken_owner.value(), 0U);
 }
 
 // ============================================================================


### PR DESCRIPTION
  ## Description

Enforce uniqueness for scalar item IDs in RocksDB-backed storage so duplicate IDs are rejected instead of silently overwriting or aliasing existing records. This change also updates the graph update path and Python-facing parsing/binding code so the behavior is consistent across the stack.

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - Added duplicate item-id validation in `include/storage/rocksdb_storage.hpp`
  - Updated graph update handling in `include/executor/jobs/graph_update_job.hpp`
  - Updated Python index/parse bindings to reflect the new validation path
  - Added regression coverage in C++ storage tests and Python client tests

  ## Testing

  - [x] Unit tests added/updated
  - [x] Integration tests added/updated

  ## Additional Notes

  This PR is scoped to scalar item-id uniqueness and does not change the existing behavior for non-duplicate writes.