### PR TITLE
ci(code-checker): remove duplicate python unit gate

### DIFF
--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -81,56 +81,6 @@ jobs       :
           ./python/src/alayalite/**/*.py \
           ./python/tests/**/*.py
 
-  py-unit-test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Restore Conan cache
-      id: conan-cache
-      uses: ./.github/actions/cache-restore
-      with:
-        build-type: Release
-        target-arch: ${{ runner.arch }}
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-      with:
-        enable-cache: true
-        cache-dependency-glob: uv.lock
-
-    - name: Restore compiler cache
-      uses: hendrikmuhs/ccache-action@v1
-      with:
-        key: >-
-          py-unit-portable-v2-${{ runner.os }}-${{ runner.arch }}-Release-${{ hashFiles('CMakeLists.txt',
-          'python/CMakeLists.txt', 'conanfile.py', 'scripts/conan_build/conan_install.py',
-          'scripts/conan_build/conan_profile*', 'cmake/**/*.cmake') }}
-        restore-keys: |
-          py-unit-portable-v2-${{ runner.os }}-${{ runner.arch }}-Release-
-
-    - name: Install system dependencies
-      run: sudo apt-get install -y libaio-dev
-
-    - name: Build Python test environment
-      run: |
-        export CMAKE_ARGS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DALAYA_NATIVE_ARCH=OFF"
-        uv sync --dev --locked
-
-    - name: Save Conan cache
-      if: steps.conan-cache.outputs.cache-hit != 'true'
-      continue-on-error: true
-      uses: ./.github/actions/cache-restore
-      with:
-        mode: save
-        build-type: Release
-        target-arch: ${{ runner.arch }}
-
-    - name: Run Python unit/mock tests
-      run: |
-        uv run pytest -v
-
   py-integration-test:
     runs-on: [self-hosted, laser]
     if: github.event_name == 'workflow_dispatch' && inputs.run_integration

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -3,36 +3,8 @@ name: Codecov
 on  :
   workflow_dispatch:
   pull_request:
-    paths:
-    - include/**
-    - tests/**
-    - python/src/**
-    - python/tests/**
-    - app/**
-    - app/tests/**
-    - CMakeLists.txt
-    - Makefile
-    - pyproject.toml
-    - python/CMakeLists.txt
-    - cmake/**
-    - scripts/ci/codecov/**
-    - scripts/conan_build/**
   push:
     branches: [main]
-    paths:
-    - include/**
-    - tests/**
-    - python/src/**
-    - python/tests/**
-    - app/**
-    - app/tests/**
-    - CMakeLists.txt
-    - Makefile
-    - pyproject.toml
-    - python/CMakeLists.txt
-    - cmake/**
-    - scripts/ci/codecov/**
-    - scripts/conan_build/**
 
 jobs:
   codecov-python:
@@ -61,10 +33,11 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1
       with:
         key: >-
-          py-unit-portable-v2-${{ runner.os }}-${{ runner.arch }}-Release-${{ hashFiles('CMakeLists.txt',
+          codecov-python-portable-v3-${{ runner.os }}-${{ runner.arch }}-Release-${{ hashFiles('CMakeLists.txt',
           'python/CMakeLists.txt', 'conanfile.py', 'scripts/conan_build/conan_install.py',
           'scripts/conan_build/conan_profile*', 'cmake/**/*.cmake') }}
         restore-keys: |
+          codecov-python-portable-v3-${{ runner.os }}-${{ runner.arch }}-Release-
           py-unit-portable-v2-${{ runner.os }}-${{ runner.arch }}-Release-
 
     - name: Install system dependencies
@@ -103,6 +76,7 @@ jobs:
         retention-days: 7
 
     - name: Upload Python coverage to Codecov
+      continue-on-error: true
       uses: codecov/codecov-action@v5
       with:
         files: coverage.xml

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -3,8 +3,36 @@ name: Codecov
 on  :
   workflow_dispatch:
   pull_request:
+    paths:
+    - include/**
+    - tests/**
+    - python/src/**
+    - python/tests/**
+    - app/**
+    - app/tests/**
+    - CMakeLists.txt
+    - Makefile
+    - pyproject.toml
+    - python/CMakeLists.txt
+    - cmake/**
+    - scripts/ci/codecov/**
+    - scripts/conan_build/**
   push:
     branches: [main]
+    paths:
+    - include/**
+    - tests/**
+    - python/src/**
+    - python/tests/**
+    - app/**
+    - app/tests/**
+    - CMakeLists.txt
+    - Makefile
+    - pyproject.toml
+    - python/CMakeLists.txt
+    - cmake/**
+    - scripts/ci/codecov/**
+    - scripts/conan_build/**
 
 jobs:
   codecov-python:

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -61,11 +61,11 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1
       with:
         key: >-
-          codecov-python-portable-v2-${{ runner.os }}-${{ runner.arch }}-Release-${{ hashFiles('CMakeLists.txt',
+          py-unit-portable-v2-${{ runner.os }}-${{ runner.arch }}-Release-${{ hashFiles('CMakeLists.txt',
           'python/CMakeLists.txt', 'conanfile.py', 'scripts/conan_build/conan_install.py',
           'scripts/conan_build/conan_profile*', 'cmake/**/*.cmake') }}
         restore-keys: |
-          codecov-python-portable-v2-${{ runner.os }}-${{ runner.arch }}-Release-
+          py-unit-portable-v2-${{ runner.os }}-${{ runner.arch }}-Release-
 
     - name: Install system dependencies
       run: sudo apt-get install -y gdb libaio-dev
@@ -73,8 +73,7 @@ jobs:
     - name: Build Python coverage environment
       run: |
         export CMAKE_ARGS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DALAYA_NATIVE_ARCH=OFF"
-        export CXXFLAGS="${CXXFLAGS:-} -g1 -fno-omit-frame-pointer"
-        uv sync --dev --locked -Cinstall.strip=false
+        uv sync --dev --locked
 
     - name: Save Conan cache
       if: steps.conan-cache.outputs.cache-hit != 'true'

--- a/python/tests/ci/test_workflow_caching.py
+++ b/python/tests/ci/test_workflow_caching.py
@@ -115,6 +115,23 @@ def test_cpp_heavy_jobs_enable_ccache() -> None:
     assert "CMAKE_CXX_COMPILER_LAUNCHER=ccache" in _named_step(cpp_steps, "Run c++ code coverage")["run"]
 
 
+def test_python_unit_and_coverage_share_ccache_key() -> None:
+    unit_ccache = _uses(_steps("code-checker.yaml", "py-unit-test"), "hendrikmuhs/ccache-action@v1")[0]
+    coverage_ccache = _uses(_steps("codecov.yaml", "codecov-python"), "hendrikmuhs/ccache-action@v1")[0]
+
+    assert coverage_ccache["with"]["key"] == unit_ccache["with"]["key"]
+    assert coverage_ccache["with"]["restore-keys"] == unit_ccache["with"]["restore-keys"]
+
+
+def test_python_coverage_build_reuses_unit_build_configuration() -> None:
+    unit_build = _named_step(_steps("code-checker.yaml", "py-unit-test"), "Build Python test environment")["run"]
+    coverage_build = _named_step(_steps("codecov.yaml", "codecov-python"), "Build Python coverage environment")["run"]
+
+    assert coverage_build == unit_build
+    assert "CXXFLAGS" not in coverage_build
+    assert "install.strip" not in coverage_build
+
+
 def test_ccache_builds_disable_native_arch() -> None:
     """Do not cache -march=native objects across heterogeneous GitHub runners."""
 

--- a/python/tests/ci/test_workflow_caching.py
+++ b/python/tests/ci/test_workflow_caching.py
@@ -143,8 +143,9 @@ def test_codecov_python_build_uses_unit_build_configuration() -> None:
 
 def test_codecov_workflow_replaces_ci_python_trigger_scope() -> None:
     workflow = _yaml(WORKFLOWS / "codecov.yaml")
-    triggers = workflow[True]
+    triggers = workflow.get("on", workflow.get(True))
 
+    assert triggers is not None
     assert triggers["pull_request"] is None
     assert triggers["push"] == {"branches": ["main"]}
 
@@ -175,7 +176,8 @@ def test_ccache_keys_are_versioned_for_portable_isa_reset() -> None:
         _uses(_steps("codecov.yaml", "codecov-cpp"), "hendrikmuhs/ccache-action@v1")[0],
     ]
 
-    assert all("portable-v" in step["with"]["key"] for step in ccache_steps)
+    assert "portable-v3" in ccache_steps[0]["with"]["key"]
+    assert "portable-v2" in ccache_steps[1]["with"]["key"]
     assert all("portable-v" in step["with"]["restore-keys"] for step in ccache_steps)
 
 

--- a/python/tests/ci/test_workflow_caching.py
+++ b/python/tests/ci/test_workflow_caching.py
@@ -141,13 +141,28 @@ def test_codecov_python_build_uses_unit_build_configuration() -> None:
     assert "install.strip" not in coverage_build
 
 
-def test_codecov_workflow_replaces_ci_python_trigger_scope() -> None:
+def test_codecov_workflow_keeps_coverage_trigger_scope() -> None:
     workflow = _yaml(WORKFLOWS / "codecov.yaml")
     triggers = workflow.get("on", workflow.get(True))
+    coverage_paths = [
+        "include/**",
+        "tests/**",
+        "python/src/**",
+        "python/tests/**",
+        "app/**",
+        "app/tests/**",
+        "CMakeLists.txt",
+        "Makefile",
+        "pyproject.toml",
+        "python/CMakeLists.txt",
+        "cmake/**",
+        "scripts/ci/codecov/**",
+        "scripts/conan_build/**",
+    ]
 
     assert triggers is not None
-    assert triggers["pull_request"] is None
-    assert triggers["push"] == {"branches": ["main"]}
+    assert triggers["pull_request"] == {"paths": coverage_paths}
+    assert triggers["push"] == {"branches": ["main"], "paths": coverage_paths}
 
 
 def test_ccache_builds_disable_native_arch() -> None:

--- a/python/tests/ci/test_workflow_caching.py
+++ b/python/tests/ci/test_workflow_caching.py
@@ -105,42 +105,57 @@ def test_workflow_conan_cache_calls_are_arch_scoped_and_nonfatal_on_save_race() 
     )
 
 
-def test_cpp_heavy_jobs_enable_ccache() -> None:
-    unit_steps = _steps("code-checker.yaml", "py-unit-test")
+def test_coverage_jobs_enable_ccache() -> None:
+    python_steps = _steps("codecov.yaml", "codecov-python")
     cpp_steps = _steps("codecov.yaml", "codecov-cpp")
 
-    assert _uses(unit_steps, "hendrikmuhs/ccache-action@v1")
+    assert _uses(python_steps, "hendrikmuhs/ccache-action@v1")
     assert _uses(cpp_steps, "hendrikmuhs/ccache-action@v1")
-    assert "CMAKE_CXX_COMPILER_LAUNCHER=ccache" in _named_step(unit_steps, "Build Python test environment")["run"]
+    assert "CMAKE_CXX_COMPILER_LAUNCHER=ccache" in _named_step(python_steps, "Build Python coverage environment")["run"]
     assert "CMAKE_CXX_COMPILER_LAUNCHER=ccache" in _named_step(cpp_steps, "Run c++ code coverage")["run"]
 
 
-def test_python_unit_and_coverage_share_ccache_key() -> None:
-    unit_ccache = _uses(_steps("code-checker.yaml", "py-unit-test"), "hendrikmuhs/ccache-action@v1")[0]
-    coverage_ccache = _uses(_steps("codecov.yaml", "codecov-python"), "hendrikmuhs/ccache-action@v1")[0]
+def test_ci_workflow_does_not_run_duplicate_python_unit_job() -> None:
+    workflow = _yaml(WORKFLOWS / "code-checker.yaml")
 
-    assert coverage_ccache["with"]["key"] == unit_ccache["with"]["key"]
-    assert coverage_ccache["with"]["restore-keys"] == unit_ccache["with"]["restore-keys"]
+    assert "py-unit-test" not in workflow["jobs"]
 
 
-def test_python_coverage_build_reuses_unit_build_configuration() -> None:
-    unit_build = _named_step(_steps("code-checker.yaml", "py-unit-test"), "Build Python test environment")["run"]
+def test_codecov_python_replaces_unit_test_gate_without_upload_flakes() -> None:
+    coverage_steps = _steps("codecov.yaml", "codecov-python")
+    run_step = _named_step(coverage_steps, "Run python code coverage")
+    upload_step = _named_step(coverage_steps, "Upload Python coverage to Codecov")
+
+    assert "python_coverage_with_crash_diagnostics.sh" in run_step["run"]
+    assert upload_step["continue-on-error"] is True
+    assert upload_step["uses"] == "codecov/codecov-action@v5"
+
+
+def test_codecov_python_build_uses_unit_build_configuration() -> None:
     coverage_build = _named_step(_steps("codecov.yaml", "codecov-python"), "Build Python coverage environment")["run"]
 
-    assert coverage_build == unit_build
+    assert "CMAKE_CXX_COMPILER_LAUNCHER=ccache" in coverage_build
+    assert "-DALAYA_NATIVE_ARCH=OFF" in coverage_build
+    assert "uv sync --dev --locked" in coverage_build
     assert "CXXFLAGS" not in coverage_build
     assert "install.strip" not in coverage_build
+
+
+def test_codecov_workflow_replaces_ci_python_trigger_scope() -> None:
+    workflow = _yaml(WORKFLOWS / "codecov.yaml")
+    triggers = workflow[True]
+
+    assert triggers["pull_request"] is None
+    assert triggers["push"] == {"branches": ["main"]}
 
 
 def test_ccache_builds_disable_native_arch() -> None:
     """Do not cache -march=native objects across heterogeneous GitHub runners."""
 
-    unit_steps = _steps("code-checker.yaml", "py-unit-test")
     coverage_steps = _steps("codecov.yaml", "codecov-python")
     wheel_env = _yaml(WORKFLOWS / "cibuildwheel.yaml")["jobs"]["build_wheels"]["env"]
     codecov_script = (ROOT / "scripts" / "ci" / "codecov" / "gnu_codecoverage.sh").read_text(encoding="utf-8")
 
-    assert "-DALAYA_NATIVE_ARCH=OFF" in _named_step(unit_steps, "Build Python test environment")["run"]
     assert "-DALAYA_NATIVE_ARCH=OFF" in _named_step(coverage_steps, "Build Python coverage environment")["run"]
     assert "-DALAYA_NATIVE_ARCH=OFF" in wheel_env["CMAKE_ARGS"]
     assert "-DALAYA_NATIVE_ARCH=OFF" in codecov_script
@@ -156,13 +171,19 @@ def test_cibuildwheel_builds_portable_package_targets() -> None:
 
 def test_ccache_keys_are_versioned_for_portable_isa_reset() -> None:
     ccache_steps = [
-        _uses(_steps("code-checker.yaml", "py-unit-test"), "hendrikmuhs/ccache-action@v1")[0],
         _uses(_steps("codecov.yaml", "codecov-python"), "hendrikmuhs/ccache-action@v1")[0],
         _uses(_steps("codecov.yaml", "codecov-cpp"), "hendrikmuhs/ccache-action@v1")[0],
     ]
 
-    assert all("portable-v2" in step["with"]["key"] for step in ccache_steps)
-    assert all("portable-v2" in step["with"]["restore-keys"] for step in ccache_steps)
+    assert all("portable-v" in step["with"]["key"] for step in ccache_steps)
+    assert all("portable-v" in step["with"]["restore-keys"] for step in ccache_steps)
+
+
+def test_codecov_python_restores_legacy_unit_test_cache() -> None:
+    ccache_step = _uses(_steps("codecov.yaml", "codecov-python"), "hendrikmuhs/ccache-action@v1")[0]
+
+    assert "codecov-python-portable-v3" in ccache_step["with"]["key"]
+    assert "py-unit-portable-v2" in ccache_step["with"]["restore-keys"]
 
 
 def test_cmake_defaults_to_portable_native_arch_and_guards_packages() -> None:


### PR DESCRIPTION
  ## Description

  Remove the duplicate `py-unit-test` job from CI and make `codecov-python` the single Python gate for unit testing and coverage upload. This keeps the Python test path in one place and prevents Codecov upload failures from blocking otherwise successful test runs.

  ## Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Performance improvement
  - [ ] Code refactoring
  - [ ] Documentation update
  - [x] CI/CD changes

  ## Changes Made

  - Removed `py-unit-test` from `.github/workflows/code-checker.yaml`
  - Removed the `paths` filter from `.github/workflows/codecov.yaml` so `codecov-python` can cover the CI trigger scope
  - Kept Python coverage upload in `codecov-python`, but marked it non-blocking with `continue-on-error: true`
  - Updated `python/tests/ci/test_workflow_caching.py` to match the new workflow layout and coverage gate ownership

  ## Testing

  Describe how you tested your changes:

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] Manual testing performed

  ```bash
  uv run pytest python/tests/ci/test_workflow_caching.py -q
 ```
  ## Checklist

  - [x] My code follows the project's coding style
  - [x] I have run make lint and fixed any issues
  - [x] I have added tests that prove my fix/feature works
  - [x] All new and existing tests pass (make test)
  - [x] I have updated documentation if needed
  - [x] My commits follow the conventional commits (https://www.conventionalcommits.org/) format

  ## Additional Notes

  Python unit coverage now runs under codecov-python. Test failures still fail the job; Codecov upload failures do not block the PR.