### PR TITLE
feat(diskann): self-contained DiskANN disk index with in-place updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /build_asan/
 /build_tsan/
 /build-tidy
+/build_bench
 
 # Python artifacts
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-20
+
+### Added
+- Self-contained DiskANN disk index (`alaya::diskann::DiskANNIndex`): in-memory
+  Vamana build, sector-aligned disk layout, optional PQ, BFS node cache, and
+  cached beam search (PQ + No-PQ greedy) with async-pipelined I/O and opt-in
+  deterministic mode for byte-exact batch/sequential reproducibility.
+- IP-DiskANN in-place update with tombstone, slot reuse, and proactive graph
+  repair: `insert()` / `remove()` / `flush()` on the No-PQ disk index,
+  following the IP-DiskANN design (search + c=3 replacement edges at delete
+  time). New components: `TombstoneBitmap`, `SlotAllocator`, `DiskPageIO`,
+  `DiskUpdateContext`. Meta v2 with backward-compatible v1 read.
+
+### Changed
+- Refactored DiskANN update internals: extracted shared reconnect backbone
+  (`cached_l2`, `prune_and_write`) from `update_node_impl` and
+  `update_node_ipdiskann`, eliminating ~60 lines of duplication. Removed
+  redundant `removed_vertices_` set from `DiskUpdateContext`. Replaced
+  `unordered_set` with sorted comparison in `same_neighbor_set`. Reuse
+  `AlignedRead` in PQ rerank loop. Use `partial_sort` for IP-DiskANN top-3
+  candidate selection.
+
 ## [1.0.0] - 2026-05-22
 
 First stable release of AlayaLite. Highlights since the 0.1.x alpha line:
@@ -277,7 +299,8 @@ First stable release of AlayaLite. Highlights since the 0.1.x alpha line:
 - RAG components (embedders, chunkers)
 - Basic CI/CD pipeline
 
-[Unreleased]: https://github.com/AlayaDB-AI/AlayaLite/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/AlayaDB-AI/AlayaLite/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/AlayaDB-AI/AlayaLite/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/AlayaDB-AI/AlayaLite/compare/v0.1.1a1...v1.0.0
 [0.1.1-alpha1]: https://github.com/AlayaDB-AI/AlayaLite/compare/v0.1.0a3...v0.1.1a1
 [0.1.0-alpha3]: https://github.com/AlayaDB-AI/AlayaLite/compare/v0.1.0a2...v0.1.0a3

--- a/include/index/graph/diskann/beam_search.hpp
+++ b/include/index/graph/diskann/beam_search.hpp
@@ -120,10 +120,9 @@ inline void scan_and_insert_neighbors(alaya::vamana::NeighborPriorityQueue &rets
     if (m >= num_points) {
       continue;  // defensive: ignore corrupt neighbor ids
     }
-    if (visited.find(m) != visited.end()) {
+    if (!visited.insert(m).second) {
       continue;
     }
-    visited.insert(m);
     retset.insert(alaya::vamana::Neighbor(m, pq.pq_distance(m, pq_table)));
   }
 }
@@ -200,14 +199,12 @@ inline std::vector<std::pair<uint32_t, float>> disk_greedy_search(const SearchCo
   // IP-DiskANN: tombstoned nodes are skipped (graph repaired at delete time).
   const TombstoneBitmap *tomb = ctx.tombstone;
   auto consider = [&](uint32_t m, auto &&emit) {
-    if (m >= ctx.num_points || visited.find(m) != visited.end()) {
+    if (m >= ctx.num_points || !visited.insert(m).second) {
       return;
     }
     if (tomb != nullptr && tomb->is_deleted(m)) {
-      visited.insert(m);
       return;
     }
-    visited.insert(m);
     emit(m);
   };
 

--- a/include/index/graph/diskann/beam_search.hpp
+++ b/include/index/graph/diskann/beam_search.hpp
@@ -561,6 +561,7 @@ inline std::vector<std::pair<uint32_t, float>> cached_beam_search(const SearchCo
 
   // ---------------- Result extraction (PQ) ----------------
   std::vector<std::pair<uint32_t, float>> out;
+  std::vector<AlignedRead> rerank_req(1);
 
   auto read_exact_sync = [&](uint32_t id) -> float {
     const auto it = exact_by_id.find(id);
@@ -568,9 +569,8 @@ inline std::vector<std::pair<uint32_t, float>> cached_beam_search(const SearchCo
       return it->second;
     }
     char *buf = td.sector_scratch;
-    std::vector<AlignedRead> r1;
-    r1.emplace_back(geom.get_page_offset(id), page_size, id, buf);
-    reader.read(r1, td.ctx_);
+    rerank_req[0] = {geom.get_page_offset(id), page_size, id, buf};
+    reader.read(rerank_req, td.ctx_);
     NodeRecordView view{buf + geom.offset_to_node(id), dim};
     const float ex = l2(query, view.coords(), dim);
     exact_by_id[id] = ex;

--- a/include/index/graph/diskann/beam_search.hpp
+++ b/include/index/graph/diskann/beam_search.hpp
@@ -59,6 +59,7 @@
 #include "index/graph/diskann/node_cache.hpp"
 #include "index/graph/diskann/pq_table.hpp"
 #include "index/graph/diskann/search_scratch.hpp"
+#include "index/graph/diskann/tombstone_bitmap.hpp"
 #include "index/graph/laser/utils/aligned_file_reader.hpp"
 #include "index/graph/vamana/robust_prune.hpp"
 #include "simd/distance_l2.hpp"
@@ -85,6 +86,9 @@ struct SearchContext {
   const PQTable *pq = nullptr;  ///< nullptr => index has no PQ
   uint32_t medoid = 0;
   uint64_t num_points = 0;
+
+  // Tombstone-aware search (null for static indices).
+  const TombstoneBitmap *tombstone = nullptr;
 };
 
 /// Optional instrumentation for tests / profiling.
@@ -193,6 +197,20 @@ inline std::vector<std::pair<uint32_t, float>> disk_greedy_search(const SearchCo
     return td.sector_scratch + geom.offset_to_node(id);
   };
 
+  // IP-DiskANN: tombstoned nodes are skipped (graph repaired at delete time).
+  const TombstoneBitmap *tomb = ctx.tombstone;
+  auto consider = [&](uint32_t m, auto &&emit) {
+    if (m >= ctx.num_points || visited.find(m) != visited.end()) {
+      return;
+    }
+    if (tomb != nullptr && tomb->is_deleted(m)) {
+      visited.insert(m);
+      return;
+    }
+    visited.insert(m);
+    emit(m);
+  };
+
   visited.insert(ctx.medoid);
   absorb(ctx.medoid, read_seed(ctx.medoid));
 
@@ -218,11 +236,9 @@ inline std::vector<std::pair<uint32_t, float>> disk_greedy_search(const SearchCo
       const std::vector<uint32_t> nbrs = it->second;
       todo.clear();
       for (const uint32_t m : nbrs) {
-        if (m >= ctx.num_points || visited.find(m) != visited.end()) {
-          continue;
-        }
-        visited.insert(m);
-        todo.push_back(m);
+        consider(m, [&](uint32_t id) {
+          todo.push_back(id);
+        });
       }
       for (size_t off = 0; off < todo.size(); off += n_slots) {
         const size_t end = std::min<size_t>(off + n_slots, todo.size());
@@ -284,11 +300,9 @@ inline std::vector<std::pair<uint32_t, float>> disk_greedy_search(const SearchCo
           continue;
         }
         for (const uint32_t m : it->second) {
-          if (m >= ctx.num_points || visited.find(m) != visited.end()) {
-            continue;
-          }
-          visited.insert(m);
-          pending.push_back(m);
+          consider(m, [&](uint32_t id) {
+            pending.push_back(id);
+          });
         }
       }
     };
@@ -352,10 +366,13 @@ inline std::vector<std::pair<uint32_t, float>> disk_greedy_search(const SearchCo
   }
 
   std::vector<std::pair<uint32_t, float>> out;
-  const size_t take = std::min<size_t>(frontier.size(), top_k);
-  out.reserve(take);
-  for (size_t i = 0; i < take; ++i) {  // frontier is sorted ascending by (dist, id)
-    out.emplace_back(frontier[i].id, frontier[i].distance);
+  out.reserve(std::min<size_t>(frontier.size(), top_k));
+  for (size_t i = 0; i < frontier.size() && out.size() < top_k; ++i) {
+    const uint32_t id = frontier[i].id;
+    if (tomb != nullptr && tomb->is_deleted(id)) {
+      continue;
+    }
+    out.emplace_back(id, frontier[i].distance);
   }
   return out;
 }

--- a/include/index/graph/diskann/beam_search.hpp
+++ b/include/index/graph/diskann/beam_search.hpp
@@ -1,0 +1,596 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * @file beam_search.hpp
+ * @brief Disk search over the DiskANN layout — PQ beam search and No-PQ greedy.
+ *
+ * Two modes (design D2/D5), dispatched by cached_beam_search():
+ *
+ *   - PQ mode (use_pq): a beam that pops the closest unexpanded candidates from
+ *     the frontier, serves cache hits from memory, and submits cache misses as
+ *     async O_DIRECT page reads. Neighbor distances come from the per-query PQ
+ *     table, so the frontier is ordered best-first cheaply. Optional rerank reads
+ *     the top candidates' coordinates and re-scores them with exact L2.
+ *
+ *     Two scheduling variants (SearchParams::deterministic): the default
+ *     pipelines I/O with compute (up to beam_width reads in flight, processed in
+ *     completion order — fastest, but results vary with I/O timing); the opt-in
+ *     deterministic variant uses a per-beam barrier (process in popped order,
+ *     ~10-15% slower) so concurrent batch_search() matches sequential search()
+ *     byte for byte.
+ *
+ *   - No-PQ mode: a faithful disk port of Vamana greedy search. Expanding a node
+ *     reads each unvisited neighbor's coordinates and computes its *exact* L2
+ *     distance, so the frontier is ordered by true distance and descends to the
+ *     query. This costs more I/O than PQ (every discovered node is read) but
+ *     needs no quantization and yields full-precision results. (A lazy
+ *     FLT_MAX / parent-distance placeholder was measured to converge far too
+ *     slowly — recall < 0.5 even reading 20% of the index — so the neighbor
+ *     distances are computed eagerly, matching the in-memory VamanaGreedySearch
+ *     model that design D5 names.)
+ *
+ *     Like PQ, No-PQ has two scheduling variants (SearchParams::deterministic).
+ *     Because every distance is exact and the frontier's insert is order-
+ *     independent in its final contents, both yield the same recall; they differ
+ *     only in how neighbor reads are issued. deterministic = true (batched
+ *     barrier) reads each expansion's unvisited neighbors as one concurrent batch
+ *     and is byte-for-byte identical to a one-at-a-time synchronous read, so
+ *     batch_search() == search(). The default pipelines reads across expansions
+ *     (up to 2*beam_width in flight), maximising I/O/compute overlap at the cost
+ *     of strict-greedy ordering (only tie-ordering of equally-distant nodes may
+ *     differ, not recall).
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <deque>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "index/graph/diskann/disk_layout.hpp"
+#include "index/graph/diskann/node_cache.hpp"
+#include "index/graph/diskann/pq_table.hpp"
+#include "index/graph/diskann/search_scratch.hpp"
+#include "index/graph/laser/utils/aligned_file_reader.hpp"
+#include "index/graph/vamana/robust_prune.hpp"
+#include "simd/distance_l2.hpp"
+
+namespace alaya::diskann {
+
+/// Tunable runtime search parameters.
+struct SearchParams {
+  uint32_t search_list_size = 100;  ///< L: frontier capacity (>= top_k)
+  uint32_t beam_width = 4;          ///< PQ mode: max async reads per beam step
+  bool use_pq = true;               ///< use PQ approx distances (needs a PQTable)
+  bool rerank = true;               ///< PQ only: re-score top candidates with exact L2
+  uint32_t rerank_count = 0;        ///< PQ rerank pool size; 0 => top_k*3 (spec default)
+  bool deterministic = false;       ///< Reproducible batch==sequential via a per-expansion
+                                    ///< barrier (PQ: per-beam). Default off = async-pipelined
+                                    ///< I/O (faster). Applies to both PQ and No-PQ modes.
+};
+
+/// Immutable per-index context the search borrows (no ownership).
+struct SearchContext {
+  AlignedFileReader *reader = nullptr;
+  const DiskLayoutGeometry *geom = nullptr;
+  const NodeCache *cache = nullptr;
+  const PQTable *pq = nullptr;  ///< nullptr => index has no PQ
+  uint32_t medoid = 0;
+  uint64_t num_points = 0;
+};
+
+/// Optional instrumentation for tests / profiling.
+struct SearchStats {
+  uint64_t n_ios = 0;                ///< page reads issued to disk
+  uint64_t n_cache_hits = 0;         ///< nodes served from the BFS cache
+  uint64_t n_nodes_processed = 0;    ///< nodes whose exact distance was computed
+  uint64_t n_rerank_reads = 0;       ///< extra synchronous reads for PQ rerank
+  std::vector<uint32_t> read_order;  ///< ids in the order first processed
+};
+
+/**
+ * @brief Scan a node's neighbors and insert the unvisited ones into the frontier
+ *        with their PQ approximate distances (PQ mode).
+ *
+ * The frontier's bounded insert prunes neighbors that cannot beat the current
+ * worst entry. Already-visited neighbors and out-of-range ids are skipped.
+ * Extracted as a free function so the contract is unit-testable in isolation.
+ */
+inline void scan_and_insert_neighbors(alaya::vamana::NeighborPriorityQueue &retset,
+                                      std::unordered_set<uint32_t> &visited,
+                                      const uint32_t *nbrs,
+                                      uint32_t n_nbrs,
+                                      const PQTable &pq,
+                                      const float *pq_table,
+                                      uint64_t num_points) {
+  for (uint32_t k = 0; k < n_nbrs; ++k) {
+    const uint32_t m = nbrs[k];
+    if (m >= num_points) {
+      continue;  // defensive: ignore corrupt neighbor ids
+    }
+    if (visited.find(m) != visited.end()) {
+      continue;
+    }
+    visited.insert(m);
+    retset.insert(alaya::vamana::Neighbor(m, pq.pq_distance(m, pq_table)));
+  }
+}
+
+/**
+ * @brief No-PQ disk greedy search: a disk port of Vamana greedy search.
+ *
+ * Expanding a node reads each unvisited neighbor's coordinates and computes its
+ * exact L2 distance, so the frontier (NeighborPriorityQueue of capacity L) is
+ * ordered by true distance and the search descends to the query. Each node is
+ * read at most once; its neighbor list is cached for when it is expanded.
+ *
+ * Two I/O scheduling variants share this code (SearchParams::deterministic):
+ * a batched per-expansion barrier (byte-exact, batch == sequential) and the
+ * default async pipeline (reads overlap across expansions). Because all
+ * distances are exact and the frontier insert is order-independent, both give
+ * identical recall — see the file header for the contract.
+ */
+inline std::vector<std::pair<uint32_t, float>> disk_greedy_search(const SearchContext &ctx,
+                                                                  const float *query,
+                                                                  uint32_t top_k,
+                                                                  const SearchParams &params,
+                                                                  ThreadData &td,
+                                                                  SearchStats *stats) {
+  AlignedFileReader &reader = *ctx.reader;
+  const DiskLayoutGeometry &geom = *ctx.geom;
+  const NodeCache &cache = *ctx.cache;
+  const uint64_t dim = geom.dim;
+  const uint64_t page_size = geom.page_size;
+  const auto l2 = alaya::simd::get_l2_sqr_func();
+  // Page slots available in the sector scratch (alloc_scratch sizes it for
+  // 2 * beam_width pages); both schedulers cap their in-flight reads at this.
+  const uint64_t n_slots = std::max<uint64_t>(1, td.sector_scratch_bytes / page_size);
+
+  const size_t list_size = std::max<size_t>(params.search_list_size, top_k);
+  td.reset_query(list_size);
+  auto &frontier = td.retset;
+  auto &visited = td.visited;
+
+  // Neighbor lists of read nodes, needed when a node is later expanded.
+  std::unordered_map<uint32_t, std::vector<uint32_t>> nbrs_cache;
+
+  // Absorb a freshly-read node: cache its neighbor list and insert it into the
+  // frontier with its exact L2 distance (coords are co-located in the record).
+  auto absorb = [&](uint32_t id, const char *rec) {
+    NodeRecordView view{rec, dim};
+    nbrs_cache[id].assign(view.nbrs(), view.nbrs() + view.n_nbrs());
+    frontier.insert(alaya::vamana::Neighbor(id, l2(query, view.coords(), dim)));
+    if (stats != nullptr) {
+      stats->read_order.push_back(id);
+      stats->n_nodes_processed++;
+    }
+  };
+
+  // Synchronously read one node into scratch slot 0 (used only to seed the
+  // medoid); returns a pointer to its record (cache or scratch).
+  auto read_seed = [&](uint32_t id) -> const char * {
+    const char *rec = cache.lookup(id);
+    if (rec != nullptr) {
+      if (stats != nullptr) {
+        stats->n_cache_hits++;
+      }
+      return rec;
+    }
+    std::vector<AlignedRead> r1;
+    r1.emplace_back(geom.get_page_offset(id), page_size, id, td.sector_scratch);
+    reader.read(r1, td.ctx_);
+    if (stats != nullptr) {
+      stats->n_ios++;
+    }
+    return td.sector_scratch + geom.offset_to_node(id);
+  };
+
+  visited.insert(ctx.medoid);
+  absorb(ctx.medoid, read_seed(ctx.medoid));
+
+  std::vector<AlignedRead> reqs;
+
+  if (params.deterministic) {
+    // Batched barrier: expand strictly closest-first. For each expansion, read
+    // ALL unvisited neighbors concurrently (chunked to n_slots), wait for the
+    // chunk, then absorb in neighbor-list order. Identical insert sequence to a
+    // one-at-a-time synchronous read, so concurrent batch_search() reproduces
+    // sequential search() byte for byte — it only overlaps the up-to-R reads of
+    // each expansion instead of serialising them.
+    std::vector<uint32_t> todo;
+    std::vector<uint32_t> chunk_ids;
+    std::vector<const char *> chunk_recs;
+    while (frontier.has_unexpanded_node()) {
+      const uint32_t x = frontier.closest_unexpanded().id;
+      const auto it = nbrs_cache.find(x);
+      if (it == nbrs_cache.end()) {
+        continue;  // defensive: a frontier node is always absorbed (and so cached)
+      }
+      // Copy: absorb() below may rehash nbrs_cache and invalidate it->second.
+      const std::vector<uint32_t> nbrs = it->second;
+      todo.clear();
+      for (const uint32_t m : nbrs) {
+        if (m >= ctx.num_points || visited.find(m) != visited.end()) {
+          continue;
+        }
+        visited.insert(m);
+        todo.push_back(m);
+      }
+      for (size_t off = 0; off < todo.size(); off += n_slots) {
+        const size_t end = std::min<size_t>(off + n_slots, todo.size());
+        reqs.clear();
+        chunk_ids.clear();
+        chunk_recs.clear();
+        uint64_t slot = 0;
+        for (size_t i = off; i < end; ++i) {
+          const uint32_t m = todo[i];
+          const char *crec = cache.lookup(m);
+          if (crec != nullptr) {
+            if (stats != nullptr) {
+              stats->n_cache_hits++;
+            }
+            chunk_ids.push_back(m);
+            chunk_recs.push_back(crec);
+            continue;
+          }
+          char *buf = td.sector_scratch + (slot++) * page_size;
+          chunk_ids.push_back(m);
+          chunk_recs.push_back(buf + geom.offset_to_node(m));
+          reqs.emplace_back(geom.get_page_offset(m), page_size, m, buf);
+        }
+        if (!reqs.empty()) {
+          reader.read(reqs, td.ctx_);  // blocking; kernel runs the batch concurrently
+          if (stats != nullptr) {
+            stats->n_ios += reqs.size();
+          }
+        }
+        for (size_t j = 0; j < chunk_ids.size(); ++j) {
+          absorb(chunk_ids[j], chunk_recs[j]);
+        }
+      }
+    }
+  } else {
+    // Async pipeline (default): keep up to n_slots reads in flight across
+    // expansions. `pending` holds discovered (visited-marked) ids awaiting a slot;
+    // `inflight` maps an in-flight id to its (slot, record pointer). Processing
+    // follows I/O completion order, so the strict-greedy expansion order is
+    // relaxed (results may differ only in tie-ordering of equally-distant nodes).
+    std::vector<uint64_t> free_slots;
+    free_slots.reserve(n_slots);
+    for (uint64_t s = 0; s < n_slots; ++s) {
+      free_slots.push_back(s);
+    }
+    std::unordered_map<uint32_t, std::pair<uint64_t, const char *>> inflight;
+    std::deque<uint32_t> pending;
+    std::vector<AlignedReadEvent> evts;
+
+    // Expand closest-unexpanded nodes into `pending` until there is enough queued
+    // to fill the free slots (relaxed greedy: may expand before a closer in-flight
+    // node lands). closest_unexpanded() advances the cursor monotonically, so this
+    // always makes progress and cannot loop forever.
+    auto refill_pending = [&]() {
+      while (pending.size() < free_slots.size() && frontier.has_unexpanded_node()) {
+        const uint32_t x = frontier.closest_unexpanded().id;
+        const auto it = nbrs_cache.find(x);
+        if (it == nbrs_cache.end()) {
+          continue;
+        }
+        for (const uint32_t m : it->second) {
+          if (m >= ctx.num_points || visited.find(m) != visited.end()) {
+            continue;
+          }
+          visited.insert(m);
+          pending.push_back(m);
+        }
+      }
+    };
+
+    // Drain `pending` into free slots: cache hits absorbed inline (no slot), misses
+    // submitted as O_DIRECT reads.
+    auto submit_pending = [&]() {
+      reqs.clear();
+      while (!free_slots.empty() && !pending.empty()) {
+        const uint32_t m = pending.front();
+        pending.pop_front();
+        const char *crec = cache.lookup(m);
+        if (crec != nullptr) {
+          if (stats != nullptr) {
+            stats->n_cache_hits++;
+          }
+          absorb(m, crec);
+          continue;
+        }
+        const uint64_t slot = free_slots.back();
+        free_slots.pop_back();
+        char *buf = td.sector_scratch + slot * page_size;
+        inflight.emplace(m, std::make_pair(slot, buf + geom.offset_to_node(m)));
+        reqs.emplace_back(geom.get_page_offset(m), page_size, m, buf);
+      }
+      if (!reqs.empty()) {
+        reader.submit_reqs(reqs, td.ctx_);
+        if (stats != nullptr) {
+          stats->n_ios += reqs.size();
+        }
+      }
+    };
+
+    refill_pending();
+    submit_pending();
+    // Continue while any work remains: a read in flight, a queued read, or an
+    // unexpanded frontier node (the latter matters when cache hits add nodes
+    // without ever entering `inflight`).
+    while (!inflight.empty() || !pending.empty() || frontier.has_unexpanded_node()) {
+      if (!inflight.empty()) {
+        reader.get_events(td.ctx_, 1, evts);  // get_events clears + fills `evts`
+        for (const auto &e : evts) {
+          if (e.result != static_cast<int64_t>(page_size)) {
+            throw std::runtime_error("disk_greedy_search: short/failed read, result=" +
+                                     std::to_string(e.result));
+          }
+          const auto it = inflight.find(static_cast<uint32_t>(e.id));
+          if (it == inflight.end()) {
+            continue;  // defensive: completion for an id we are not tracking
+          }
+          const uint64_t slot = it->second.first;
+          const char *rec = it->second.second;
+          absorb(static_cast<uint32_t>(e.id), rec);
+          free_slots.push_back(slot);
+          inflight.erase(it);
+        }
+      }
+      refill_pending();
+      submit_pending();
+    }
+  }
+
+  std::vector<std::pair<uint32_t, float>> out;
+  const size_t take = std::min<size_t>(frontier.size(), top_k);
+  out.reserve(take);
+  for (size_t i = 0; i < take; ++i) {  // frontier is sorted ascending by (dist, id)
+    out.emplace_back(frontier[i].id, frontier[i].distance);
+  }
+  return out;
+}
+
+/**
+ * @brief Run the disk search for one query (PQ beam or No-PQ greedy).
+ *
+ * @return Up to @p top_k (internal_id, distance) pairs sorted by ascending
+ *         distance. Distances are exact L2-squared except for PQ no-rerank
+ *         results on nodes that were never read (those carry their PQ
+ *         approximation).
+ */
+inline std::vector<std::pair<uint32_t, float>> cached_beam_search(const SearchContext &ctx,
+                                                                  const float *query,
+                                                                  uint32_t top_k,
+                                                                  const SearchParams &params,
+                                                                  ThreadData &td,
+                                                                  SearchStats *stats = nullptr) {
+  const bool use_pq = params.use_pq && (ctx.pq != nullptr);
+  if (!use_pq) {
+    return disk_greedy_search(ctx, query, top_k, params, td, stats);
+  }
+
+  AlignedFileReader &reader = *ctx.reader;
+  const DiskLayoutGeometry &geom = *ctx.geom;
+  const NodeCache &cache = *ctx.cache;
+  const PQTable &pq = *ctx.pq;
+  const uint64_t dim = geom.dim;
+  const uint64_t page_size = geom.page_size;
+  const auto l2 = alaya::simd::get_l2_sqr_func();
+
+  const size_t list_size = std::max<size_t>(params.search_list_size, top_k);
+  td.reset_query(list_size);
+  auto &retset = td.retset;
+  auto &visited = td.visited;
+  auto &exact_by_id = td.exact_by_id;
+
+  pq.preprocess_query(query, td.pq_table.data());
+  const float *pq_table = td.pq_table.data();
+
+  // Seed from the medoid (first node expanded — spec scenario).
+  visited.insert(ctx.medoid);
+  retset.insert(alaya::vamana::Neighbor(ctx.medoid, pq.pq_distance(ctx.medoid, pq_table)));
+
+  const uint64_t beam = std::max<uint64_t>(1, params.beam_width);
+
+  // Process a freshly-read node: compute its exact L2 (the coords are co-located
+  // on the sector we just read) and insert its unvisited neighbors into the
+  // frontier with PQ approximate distances. Shared by both search paths.
+  auto process_node = [&](uint32_t id, const char *rec) {
+    NodeRecordView view{rec, dim};
+    exact_by_id[id] = l2(query, view.coords(), dim);
+    if (stats != nullptr) {
+      stats->read_order.push_back(id);
+      stats->n_nodes_processed++;
+    }
+    scan_and_insert_neighbors(retset,
+                              visited,
+                              view.nbrs(),
+                              view.n_nbrs(),
+                              pq,
+                              pq_table,
+                              ctx.num_points);
+  };
+
+  std::vector<AlignedRead> reqs;
+  std::vector<AlignedReadEvent> evts;
+
+  if (params.deterministic) {
+    // Deterministic per-beam barrier: pop the closest unexpanded candidates, read
+    // the cache misses together, wait for ALL of them, then process the batch in
+    // popped order. Processing order is independent of I/O completion timing, so
+    // concurrent batch_search() matches sequential search() byte for byte. Opt-in
+    // (DiskANNSearchParams::deterministic) — it forgoes the cross-beam I/O/compute
+    // overlap of the default path and so runs ~10-15% slower.
+    std::vector<uint32_t> batch;
+    std::unordered_map<uint32_t, const char *> rec_of;
+    while (retset.has_unexpanded_node()) {
+      batch.clear();
+      reqs.clear();
+      rec_of.clear();
+      uint64_t slot = 0;
+      while (retset.has_unexpanded_node() && reqs.size() < beam) {
+        const uint32_t id = retset.closest_unexpanded().id;
+        batch.push_back(id);
+        const char *crec = cache.lookup(id);
+        if (crec != nullptr) {
+          rec_of[id] = crec;
+          if (stats != nullptr) {
+            stats->n_cache_hits++;
+          }
+        } else {
+          char *buf = td.sector_scratch + (slot++) * page_size;
+          rec_of[id] = buf + geom.offset_to_node(id);
+          reqs.emplace_back(geom.get_page_offset(id), page_size, id, buf);
+        }
+      }
+
+      if (!reqs.empty()) {
+        reader.submit_reqs(reqs, td.ctx_);
+        reader.get_events(td.ctx_, static_cast<int>(reqs.size()), evts);
+        if (stats != nullptr) {
+          stats->n_ios += reqs.size();
+        }
+        for (const auto &e : evts) {
+          if (e.result != static_cast<int64_t>(page_size)) {
+            throw std::runtime_error("cached_beam_search: short/failed read, result=" +
+                                     std::to_string(e.result));
+          }
+        }
+      }
+
+      for (const uint32_t id : batch) {
+        process_node(id, rec_of[id]);
+      }
+    }
+  } else {
+    // Async pipelined beam (default): keep up to `beam` reads in flight and
+    // process each as it completes, refilling the pipe immediately, so disk I/O
+    // overlaps with distance computation. Processing follows I/O completion order,
+    // so results are NOT bitwise-reproducible across runs/threads (set
+    // deterministic for that). Thread-safety, correctness and recall are
+    // unaffected — only the tie-ordering of equally-good candidates differs.
+    std::vector<uint64_t> free_slots;
+    free_slots.reserve(beam);
+    for (uint64_t s = 0; s < beam; ++s) {
+      free_slots.push_back(s);
+    }
+    // In-flight reads: node id -> (scratch slot, record pointer within that page).
+    std::unordered_map<uint32_t, std::pair<uint64_t, const char *>> inflight;
+
+    // Pop closest-unexpanded candidates, serving cache hits inline and submitting
+    // cache misses into free scratch slots. Stops when the slots are full or the
+    // frontier has no unexpanded node left.
+    auto fill_pipe = [&]() {
+      reqs.clear();
+      while (!free_slots.empty() && retset.has_unexpanded_node()) {
+        const uint32_t id = retset.closest_unexpanded().id;
+        const char *crec = cache.lookup(id);
+        if (crec != nullptr) {
+          if (stats != nullptr) {
+            stats->n_cache_hits++;
+          }
+          process_node(id, crec);
+          continue;
+        }
+        const uint64_t slot = free_slots.back();
+        free_slots.pop_back();
+        char *buf = td.sector_scratch + slot * page_size;
+        inflight.emplace(id, std::make_pair(slot, buf + geom.offset_to_node(id)));
+        reqs.emplace_back(geom.get_page_offset(id), page_size, id, buf);
+      }
+      if (!reqs.empty()) {
+        reader.submit_reqs(reqs, td.ctx_);
+        if (stats != nullptr) {
+          stats->n_ios += reqs.size();
+        }
+      }
+    };
+
+    fill_pipe();
+    while (!inflight.empty()) {
+      // Wait for exactly one completion (get_events clears and fills `evts`). The
+      // other in-flight reads keep the disk busy while we process this one — that
+      // is the I/O/compute overlap. NOTE: poll_events/get_events both clear their
+      // out-vector, so they must not share one; we use get_events alone here.
+      reader.get_events(td.ctx_, 1, evts);
+      for (const auto &e : evts) {
+        if (e.result != static_cast<int64_t>(page_size)) {
+          throw std::runtime_error("cached_beam_search: short/failed read, result=" +
+                                   std::to_string(e.result));
+        }
+        const auto it = inflight.find(static_cast<uint32_t>(e.id));
+        if (it == inflight.end()) {
+          continue;  // defensive: completion for an id we are not tracking
+        }
+        const uint64_t slot = it->second.first;
+        const char *rec = it->second.second;
+        process_node(static_cast<uint32_t>(e.id), rec);
+        free_slots.push_back(slot);
+        inflight.erase(it);
+      }
+      fill_pipe();
+    }
+  }
+
+  // ---------------- Result extraction (PQ) ----------------
+  std::vector<std::pair<uint32_t, float>> out;
+
+  auto read_exact_sync = [&](uint32_t id) -> float {
+    const auto it = exact_by_id.find(id);
+    if (it != exact_by_id.end()) {
+      return it->second;
+    }
+    char *buf = td.sector_scratch;
+    std::vector<AlignedRead> r1;
+    r1.emplace_back(geom.get_page_offset(id), page_size, id, buf);
+    reader.read(r1, td.ctx_);
+    NodeRecordView view{buf + geom.offset_to_node(id), dim};
+    const float ex = l2(query, view.coords(), dim);
+    exact_by_id[id] = ex;
+    if (stats != nullptr) {
+      stats->n_rerank_reads++;
+    }
+    return ex;
+  };
+
+  if (params.rerank) {
+    // Re-score the top PQ candidates with exact L2.
+    const size_t want =
+        params.rerank_count > 0 ? params.rerank_count : static_cast<size_t>(top_k) * 3;
+    const size_t n_cand = std::min<size_t>(retset.size(), want);
+    out.reserve(n_cand);
+    for (size_t i = 0; i < n_cand; ++i) {
+      const uint32_t id = retset[i].id;
+      out.emplace_back(id, read_exact_sync(id));
+    }
+  } else {
+    // Top candidates ranked by PQ distance (exact where known during traversal).
+    const size_t n_cand = std::min<size_t>(retset.size(), static_cast<size_t>(top_k));
+    out.reserve(n_cand);
+    for (size_t i = 0; i < n_cand; ++i) {
+      const uint32_t id = retset[i].id;
+      const auto it = exact_by_id.find(id);
+      out.emplace_back(id, it != exact_by_id.end() ? it->second : retset[i].distance);
+    }
+  }
+
+  std::sort(out.begin(), out.end(), [](const auto &a, const auto &b) {
+    return a.second < b.second || (a.second == b.second && a.first < b.first);
+  });
+  if (out.size() > top_k) {
+    out.resize(top_k);
+  }
+  return out;
+}
+
+}  // namespace alaya::diskann

--- a/include/index/graph/diskann/disk_layout.hpp
+++ b/include/index/graph/diskann/disk_layout.hpp
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <algorithm>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -39,6 +40,9 @@
 #include <vector>
 
 namespace alaya::diskann {
+
+static_assert(std::endian::native == std::endian::little,
+              "DiskANN on-disk layout assumes little-endian host");
 
 /// Sector size (O_DIRECT page granularity). All reads must be aligned to this.
 inline constexpr uint64_t kSectorLen = 4096;

--- a/include/index/graph/diskann/disk_layout.hpp
+++ b/include/index/graph/diskann/disk_layout.hpp
@@ -1,0 +1,350 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * @file disk_layout.hpp
+ * @brief Sector-aligned on-disk layout for the DiskANN disk index.
+ *
+ * The disk index file (`diskann.index`) begins with a 4096-byte header sector,
+ * followed by node data packed into sector-aligned pages. Each node is a
+ * fixed-length record:
+ *
+ *     [ float32[dim] coords | uint32 n_nbrs | uint32[max_degree] nbr_ids ]
+ *
+ * The fixed `node_len` lets a node's disk offset be computed directly from its
+ * id (no auxiliary index), which is what makes async O_DIRECT reads and future
+ * in-place delete/update possible.
+ *
+ * Geometry (matching the LASER QuantizedGraph convention so both share the same
+ * AlignedFileReader contract):
+ *   - node_len         = dim*4 + 4 + max_degree*4
+ *   - nodes_per_sector = max(1, kSectorLen / node_len)
+ *   - page_size        = ceil(nodes_per_sector * node_len / kSectorLen) * kSectorLen
+ *
+ * The header format is an explicit little-endian byte layout (not a struct
+ * dump), so the on-disk format is decoupled from the host ABI.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>  // NOLINT(build/c++17)
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace alaya::diskann {
+
+/// Sector size (O_DIRECT page granularity). All reads must be aligned to this.
+inline constexpr uint64_t kSectorLen = 4096;
+
+/// Fixed byte offsets of header fields within the 4096-byte header sector.
+namespace header_offset {
+inline constexpr size_t kNumPoints = 0;        ///< u64
+inline constexpr size_t kDim = 8;              ///< u64
+inline constexpr size_t kMedoid = 16;          ///< u32
+inline constexpr size_t kMaxDegree = 20;       ///< u32
+inline constexpr size_t kNodeLen = 24;         ///< u64
+inline constexpr size_t kNodesPerSector = 32;  ///< u64
+inline constexpr size_t kTotalFileSize = 40;   ///< u64 (header uses 48 bytes total)
+}  // namespace header_offset
+
+/// Parsed header sector contents.
+struct DiskLayoutHeader {
+  uint64_t num_points = 0;
+  uint64_t dim = 0;
+  uint32_t medoid = 0;
+  uint32_t max_degree = 0;
+  uint64_t node_len = 0;
+  uint64_t nodes_per_sector = 0;
+  uint64_t total_file_size = 0;
+};
+
+namespace detail {
+inline void put_u64(char *buf, size_t off, uint64_t v) { std::memcpy(buf + off, &v, sizeof(v)); }
+inline void put_u32(char *buf, size_t off, uint32_t v) { std::memcpy(buf + off, &v, sizeof(v)); }
+inline uint64_t get_u64(const char *buf, size_t off) {
+  uint64_t v;
+  std::memcpy(&v, buf + off, sizeof(v));
+  return v;
+}
+inline uint32_t get_u32(const char *buf, size_t off) {
+  uint32_t v;
+  std::memcpy(&v, buf + off, sizeof(v));
+  return v;
+}
+}  // namespace detail
+
+/**
+ * @brief Sector geometry derived deterministically from (dim, max_degree).
+ *
+ * Bundles node_len / nodes_per_sector / page_size and the offset arithmetic so
+ * callers never re-derive (or disagree on) the layout math.
+ */
+struct DiskLayoutGeometry {
+  uint64_t dim = 0;
+  uint32_t max_degree = 0;
+  uint64_t node_len = 0;
+  uint64_t nodes_per_sector = 0;
+  uint64_t page_size = 0;
+
+  /// Compute geometry for a given vector dimension and max graph degree.
+  static DiskLayoutGeometry compute(uint64_t dim, uint32_t max_degree) {
+    if (dim == 0) {
+      throw std::invalid_argument("DiskLayoutGeometry: dim must be > 0");
+    }
+    DiskLayoutGeometry g;
+    g.dim = dim;
+    g.max_degree = max_degree;
+    g.node_len = dim * sizeof(float) + sizeof(uint32_t) +
+                 static_cast<uint64_t>(max_degree) * sizeof(uint32_t);
+    g.nodes_per_sector = std::max<uint64_t>(1, kSectorLen / g.node_len);
+    g.page_size = (g.nodes_per_sector * g.node_len + kSectorLen - 1) / kSectorLen * kSectorLen;
+    return g;
+  }
+
+  /// File offset of the sector page that contains @p node_id.
+  [[nodiscard]] uint64_t get_page_offset(uint64_t node_id) const {
+    return kSectorLen + page_size * (node_id / nodes_per_sector);
+  }
+
+  /// Byte offset of @p node_id within its page.
+  [[nodiscard]] uint64_t offset_to_node(uint64_t node_id) const {
+    return (node_id % nodes_per_sector) * node_len;
+  }
+
+  /// Absolute file offset of @p node_id's record.
+  [[nodiscard]] uint64_t file_offset(uint64_t node_id) const {
+    return get_page_offset(node_id) + offset_to_node(node_id);
+  }
+
+  /// Number of sector pages needed to store @p num_points nodes.
+  [[nodiscard]] uint64_t num_pages(uint64_t num_points) const {
+    if (num_points == 0) {
+      return 0;
+    }
+    return (num_points + nodes_per_sector - 1) / nodes_per_sector;
+  }
+
+  /// Total on-disk file size (header sector + all node pages) for @p num_points.
+  [[nodiscard]] uint64_t total_file_size(uint64_t num_points) const {
+    return kSectorLen + num_pages(num_points) * page_size;
+  }
+};
+
+/**
+ * @brief Serialize one node record into @p rec (node_len bytes).
+ *
+ * Writes @c [coords | n_nbrs | nbr_ids]. Unused neighbor slots are left
+ * untouched, so the caller must pre-zero @p rec (or its enclosing page/buffer)
+ * to satisfy the zero-fill requirement. Used by both the disk writer and the
+ * node cache so cached records are byte-identical to on-disk records.
+ */
+inline void pack_node_record(char *rec,
+                             const float *coords,
+                             const uint32_t *nbrs,
+                             uint32_t n_nbrs,
+                             uint64_t dim) {
+  const uint64_t coords_bytes = dim * sizeof(float);
+  std::memcpy(rec, coords, coords_bytes);
+  std::memcpy(rec + coords_bytes, &n_nbrs, sizeof(n_nbrs));
+  if (n_nbrs > 0) {
+    std::memcpy(rec + coords_bytes + sizeof(uint32_t),
+                nbrs,
+                static_cast<size_t>(n_nbrs) * sizeof(uint32_t));
+  }
+}
+
+/**
+ * @brief Read-only accessor over a node record (from disk page or cache).
+ *
+ * The same parser is used whether the @p rec bytes came from a cache hit or an
+ * async disk read, guaranteeing the two paths interpret a node identically.
+ */
+struct NodeRecordView {
+  const char *rec = nullptr;
+  uint64_t dim = 0;
+
+  /// Pointer to the node's coordinates (dim float32). Suitable for l2_sqr.
+  [[nodiscard]] const float *coords() const { return reinterpret_cast<const float *>(rec); }
+
+  /// Number of valid neighbors stored in this record.
+  [[nodiscard]] uint32_t n_nbrs() const {
+    uint32_t v;
+    std::memcpy(&v, rec + dim * sizeof(float), sizeof(v));
+    return v;
+  }
+
+  /// Pointer to the neighbor id array (n_nbrs() valid entries).
+  [[nodiscard]] const uint32_t *nbrs() const {
+    return reinterpret_cast<const uint32_t *>(rec + dim * sizeof(float) + sizeof(uint32_t));
+  }
+};
+
+/// Inputs to write_disk_layout() that are not raw buffers.
+struct WriteDiskLayoutParams {
+  uint64_t num_points = 0;
+  uint64_t dim = 0;
+  uint32_t max_degree = 0;
+  uint32_t medoid = 0;
+};
+
+/**
+ * @brief Pack a graph + vectors into a sector-aligned disk index file.
+ *
+ * @param path     Output file path (overwritten if it exists).
+ * @param vectors  Row-major @c num_points*dim float32 coordinates.
+ * @param graph    Adjacency lists; graph[i] are the neighbor ids of node i.
+ * @param params   num_points / dim / max_degree / medoid.
+ *
+ * Layout: a 4096-byte header sector, then node pages. Each node record is
+ * @c [coords | n_nbrs | nbr_ids] with unused neighbor slots zero-filled.
+ *
+ * @throws std::invalid_argument if params are inconsistent (e.g. graph size
+ *         mismatch, or a node has more than @c max_degree neighbors).
+ * @throws std::runtime_error if the file cannot be written.
+ */
+inline void write_disk_layout(const std::string &path,
+                              const float *vectors,
+                              const std::vector<std::vector<uint32_t>> &graph,
+                              const WriteDiskLayoutParams &params) {
+  if (params.dim == 0) {
+    throw std::invalid_argument("write_disk_layout: dim must be > 0");
+  }
+  if (params.num_points == 0) {
+    throw std::invalid_argument("write_disk_layout: num_points must be > 0");
+  }
+  if (vectors == nullptr) {
+    throw std::invalid_argument("write_disk_layout: vectors must not be null");
+  }
+  if (graph.size() != params.num_points) {
+    throw std::invalid_argument("write_disk_layout: graph size (" + std::to_string(graph.size()) +
+                                ") != num_points (" + std::to_string(params.num_points) + ")");
+  }
+  if (params.medoid >= params.num_points) {
+    throw std::invalid_argument("write_disk_layout: medoid out of range");
+  }
+
+  const DiskLayoutGeometry geom = DiskLayoutGeometry::compute(params.dim, params.max_degree);
+
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
+  if (!out) {
+    throw std::runtime_error("write_disk_layout: cannot open " + path);
+  }
+
+  // --- Header sector ---
+  std::vector<char> header(kSectorLen, 0);
+  detail::put_u64(header.data(), header_offset::kNumPoints, params.num_points);
+  detail::put_u64(header.data(), header_offset::kDim, params.dim);
+  detail::put_u32(header.data(), header_offset::kMedoid, params.medoid);
+  detail::put_u32(header.data(), header_offset::kMaxDegree, params.max_degree);
+  detail::put_u64(header.data(), header_offset::kNodeLen, geom.node_len);
+  detail::put_u64(header.data(), header_offset::kNodesPerSector, geom.nodes_per_sector);
+  detail::put_u64(header.data(),
+                  header_offset::kTotalFileSize,
+                  geom.total_file_size(params.num_points));
+  out.write(header.data(), static_cast<std::streamsize>(kSectorLen));
+
+  // --- Node pages ---
+  std::vector<char> page(geom.page_size, 0);
+  for (uint64_t node_id = 0; node_id < params.num_points; ++node_id) {
+    const uint64_t slot = node_id % geom.nodes_per_sector;
+    if (slot == 0) {
+      std::fill(page.begin(), page.end(), char{0});
+    }
+
+    char *rec = page.data() + slot * geom.node_len;
+    const auto &nbrs = graph[node_id];
+    if (nbrs.size() > params.max_degree) {
+      throw std::invalid_argument("write_disk_layout: node " + std::to_string(node_id) +
+                                  " degree " + std::to_string(nbrs.size()) +
+                                  " exceeds max_degree " + std::to_string(params.max_degree));
+    }
+    pack_node_record(rec,
+                     vectors + node_id * params.dim,
+                     nbrs.data(),
+                     static_cast<uint32_t>(nbrs.size()),
+                     params.dim);
+
+    const bool last_in_page = (slot == geom.nodes_per_sector - 1);
+    const bool last_node = (node_id == params.num_points - 1);
+    if (last_in_page || last_node) {
+      out.write(page.data(), static_cast<std::streamsize>(geom.page_size));
+    }
+  }
+
+  out.flush();
+  if (!out) {
+    throw std::runtime_error("write_disk_layout: write failed for " + path);
+  }
+}
+
+/**
+ * @brief Read and validate the header sector of a disk index file.
+ *
+ * Validates internal consistency: node_len / nodes_per_sector match the
+ * geometry derived from (dim, max_degree), the medoid is in range, and
+ * total_file_size matches the actual size of the file on disk.
+ *
+ * @throws std::runtime_error on any inconsistency or read failure.
+ */
+inline DiskLayoutHeader read_disk_layout_header(const std::string &path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    throw std::runtime_error("read_disk_layout_header: cannot open " + path);
+  }
+  std::vector<char> buf(kSectorLen, 0);
+  in.read(buf.data(), static_cast<std::streamsize>(kSectorLen));
+  if (in.gcount() != static_cast<std::streamsize>(kSectorLen)) {
+    throw std::runtime_error("read_disk_layout_header: short read (truncated header) for " + path);
+  }
+
+  DiskLayoutHeader h;
+  h.num_points = detail::get_u64(buf.data(), header_offset::kNumPoints);
+  h.dim = detail::get_u64(buf.data(), header_offset::kDim);
+  h.medoid = detail::get_u32(buf.data(), header_offset::kMedoid);
+  h.max_degree = detail::get_u32(buf.data(), header_offset::kMaxDegree);
+  h.node_len = detail::get_u64(buf.data(), header_offset::kNodeLen);
+  h.nodes_per_sector = detail::get_u64(buf.data(), header_offset::kNodesPerSector);
+  h.total_file_size = detail::get_u64(buf.data(), header_offset::kTotalFileSize);
+
+  // --- Consistency checks ---
+  if (h.num_points == 0 || h.dim == 0) {
+    throw std::runtime_error("read_disk_layout_header: zero num_points/dim in " + path);
+  }
+  const DiskLayoutGeometry geom = DiskLayoutGeometry::compute(h.dim, h.max_degree);
+  if (h.node_len != geom.node_len) {
+    throw std::runtime_error("read_disk_layout_header: node_len mismatch (header " +
+                             std::to_string(h.node_len) + " vs derived " +
+                             std::to_string(geom.node_len) + ")");
+  }
+  if (h.nodes_per_sector != geom.nodes_per_sector) {
+    throw std::runtime_error("read_disk_layout_header: nodes_per_sector mismatch in " + path);
+  }
+  if (h.medoid >= h.num_points) {
+    throw std::runtime_error("read_disk_layout_header: medoid out of range in " + path);
+  }
+  const uint64_t expected = geom.total_file_size(h.num_points);
+  if (h.total_file_size != expected) {
+    throw std::runtime_error("read_disk_layout_header: header total_file_size " +
+                             std::to_string(h.total_file_size) + " != expected " +
+                             std::to_string(expected));
+  }
+  std::error_code ec;
+  const auto actual = std::filesystem::file_size(path, ec);
+  if (ec) {
+    throw std::runtime_error("read_disk_layout_header: cannot stat " + path);
+  }
+  if (static_cast<uint64_t>(actual) != h.total_file_size) {
+    throw std::runtime_error("read_disk_layout_header: on-disk size " + std::to_string(actual) +
+                             " != header total_file_size " + std::to_string(h.total_file_size));
+  }
+  return h;
+}
+
+}  // namespace alaya::diskann

--- a/include/index/graph/diskann/disk_page_io.hpp
+++ b/include/index/graph/diskann/disk_page_io.hpp
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * @file disk_page_io.hpp
+ * @brief Sector-aligned read-modify-write of node records in diskann.index.
+ *
+ * `DiskPageIO` (design D6) is the single place that writes the disk index during
+ * in-place updates. It owns its own `O_DIRECT | O_RDWR` file descriptor (separate
+ * from the search reader's read-only descriptor); in serial-update mode (a global
+ * mutex serialises search and update) the two descriptors never race, and because
+ * both use O_DIRECT a completed pwrite is visible to a subsequent pread.
+ *
+ * Every operation works on one sector-aligned page:
+ *   1. compute the page offset via `DiskLayoutGeometry` (O(1));
+ *   2. read the full page into a 4096-aligned buffer (preserving co-resident
+ *      nodes when several share a sector);
+ *   3. modify the target node's record in place;
+ *   4. pwrite the full page back.
+ *
+ * Appends past the current file size extend it with `ftruncate` first (the kernel
+ * zero-fills the new region). A transient coords cache (design D8) lets a single
+ * insert's reconnect avoid re-reading candidate vectors it already touched.
+ *
+ * The public API is platform-neutral; the five private syscalls are gated to
+ * Linux (O_DIRECT). On other platforms they throw — updates are Linux-only by
+ * design, and the header still compiles so cross-platform search builds are
+ * unaffected.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#if defined(__linux__)
+  #include <fcntl.h>
+  #include <sys/stat.h>
+  #include <unistd.h>
+#endif
+
+#include "index/graph/diskann/disk_layout.hpp"
+#include "index/graph/laser/utils/memory.hpp"
+
+namespace alaya::diskann {
+
+class DiskPageIO {
+ public:
+  /// A decoded node record: raw coordinates plus the live neighbor id list.
+  struct NodeData {
+    std::vector<float> coords;   ///< dim float32 entries
+    std::vector<uint32_t> nbrs;  ///< n_nbrs neighbor ids
+  };
+
+  DiskPageIO(const std::string &index_path, const DiskLayoutGeometry &geom) : geom_(geom) {
+    page_buf_ =
+        static_cast<char *>(alaya::laser::memory::align_allocate<kSectorLen>(geom_.page_size));
+    try {
+      open_rw(index_path);  // sets fd_ + file_size_
+    } catch (...) {
+      alaya::laser::memory::align_free(page_buf_);
+      page_buf_ = nullptr;
+      throw;
+    }
+  }
+
+  ~DiskPageIO() {
+    close_fd();
+    if (page_buf_ != nullptr) {
+      alaya::laser::memory::align_free(page_buf_);
+      page_buf_ = nullptr;
+    }
+  }
+
+  DiskPageIO(const DiskPageIO &) = delete;
+  DiskPageIO &operator=(const DiskPageIO &) = delete;
+  DiskPageIO(DiskPageIO &&) = delete;
+  DiskPageIO &operator=(DiskPageIO &&) = delete;
+
+  /// Read the full node record (coords + neighbors) of @p id.
+  NodeData read_node(uint32_t id) {
+    read_page(id);
+    const NodeRecordView view{page_buf_ + geom_.offset_to_node(id), geom_.dim};
+    NodeData d;
+    d.coords.assign(view.coords(), view.coords() + geom_.dim);
+    const uint32_t n = view.n_nbrs();
+    d.nbrs.assign(view.nbrs(), view.nbrs() + n);
+    return d;
+  }
+
+  /// Write a complete node record `[coords | n_nbrs | nbr_ids]`. Read-modify-write
+  /// that preserves co-resident nodes; extends the file for a new-append slot.
+  void write_node(uint32_t id, const float *coords, uint32_t n_nbrs, const uint32_t *nbr_ids) {
+    if (n_nbrs > geom_.max_degree) {
+      throw std::invalid_argument("DiskPageIO::write_node: n_nbrs exceeds max_degree");
+    }
+    load_page_for_write(id);
+    char *rec = page_buf_ + geom_.offset_to_node(id);
+    std::memset(rec, 0, geom_.node_len);  // clear stale bytes (esp. a reused slot's tail)
+    pack_node_record(rec, coords, nbr_ids, n_nbrs, geom_.dim);
+    write_page(id);
+    vec_cache_[id].assign(coords, coords + geom_.dim);  // keep the coords cache coherent
+  }
+
+  /// Overwrite only the `n_nbrs` + `nbr_ids` fields, leaving coords untouched.
+  void write_node_neighbors(uint32_t id, uint32_t n_nbrs, const uint32_t *nbr_ids) {
+    if (n_nbrs > geom_.max_degree) {
+      throw std::invalid_argument("DiskPageIO::write_node_neighbors: n_nbrs exceeds max_degree");
+    }
+    read_page(id);  // must read first to preserve coords + co-resident nodes
+    char *rec = page_buf_ + geom_.offset_to_node(id);
+    const uint64_t coords_bytes = geom_.dim * sizeof(float);
+    // Zero the whole neighbor region first so no stale trailing ids survive.
+    std::memset(rec + coords_bytes, 0, geom_.node_len - coords_bytes);
+    std::memcpy(rec + coords_bytes, &n_nbrs, sizeof(n_nbrs));
+    if (n_nbrs > 0) {
+      std::memcpy(rec + coords_bytes + sizeof(uint32_t),
+                  nbr_ids,
+                  static_cast<size_t>(n_nbrs) * sizeof(uint32_t));
+    }
+    write_page(id);
+  }
+
+  /// Coords of @p id, served from the transient cache when present (design D8).
+  /// The reference is valid until the next clear_cache() / write_node(id).
+  const std::vector<float> &read_coords_cached(uint32_t id) {
+    auto it = vec_cache_.find(id);
+    if (it != vec_cache_.end()) {
+      return it->second;
+    }
+    read_page(id);
+    const NodeRecordView view{page_buf_ + geom_.offset_to_node(id), geom_.dim};
+    auto res = vec_cache_.emplace(id, std::vector<float>(view.coords(), view.coords() + geom_.dim));
+    return res.first->second;
+  }
+
+  /// Drop the transient coords cache (call between independent update operations).
+  void clear_cache() { vec_cache_.clear(); }
+
+  [[nodiscard]] uint64_t file_size() const { return file_size_; }
+  [[nodiscard]] const DiskLayoutGeometry &geometry() const { return geom_; }
+
+ private:
+  /// Ensure the page holding @p id exists, with page_buf_ holding its current
+  /// content (existing page: RMW) or zeros (freshly extended page).
+  void load_page_for_write(uint32_t id) {
+    const uint64_t page_off = geom_.get_page_offset(id);
+    const uint64_t page_end = page_off + geom_.page_size;
+    if (page_end <= file_size_) {
+      read_page(id);
+    } else {
+      extend_to(page_end);                         // ftruncate; OS zero-fills the new region
+      std::memset(page_buf_, 0, geom_.page_size);  // fresh in-memory page
+    }
+  }
+
+  // ---- platform-gated syscalls (Linux O_DIRECT) ----
+  void open_rw(const std::string &path);
+  void read_page(uint32_t id);
+  void write_page(uint32_t id);
+  void extend_to(uint64_t new_size);
+  void close_fd();
+
+  DiskLayoutGeometry geom_;
+  int fd_ = -1;
+  uint64_t file_size_ = 0;
+  char *page_buf_ = nullptr;
+  std::unordered_map<uint32_t, std::vector<float>> vec_cache_;
+};
+
+#if defined(__linux__)
+
+inline void DiskPageIO::open_rw(const std::string &path) {
+  fd_ = ::open(path.c_str(), O_DIRECT | O_RDWR);  // NOLINT(hicpp-vararg)
+  if (fd_ < 0) {
+    throw std::runtime_error("DiskPageIO::open_rw: cannot open (O_DIRECT|O_RDWR) " + path);
+  }
+  struct stat st{};
+  if (::fstat(fd_, &st) != 0) {
+    ::close(fd_);
+    fd_ = -1;
+    throw std::runtime_error("DiskPageIO::open_rw: fstat failed " + path);
+  }
+  file_size_ = static_cast<uint64_t>(st.st_size);
+}
+
+inline void DiskPageIO::read_page(uint32_t id) {
+  const uint64_t off = geom_.get_page_offset(id);
+  const ssize_t r = ::pread(fd_, page_buf_, geom_.page_size, static_cast<off_t>(off));
+  if (r != static_cast<ssize_t>(geom_.page_size)) {
+    throw std::runtime_error("DiskPageIO::read_page: short/failed pread at " + std::to_string(off) +
+                             " (got " + std::to_string(r) + ")");
+  }
+}
+
+inline void DiskPageIO::write_page(uint32_t id) {
+  const uint64_t off = geom_.get_page_offset(id);
+  const ssize_t w = ::pwrite(fd_, page_buf_, geom_.page_size, static_cast<off_t>(off));
+  if (w != static_cast<ssize_t>(geom_.page_size)) {
+    throw std::runtime_error("DiskPageIO::write_page: short/failed pwrite at " +
+                             std::to_string(off) + " (got " + std::to_string(w) + ")");
+  }
+}
+
+inline void DiskPageIO::extend_to(uint64_t new_size) {
+  if (::ftruncate(fd_, static_cast<off_t>(new_size)) != 0) {
+    throw std::runtime_error("DiskPageIO::extend_to: ftruncate failed to " +
+                             std::to_string(new_size));
+  }
+  file_size_ = new_size;
+}
+
+inline void DiskPageIO::close_fd() {
+  if (fd_ >= 0) {
+    ::close(fd_);
+    fd_ = -1;
+  }
+}
+
+#else  // !__linux__ : in-place updates require Linux O_DIRECT — fail loudly when used.
+
+inline void DiskPageIO::open_rw(const std::string &) {
+  throw std::runtime_error("DiskPageIO: in-place DiskANN updates require Linux (O_DIRECT)");
+}
+inline void DiskPageIO::read_page(uint32_t) {
+  throw std::runtime_error("DiskPageIO: unsupported platform (needs Linux O_DIRECT)");
+}
+inline void DiskPageIO::write_page(uint32_t) {
+  throw std::runtime_error("DiskPageIO: unsupported platform (needs Linux O_DIRECT)");
+}
+inline void DiskPageIO::extend_to(uint64_t) {
+  throw std::runtime_error("DiskPageIO: unsupported platform (needs Linux O_DIRECT)");
+}
+inline void DiskPageIO::close_fd() {}
+
+#endif  // __linux__
+
+}  // namespace alaya::diskann

--- a/include/index/graph/diskann/disk_update_context.hpp
+++ b/include/index/graph/diskann/disk_update_context.hpp
@@ -35,22 +35,19 @@ struct DiskUpdateContext {
   /// data no longer describes the node now living in the slot.
   void forget_slot(uint32_t slot) { removed_node_nbrs_.erase(slot); }
 
-  /// Fraction of @p total slots that are currently tombstoned (0 when total==0).
-  [[nodiscard]] double tombstone_ratio(uint64_t total) const {
-    if (total == 0) {
-      return 0.0;
-    }
-    return static_cast<double>(removed_node_nbrs_.size()) / static_cast<double>(total);
-  }
-
   /// True when the safety-net proactive reconnect should fire: the tombstone
   /// ratio has reached @p ratio_threshold AND no insert-driven reconnect has run
   /// for at least @p ops_threshold operations (delete-heavy workload).
   [[nodiscard]] bool needs_safety_net_reconnect(double ratio_threshold,
+                                                uint64_t tombstone_count,
                                                 uint64_t total,
                                                 uint64_t ops_since_last_insert,
                                                 uint64_t ops_threshold) const {
-    return ops_since_last_insert >= ops_threshold && tombstone_ratio(total) >= ratio_threshold;
+    if (total == 0) {
+      return false;
+    }
+    const double ratio = static_cast<double>(tombstone_count) / static_cast<double>(total);
+    return ops_since_last_insert >= ops_threshold && ratio >= ratio_threshold;
   }
 };
 

--- a/include/index/graph/diskann/disk_update_context.hpp
+++ b/include/index/graph/diskann/disk_update_context.hpp
@@ -15,7 +15,6 @@
 
 #include <cstdint>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace alaya::diskann {
@@ -23,31 +22,25 @@ namespace alaya::diskann {
 struct DiskUpdateContext {
   /// Reverse edges queued for a node's next reconnect (node id -> new neighbor ids).
   std::unordered_map<uint32_t, std::vector<uint32_t>> inserted_edges_;
-  /// Internal ids currently tombstoned (with cached old neighbors available).
-  std::unordered_set<uint32_t> removed_vertices_;
   /// Old neighbor list of each deleted node, for two-hop bypass.
   std::unordered_map<uint32_t, std::vector<uint32_t>> removed_node_nbrs_;
 
   /// Drop all transient state (e.g. after flush, or on teardown).
   void clear() {
     inserted_edges_.clear();
-    removed_vertices_.clear();
     removed_node_nbrs_.clear();
   }
 
   /// Forget a slot that has just been reused by an insert: its cached two-hop
   /// data no longer describes the node now living in the slot.
-  void forget_slot(uint32_t slot) {
-    removed_vertices_.erase(slot);
-    removed_node_nbrs_.erase(slot);
-  }
+  void forget_slot(uint32_t slot) { removed_node_nbrs_.erase(slot); }
 
   /// Fraction of @p total slots that are currently tombstoned (0 when total==0).
   [[nodiscard]] double tombstone_ratio(uint64_t total) const {
     if (total == 0) {
       return 0.0;
     }
-    return static_cast<double>(removed_vertices_.size()) / static_cast<double>(total);
+    return static_cast<double>(removed_node_nbrs_.size()) / static_cast<double>(total);
   }
 
   /// True when the safety-net proactive reconnect should fire: the tombstone

--- a/include/index/graph/diskann/disk_update_context.hpp
+++ b/include/index/graph/diskann/disk_update_context.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * @file disk_update_context.hpp
+ * @brief Transient bookkeeping for in-place DiskANN updates.
+ *
+ * Tracks reverse edges for reconnect and cached old neighbors for two-hop
+ * bypass through tombstoned nodes. Reused slots must call forget_slot() to
+ * evict stale two-hop data.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace alaya::diskann {
+
+struct DiskUpdateContext {
+  /// Reverse edges queued for a node's next reconnect (node id -> new neighbor ids).
+  std::unordered_map<uint32_t, std::vector<uint32_t>> inserted_edges_;
+  /// Internal ids currently tombstoned (with cached old neighbors available).
+  std::unordered_set<uint32_t> removed_vertices_;
+  /// Old neighbor list of each deleted node, for two-hop bypass.
+  std::unordered_map<uint32_t, std::vector<uint32_t>> removed_node_nbrs_;
+
+  /// Drop all transient state (e.g. after flush, or on teardown).
+  void clear() {
+    inserted_edges_.clear();
+    removed_vertices_.clear();
+    removed_node_nbrs_.clear();
+  }
+
+  /// Forget a slot that has just been reused by an insert: its cached two-hop
+  /// data no longer describes the node now living in the slot.
+  void forget_slot(uint32_t slot) {
+    removed_vertices_.erase(slot);
+    removed_node_nbrs_.erase(slot);
+  }
+
+  /// Fraction of @p total slots that are currently tombstoned (0 when total==0).
+  [[nodiscard]] double tombstone_ratio(uint64_t total) const {
+    if (total == 0) {
+      return 0.0;
+    }
+    return static_cast<double>(removed_vertices_.size()) / static_cast<double>(total);
+  }
+
+  /// True when the safety-net proactive reconnect should fire: the tombstone
+  /// ratio has reached @p ratio_threshold AND no insert-driven reconnect has run
+  /// for at least @p ops_threshold operations (delete-heavy workload).
+  [[nodiscard]] bool needs_safety_net_reconnect(double ratio_threshold,
+                                                uint64_t total,
+                                                uint64_t ops_since_last_insert,
+                                                uint64_t ops_threshold) const {
+    return ops_since_last_insert >= ops_threshold && tombstone_ratio(total) >= ratio_threshold;
+  }
+};
+
+}  // namespace alaya::diskann

--- a/include/index/graph/diskann/diskann_index.hpp
+++ b/include/index/graph/diskann/diskann_index.hpp
@@ -34,19 +34,27 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include "index/graph/diskann/beam_search.hpp"
 #include "index/graph/diskann/disk_layout.hpp"
+#include "index/graph/diskann/disk_page_io.hpp"
+#include "index/graph/diskann/disk_update_context.hpp"
 #include "index/graph/diskann/node_cache.hpp"
 #include "index/graph/diskann/pq_table.hpp"
 #include "index/graph/diskann/search_scratch.hpp"
+#include "index/graph/diskann/slot_allocator.hpp"
+#include "index/graph/diskann/tombstone_bitmap.hpp"
 #include "index/graph/laser/utils/aligned_file_reader_factory.hpp"
 #include "index/graph/laser/utils/concurrent_queue.hpp"
+#include "index/graph/vamana/robust_prune.hpp"
 #include "index/graph/vamana/vamana_builder.hpp"
+#include "simd/distance_l2.hpp"
 
 namespace alaya::diskann {
 
@@ -74,6 +82,13 @@ struct DiskANNLoadParams {
                                ///< deeper pipeline overlaps more I/O. Explicit values are floored
                                ///< at 2*beam_width and capped at the libaio context size (1024).
                                ///< Sizes the sector scratch to that many pages per thread.
+
+  // --- In-place update mode (No-PQ only; see disk-update specs) ---
+  bool updatable = false;          ///< open O_RDWR + enable insert/remove/update_node/flush
+  uint32_t update_search_l = 100;  ///< L for the insert NN-search (candidate pool before prune)
+  float update_alpha = 1.2f;       ///< alpha-RNG pruning for insert/reconnect (Vamana default)
+  double safety_net_ratio = 0.05;  ///< tombstone ratio that arms the safety-net reconnect
+  uint64_t safety_net_ops = 16;    ///< deletes without an insert before the safety net may fire
 };
 
 /// Per-query search configuration.
@@ -90,7 +105,8 @@ struct DiskANNSearchParams {
 class DiskANNIndex {
  public:
   static constexpr uint64_t kMetaMagic = 0x414C594144534B4EULL;  // "ALYADSKN"
-  static constexpr uint32_t kMetaVersion = 1;
+  /// v2 adds max_slot_id + live_count for in-place updates; v1 is read back-compat.
+  static constexpr uint32_t kMetaVersion = 2;
   /// Default No-PQ async pipeline depth when DiskANNLoadParams::nopq_io_depth == 0.
   /// Benchmark-tuned on SIFT1M/NVMe (knee at ~32; deeper gives no gain).
   static constexpr uint32_t kDefaultNoPQIoDepth = 32;
@@ -212,6 +228,8 @@ class DiskANNIndex {
     meta.pq_n_chunks = params.pq_n_chunks;
     meta.node_len = geom.node_len;
     meta.nodes_per_sector = geom.nodes_per_sector;
+    meta.max_slot_id = n;  // fresh build: file capacity == num_points
+    meta.live_count = n;   // fresh build: every slot is live
     write_meta(path(index_dir, "meta.bin"), meta);
 
     dir_guard.committed = true;  // build complete — keep the directory
@@ -232,12 +250,14 @@ class DiskANNIndex {
     medoid_ = meta.medoid;
     has_pq_ = meta.has_pq != 0;
     pq_n_chunks_ = meta.pq_n_chunks;
+    max_slot_id_ = meta.max_slot_id;  // file capacity (slots); == num_points for static/v1
+    live_count_ = meta.live_count;    // live nodes; == num_points for static/v1
     geom_ = DiskLayoutGeometry::compute(dim_, max_degree_);
     if (geom_.node_len != meta.node_len || geom_.nodes_per_sector != meta.nodes_per_sector) {
       throw std::runtime_error("DiskANNIndex::load: meta geometry inconsistent");
     }
 
-    read_ids(path(index_dir, "ids.bin"), num_points_);
+    read_ids(path(index_dir, "ids.bin"), max_slot_id_);
     cache_.load(path(index_dir, "cache_ids.bin"), path(index_dir, "cache_nodes.bin"));
     if (has_pq_) {
       pq_.load(path(index_dir, "pq_pivots.bin"),
@@ -289,6 +309,10 @@ class DiskANNIndex {
       thread_data_pool_.push(p);
     }
     num_pool_ = pool;
+
+    if (params.updatable) {
+      init_updatable(index_dir, params);
+    }
     loaded_ = true;
   }
 
@@ -317,6 +341,11 @@ class DiskANNIndex {
       throw std::invalid_argument("DiskANNIndex::search: null output buffers");
     }
 
+    std::unique_lock<std::mutex> serial_lock;
+    if (updatable_) {
+      serial_lock = std::unique_lock<std::mutex>(update_mutex_);
+    }
+
     ThreadData *td = acquire();
     uint32_t count = 0;
     try {
@@ -326,7 +355,10 @@ class DiskANNIndex {
       ctx.cache = &cache_;
       ctx.pq = has_pq_ ? &pq_ : nullptr;
       ctx.medoid = medoid_;
-      ctx.num_points = num_points_;
+      ctx.num_points = max_slot_id_;
+      if (updatable_) {
+        ctx.tombstone = &slot_alloc_.tombstone();
+      }
 
       SearchParams sp;
       sp.search_list_size = params.search_list_size;
@@ -415,15 +447,174 @@ class DiskANNIndex {
   }
 
   // --------------------------------------------------------------- accessors
-  [[nodiscard]] uint64_t size() const { return num_points_; }
+  [[nodiscard]] uint64_t size() const { return live_count_; }  // live (non-tombstoned) vectors
   [[nodiscard]] uint64_t dim() const { return dim_; }
   [[nodiscard]] bool has_pq() const { return has_pq_; }
   [[nodiscard]] uint32_t medoid() const { return medoid_; }
+  [[nodiscard]] bool updatable() const { return updatable_; }
+  [[nodiscard]] uint64_t live_count() const { return live_count_; }
+  [[nodiscard]] uint64_t max_slot_id() const { return max_slot_id_; }
+  [[nodiscard]] uint64_t tombstone_count() const { return slot_alloc_.tombstone_count(); }
+  [[nodiscard]] uint64_t free_slot_count() const { return slot_alloc_.free_count(); }
+  [[nodiscard]] uint64_t safety_net_fire_count() const { return safety_net_fires_; }
+  [[nodiscard]] bool is_deleted(uint32_t id) const { return slot_alloc_.is_deleted(id); }
 
   /// Sentinel label for padded (missing) result slots.
   static constexpr uint64_t kNoLabel = std::numeric_limits<uint64_t>::max();
 
+  // ------------------------------------------------------- in-place updates
+  /// Insert a vector: NN search -> alpha-RNG prune -> alloc slot -> write ->
+  /// reconnect pruned neighbors. Returns the allocated internal slot id.
+  uint32_t insert(const float *query, uint64_t label) {
+    if (!updatable_) {
+      throw std::runtime_error("DiskANNIndex::insert: index not loaded in updatable mode");
+    }
+    if (query == nullptr) {
+      throw std::invalid_argument("DiskANNIndex::insert: null query");
+    }
+    std::lock_guard<std::mutex> lock(update_mutex_);
+    page_io_->clear_cache();
+    const auto l2 = alaya::simd::get_l2_sqr_func();
+
+    const auto cand = run_update_search(query, update_search_l_);
+
+    std::vector<alaya::vamana::Neighbor> pool;
+    pool.reserve(cand.size());
+    for (const auto &c : cand) {
+      pool.emplace_back(c.first, c.second);
+    }
+    std::vector<uint32_t> pruned;
+    std::vector<float> occlude_scratch;
+    auto dist_fn = [this, &l2](uint32_t a, uint32_t b) -> float {
+      const std::vector<float> &ca = page_io_->read_coords_cached(a);
+      const std::vector<float> &cb = page_io_->read_coords_cached(b);
+      return l2(ca.data(), cb.data(), dim_);
+    };
+    const uint32_t maxc = std::max<uint32_t>(max_degree_, static_cast<uint32_t>(pool.size()));
+    alaya::vamana::prune_neighbors(kNoSelf,
+                                   pool,
+                                   update_alpha_,
+                                   max_degree_,
+                                   maxc,
+                                   pruned,
+                                   occlude_scratch,
+                                   dist_fn);
+
+    const uint32_t slot = slot_alloc_.alloc();
+    update_ctx_.forget_slot(slot);
+    max_slot_id_ = std::max<uint64_t>(max_slot_id_, slot_alloc_.next_fresh_id());
+
+    page_io_->write_node(slot, query, static_cast<uint32_t>(pruned.size()), pruned.data());
+
+    set_label(slot, label);
+    ++live_count_;
+    ops_since_last_insert_ = 0;
+
+    for (const uint32_t n : pruned) {
+      update_ctx_.inserted_edges_[n].push_back(slot);
+    }
+    for (const uint32_t n : pruned) {
+      update_node_impl(n);
+    }
+    return slot;
+  }
+
+  /// Lazy-delete: cache old neighbors for two-hop, tombstone + free the slot.
+  /// Reconnect is deferred to the next insert or the safety net.
+  void remove(uint32_t internal_id) {
+    if (!updatable_) {
+      throw std::runtime_error("DiskANNIndex::remove: index not loaded in updatable mode");
+    }
+    std::lock_guard<std::mutex> lock(update_mutex_);
+    if (internal_id >= max_slot_id_) {
+      throw std::invalid_argument("DiskANNIndex::remove: internal_id out of range");
+    }
+    if (slot_alloc_.is_deleted(internal_id)) {
+      throw std::invalid_argument("DiskANNIndex::remove: node already deleted");
+    }
+    page_io_->clear_cache();
+
+    // 1. Read coords + old neighbors before tombstoning.
+    const DiskPageIO::NodeData nd = page_io_->read_node(internal_id);
+    update_ctx_.removed_node_nbrs_[internal_id] = nd.nbrs;
+    update_ctx_.removed_vertices_.insert(internal_id);
+
+    // 2. Tombstone + free slot.
+    slot_alloc_.free(internal_id);
+    --live_count_;
+    ++ops_since_last_insert_;
+
+    // 3. IP-DiskANN: search around deleted point for repair candidates.
+    const auto cand = run_update_search(nd.coords.data(), update_search_l_);
+    std::vector<uint32_t> candidates;
+    candidates.reserve(cand.size());
+    for (const auto &c : cand) {
+      candidates.push_back(c.first);
+    }
+
+    // 4. Nodes to reconnect = old neighbors ∪ search results (live only).
+    std::unordered_set<uint32_t> nodes_to_upd;
+    for (const uint32_t nbr : nd.nbrs) {
+      if (!slot_alloc_.is_deleted(nbr)) {
+        nodes_to_upd.insert(nbr);
+      }
+    }
+    for (const uint32_t c : candidates) {
+      if (!slot_alloc_.is_deleted(c)) {
+        nodes_to_upd.insert(c);
+      }
+    }
+
+    // 5. IP-DiskANN reconnect: each affected node gets c replacement edges.
+    page_io_->clear_cache();
+    for (const uint32_t nid : nodes_to_upd) {
+      update_node_ipdiskann(nid, candidates);
+    }
+    maybe_safety_net_reconnect();
+  }
+
+  /**
+   * @brief Reconnect @p node_id's neighbor list in place (Yi's connect-task).
+   * @throws std::invalid_argument if @p node_id is out of range.
+   */
+  void update_node(uint32_t node_id) {
+    if (!updatable_) {
+      throw std::runtime_error("DiskANNIndex::update_node: index not loaded in updatable mode");
+    }
+    std::lock_guard<std::mutex> lock(update_mutex_);
+    if (node_id >= max_slot_id_) {
+      throw std::invalid_argument("DiskANNIndex::update_node: node_id out of range");
+    }
+    page_io_->clear_cache();
+    update_node_impl(node_id);
+  }
+
+  /// Persist meta + ids + slot allocator state to disk.
+  void flush() {
+    if (!updatable_) {
+      throw std::runtime_error("DiskANNIndex::flush: index not loaded in updatable mode");
+    }
+    std::lock_guard<std::mutex> lock(update_mutex_);
+    MetaHeader m;
+    m.num_points = max_slot_id_;
+    m.dim = dim_;
+    m.max_degree = max_degree_;
+    m.medoid = medoid_;
+    m.has_pq = 0;
+    m.pq_n_chunks = 0;
+    m.node_len = geom_.node_len;
+    m.nodes_per_sector = geom_.nodes_per_sector;
+    m.max_slot_id = max_slot_id_;
+    m.live_count = live_count_;
+    write_meta(path(index_dir_, "meta.bin"), m);
+    write_ids(path(index_dir_, "ids.bin"), labels_.data(), labels_.size());
+    slot_alloc_.save(path(index_dir_, "slots.bin"));
+  }
+
  private:
+  static constexpr uint32_t kNoSelf = std::numeric_limits<uint32_t>::max();
+  static constexpr uint32_t kIPDiskANNCopies = 3;
+
   struct MetaHeader {
     uint64_t num_points = 0;
     uint64_t dim = 0;
@@ -433,10 +624,286 @@ class DiskANNIndex {
     uint32_t pq_n_chunks = 0;
     uint64_t node_len = 0;
     uint64_t nodes_per_sector = 0;
+    uint64_t max_slot_id = 0;  // v2: file capacity in slots (only grows)
+    uint64_t live_count = 0;   // v2: num_points minus tombstones
   };
 
   static std::string path(const std::string &dir, const char *name) {
     return (std::filesystem::path(dir) / name).string();
+  }
+
+  // ---- in-place update internals (all called under update_mutex_) ----
+
+  /// Wire up the update subsystem (page IO, slot allocator, context, config).
+  void init_updatable(const std::string &index_dir, const DiskANNLoadParams &params) {
+    if (has_pq_) {
+      throw std::runtime_error(
+          "DiskANNIndex::load: updatable mode requires a No-PQ index (PQ updates unsupported)");
+    }
+    index_dir_ = index_dir;
+    update_alpha_ = params.update_alpha;
+    update_search_l_ = std::max<uint32_t>(1, params.update_search_l);
+    safety_net_ratio_ = params.safety_net_ratio;
+    safety_net_ops_ = params.safety_net_ops;
+    safety_net_fires_ = 0;
+    ops_since_last_insert_ = 0;
+    update_ctx_.clear();
+
+    page_io_ = std::make_unique<DiskPageIO>(path(index_dir, "diskann.index"), geom_);
+
+    const std::string slots_path = path(index_dir, "slots.bin");
+    if (std::filesystem::exists(slots_path)) {
+      slot_alloc_.load(slots_path);  // restore free list + next id + tombstones
+      max_slot_id_ = std::max<uint64_t>(max_slot_id_, slot_alloc_.next_fresh_id());
+    } else {
+      slot_alloc_.reset(static_cast<uint32_t>(max_slot_id_));
+    }
+    updatable_ = true;
+  }
+
+  /// Tombstone-aware exact-L2 NN search returning up to @p l (id, dist) candidates.
+  std::vector<std::pair<uint32_t, float>> run_update_search(const float *query, uint32_t l) {
+    ThreadData *td = acquire();
+    std::vector<std::pair<uint32_t, float>> results;
+    try {
+      SearchContext ctx;
+      ctx.reader = reader_.get();
+      ctx.geom = &geom_;
+      ctx.cache = &cache_;
+      ctx.pq = nullptr;
+      ctx.medoid = medoid_;
+      ctx.num_points = max_slot_id_;
+      ctx.tombstone = &slot_alloc_.tombstone();
+      SearchParams sp;
+      sp.search_list_size = l;
+      sp.beam_width = beam_width_;
+      sp.use_pq = false;
+      sp.rerank = false;
+      sp.deterministic = true;  // reproducible graph construction
+      results = disk_greedy_search(ctx, query, l, sp, *td, nullptr);
+    } catch (...) {
+      release(td);
+      throw;
+    }
+    release(td);
+    return results;
+  }
+
+  /// Reconnect node_id's neighbor list: candidates = live old + two-hop through
+  /// deleted + inserted reverse edges, exact-L2 ranked, alpha-RNG pruned.
+  void update_node_impl(uint32_t node_id) {
+    const auto l2 = alaya::simd::get_l2_sqr_func();
+    const DiskPageIO::NodeData nd = page_io_->read_node(node_id);
+
+    std::unordered_set<uint32_t> cand;
+    for (const uint32_t nbr : nd.nbrs) {
+      if (nbr == node_id) {
+        continue;
+      }
+      if (slot_alloc_.is_deleted(nbr)) {
+        const auto it = update_ctx_.removed_node_nbrs_.find(nbr);
+        if (it != update_ctx_.removed_node_nbrs_.end()) {
+          for (const uint32_t o : it->second) {  // two-hop: live old neighbors of the dead node
+            if (o != node_id && !slot_alloc_.is_deleted(o)) {
+              cand.insert(o);
+            }
+          }
+        }
+      } else {
+        cand.insert(nbr);  // live old neighbor
+      }
+    }
+    const auto ins_it = update_ctx_.inserted_edges_.find(node_id);
+    if (ins_it != update_ctx_.inserted_edges_.end()) {
+      for (const uint32_t v : ins_it->second) {
+        if (v != node_id && !slot_alloc_.is_deleted(v)) {
+          cand.insert(v);
+        }
+      }
+    }
+
+    if (!cand.empty()) {
+      const std::vector<float> self_coords = page_io_->read_coords_cached(node_id);  // copy
+      std::vector<alaya::vamana::Neighbor> pool;
+      pool.reserve(cand.size());
+      for (const uint32_t c : cand) {
+        const std::vector<float> &cc = page_io_->read_coords_cached(c);
+        pool.emplace_back(c, l2(self_coords.data(), cc.data(), dim_));
+      }
+
+      std::vector<uint32_t> new_nbrs;
+      if (pool.size() <= max_degree_) {
+        std::sort(pool.begin(), pool.end());
+        for (const auto &nb : pool) {
+          new_nbrs.push_back(nb.id);
+        }
+      } else {
+        std::vector<float> occlude_scratch;
+        auto dist_fn = [this, &l2](uint32_t a, uint32_t b) -> float {
+          const std::vector<float> &ca = page_io_->read_coords_cached(a);
+          const std::vector<float> &cb = page_io_->read_coords_cached(b);
+          return l2(ca.data(), cb.data(), dim_);
+        };
+        const uint32_t maxc = static_cast<uint32_t>(pool.size());
+        alaya::vamana::prune_neighbors(node_id,
+                                       pool,
+                                       update_alpha_,
+                                       max_degree_,
+                                       maxc,
+                                       new_nbrs,
+                                       occlude_scratch,
+                                       dist_fn);
+      }
+
+      // No unnecessary disk write when the neighbor set is unchanged.
+      if (!same_neighbor_set(nd.nbrs, new_nbrs)) {
+        page_io_->write_node_neighbors(node_id,
+                                       static_cast<uint32_t>(new_nbrs.size()),
+                                       new_nbrs.data());
+      }
+    }
+
+    if (ins_it != update_ctx_.inserted_edges_.end()) {
+      update_ctx_.inserted_edges_.erase(ins_it);  // consume the reverse edges
+    }
+  }
+
+  /// IP-DiskANN reconnect: keep live old neighbors + c closest candidates, prune.
+  void update_node_ipdiskann(uint32_t node_id, const std::vector<uint32_t> &candidates) {
+    const auto l2 = alaya::simd::get_l2_sqr_func();
+    const DiskPageIO::NodeData nd = page_io_->read_node(node_id);
+
+    std::unordered_set<uint32_t> cand;
+
+    // Live old neighbors.
+    for (const uint32_t nbr : nd.nbrs) {
+      if (nbr != node_id && !slot_alloc_.is_deleted(nbr)) {
+        cand.insert(nbr);
+      }
+    }
+    // Inserted reverse edges.
+    const auto ins_it = update_ctx_.inserted_edges_.find(node_id);
+    if (ins_it != update_ctx_.inserted_edges_.end()) {
+      for (const uint32_t v : ins_it->second) {
+        if (v != node_id && !slot_alloc_.is_deleted(v)) {
+          cand.insert(v);
+        }
+      }
+    }
+    // IP-DiskANN: add closest c candidates from the delete search.
+    const std::vector<float> self_coords = page_io_->read_coords_cached(node_id);
+    std::vector<std::pair<float, uint32_t>> scored;
+    for (const uint32_t c : candidates) {
+      if (c != node_id && !slot_alloc_.is_deleted(c) && cand.find(c) == cand.end()) {
+        const std::vector<float> &cc = page_io_->read_coords_cached(c);
+        scored.emplace_back(l2(self_coords.data(), cc.data(), dim_), c);
+      }
+    }
+    std::sort(scored.begin(), scored.end());
+    for (size_t i = 0; i < std::min<size_t>(kIPDiskANNCopies, scored.size()); ++i) {
+      cand.insert(scored[i].second);
+    }
+
+    if (cand.empty()) {
+      if (ins_it != update_ctx_.inserted_edges_.end()) {
+        update_ctx_.inserted_edges_.erase(ins_it);
+      }
+      return;
+    }
+
+    std::vector<alaya::vamana::Neighbor> pool;
+    pool.reserve(cand.size());
+    for (const uint32_t c : cand) {
+      const std::vector<float> &cc = page_io_->read_coords_cached(c);
+      pool.emplace_back(c, l2(self_coords.data(), cc.data(), dim_));
+    }
+
+    std::vector<uint32_t> new_nbrs;
+    if (pool.size() <= max_degree_) {
+      std::sort(pool.begin(), pool.end());
+      for (const auto &nb : pool) {
+        new_nbrs.push_back(nb.id);
+      }
+    } else {
+      std::vector<float> occlude_scratch;
+      auto dist_fn = [this, &l2](uint32_t a, uint32_t b) -> float {
+        const std::vector<float> &ca = page_io_->read_coords_cached(a);
+        const std::vector<float> &cb = page_io_->read_coords_cached(b);
+        return l2(ca.data(), cb.data(), dim_);
+      };
+      alaya::vamana::prune_neighbors(node_id,
+                                     pool,
+                                     update_alpha_,
+                                     max_degree_,
+                                     static_cast<uint32_t>(pool.size()),
+                                     new_nbrs,
+                                     occlude_scratch,
+                                     dist_fn);
+    }
+
+    if (!same_neighbor_set(nd.nbrs, new_nbrs)) {
+      page_io_->write_node_neighbors(node_id,
+                                     static_cast<uint32_t>(new_nbrs.size()),
+                                     new_nbrs.data());
+    }
+    if (ins_it != update_ctx_.inserted_edges_.end()) {
+      update_ctx_.inserted_edges_.erase(ins_it);
+    }
+  }
+
+  /// Lightweight consolidation: just strip dangling edges to tombstoned nodes.
+  void maybe_safety_net_reconnect() {
+    if (!update_ctx_.needs_safety_net_reconnect(safety_net_ratio_,
+                                                max_slot_id_,
+                                                ops_since_last_insert_,
+                                                safety_net_ops_)) {
+      return;
+    }
+    std::unordered_set<uint32_t> affected;
+    for (const auto &entry : update_ctx_.removed_node_nbrs_) {
+      for (const uint32_t nb : entry.second) {
+        if (!slot_alloc_.is_deleted(nb)) {
+          affected.insert(nb);
+        }
+      }
+    }
+    page_io_->clear_cache();
+    for (const uint32_t nid : affected) {
+      const DiskPageIO::NodeData nd = page_io_->read_node(nid);
+      std::vector<uint32_t> live;
+      for (const uint32_t nbr : nd.nbrs) {
+        if (!slot_alloc_.is_deleted(nbr)) {
+          live.push_back(nbr);
+        }
+      }
+      if (live.size() != nd.nbrs.size()) {
+        page_io_->write_node_neighbors(nid, static_cast<uint32_t>(live.size()), live.data());
+      }
+    }
+    ops_since_last_insert_ = 0;
+    ++safety_net_fires_;
+  }
+
+  /// Grow labels_ on append; assign in place on slot reuse.
+  void set_label(uint32_t slot, uint64_t label) {
+    if (slot >= labels_.size()) {
+      labels_.resize(static_cast<size_t>(slot) + 1, kNoLabel);
+    }
+    labels_[slot] = label;
+  }
+
+  /// Order-independent equality of two neighbor id lists.
+  static bool same_neighbor_set(const std::vector<uint32_t> &a, const std::vector<uint32_t> &b) {
+    if (a.size() != b.size()) {
+      return false;
+    }
+    const std::unordered_set<uint32_t> sa(a.begin(), a.end());
+    for (const uint32_t x : b) {
+      if (sa.find(x) == sa.end()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   ThreadData *acquire() const {
@@ -464,6 +931,9 @@ class DiskANNIndex {
     }
     thread_data_storage_.clear();
     reader_.reset();
+    page_io_.reset();
+    update_ctx_.clear();
+    updatable_ = false;
     loaded_ = false;
   }
 
@@ -488,6 +958,8 @@ class DiskANNIndex {
     w(&m.pq_n_chunks, sizeof(m.pq_n_chunks));
     w(&m.node_len, sizeof(m.node_len));
     w(&m.nodes_per_sector, sizeof(m.nodes_per_sector));
+    w(&m.max_slot_id, sizeof(m.max_slot_id));  // v2
+    w(&m.live_count, sizeof(m.live_count));    // v2
     if (!out) {
       throw std::runtime_error("DiskANNIndex: meta write failed " + p);
     }
@@ -520,7 +992,17 @@ class DiskANNIndex {
     if (magic != kMetaMagic) {
       throw std::runtime_error("DiskANNIndex::load: bad meta magic " + p);
     }
-    if (version != kMetaVersion) {
+    if (version == 1) {
+      // v1 predates in-place updates: every slot is live, capacity == num_points.
+      m.max_slot_id = m.num_points;
+      m.live_count = m.num_points;
+    } else if (version == 2) {
+      r(&m.max_slot_id, sizeof(m.max_slot_id));
+      r(&m.live_count, sizeof(m.live_count));
+      if (!in) {
+        throw std::runtime_error("DiskANNIndex::load: meta.bin truncated/corrupt " + p);
+      }
+    } else {
       throw std::runtime_error("DiskANNIndex::load: unsupported meta version " + p);
     }
     if (m.num_points == 0 || m.dim == 0) {
@@ -581,6 +1063,22 @@ class DiskANNIndex {
   // thread-scratch pool
   std::vector<std::unique_ptr<ThreadData>> thread_data_storage_;
   mutable ::ConcurrentQueue<ThreadData *> thread_data_pool_;
+
+  // in-place update state (active only when updatable_)
+  bool updatable_ = false;
+  uint64_t max_slot_id_ = 0;  ///< file capacity in slots (valid-id bound; only grows)
+  uint64_t live_count_ = 0;   ///< live (non-tombstoned) vector count
+  std::string index_dir_;     ///< saved at load for flush() output paths
+  std::unique_ptr<DiskPageIO> page_io_;
+  SlotAllocator slot_alloc_;
+  DiskUpdateContext update_ctx_;
+  mutable std::mutex update_mutex_;  ///< serialises search + mutation (v1)
+  uint64_t ops_since_last_insert_ = 0;
+  uint64_t safety_net_fires_ = 0;
+  float update_alpha_ = 1.2f;
+  uint32_t update_search_l_ = 100;
+  double safety_net_ratio_ = 0.05;
+  uint64_t safety_net_ops_ = 16;
 };
 
 }  // namespace alaya::diskann

--- a/include/index/graph/diskann/diskann_index.hpp
+++ b/include/index/graph/diskann/diskann_index.hpp
@@ -581,6 +581,9 @@ class DiskANNIndex {
     if (node_id >= max_slot_id_) {
       throw std::invalid_argument("DiskANNIndex::update_node: node_id out of range");
     }
+    if (slot_alloc_.is_deleted(node_id)) {
+      throw std::invalid_argument("DiskANNIndex::update_node: node_id is deleted");
+    }
     page_io_->clear_cache();
     update_node_impl(node_id);
   }
@@ -708,7 +711,7 @@ class DiskANNIndex {
     }
 
     if (!cand.empty()) {
-      const std::vector<float> self_coords = page_io_->read_coords_cached(node_id);
+      const std::vector<float> &self_coords = page_io_->read_coords_cached(node_id);
       const auto l2 = alaya::simd::get_l2_sqr_func();
       std::vector<alaya::vamana::Neighbor> pool;
       pool.reserve(cand.size());
@@ -787,7 +790,7 @@ class DiskANNIndex {
       }
     }
 
-    const std::vector<float> self_coords = page_io_->read_coords_cached(node_id);
+    const std::vector<float> &self_coords = page_io_->read_coords_cached(node_id);
     const auto l2 = alaya::simd::get_l2_sqr_func();
     std::vector<std::pair<float, uint32_t>> scored;
     for (const uint32_t c : candidates) {
@@ -810,6 +813,7 @@ class DiskANNIndex {
   /// Lightweight consolidation: just strip dangling edges to tombstoned nodes.
   void maybe_safety_net_reconnect() {
     if (!update_ctx_.needs_safety_net_reconnect(safety_net_ratio_,
+                                                slot_alloc_.tombstone_count(),
                                                 max_slot_id_,
                                                 ops_since_last_insert_,
                                                 safety_net_ops_)) {
@@ -882,6 +886,8 @@ class DiskANNIndex {
       }
     }
     thread_data_storage_.clear();
+    while (thread_data_pool_.pop() != nullptr) {
+    }
     reader_.reset();
     page_io_.reset();
     update_ctx_.clear();
@@ -1013,7 +1019,7 @@ class DiskANNIndex {
 
   // thread-scratch pool
   std::vector<std::unique_ptr<ThreadData>> thread_data_storage_;
-  mutable ::ConcurrentQueue<ThreadData *> thread_data_pool_;
+  mutable ::ConcurrentQueue<ThreadData *> thread_data_pool_{nullptr};
 
   // in-place update state (active only when updatable_)
   bool updatable_ = false;

--- a/include/index/graph/diskann/diskann_index.hpp
+++ b/include/index/graph/diskann/diskann_index.hpp
@@ -1,0 +1,586 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * @file diskann_index.hpp
+ * @brief Self-contained DiskANN disk index: build / load / search.
+ *
+ * `DiskANNIndex` is an autonomous index class (peer of LASER's QuantizedGraph,
+ * design D1): it builds a Vamana graph in memory, packs it into a sector-aligned
+ * disk layout, optionally trains PQ, and serves cached beam search over the
+ * resulting on-disk index. It does not participate in the segment / disk-
+ * collection subsystem.
+ *
+ * On-disk directory:
+ *   meta.bin           index metadata (this file's MetaHeader)
+ *   diskann.index      sector-aligned graph + vectors (disk_layout.hpp)
+ *   ids.bin            internal-id -> external uint64 label map
+ *   cache_ids.bin      BFS cache node ids        (node_cache.hpp)
+ *   cache_nodes.bin    BFS cache node records
+ *   pq_pivots.bin      PQ global centroid + codebook  (PQ builds only)
+ *   pq_compressed.bin  PQ codes                       (PQ builds only)
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>  // NOLINT(build/c++17)
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "index/graph/diskann/beam_search.hpp"
+#include "index/graph/diskann/disk_layout.hpp"
+#include "index/graph/diskann/node_cache.hpp"
+#include "index/graph/diskann/pq_table.hpp"
+#include "index/graph/diskann/search_scratch.hpp"
+#include "index/graph/laser/utils/aligned_file_reader_factory.hpp"
+#include "index/graph/laser/utils/concurrent_queue.hpp"
+#include "index/graph/vamana/vamana_builder.hpp"
+
+namespace alaya::diskann {
+
+/// Build-time configuration.
+struct DiskANNBuildParams {
+  uint32_t R = 64;            ///< graph degree bound
+  uint32_t L = 100;           ///< Vamana build beam width
+  float alpha = 1.2f;         ///< Vamana α-RNG pruning
+  uint32_t pq_n_chunks = 0;   ///< 0 => no PQ
+  double cache_ratio = 0.05;  ///< BFS cache fraction
+  uint32_t num_threads = 0;   ///< 0 => all cores (Vamana build + PQ train/encode)
+  uint32_t pq_train_iters = 15;
+  uint64_t seed = 1234;
+  bool verbose = false;  ///< print per-phase build wall-times to stderr
+};
+
+/// Load-time configuration (sizes the thread-scratch pool).
+struct DiskANNLoadParams {
+  uint32_t num_threads = 4;    ///< max concurrent searches (ThreadData pool size)
+  uint32_t beam_width = 4;     ///< PQ I/O beam width (PQ caps in-flight reads at this)
+  uint32_t nopq_io_depth = 0;  ///< No-PQ async pipeline depth (max reads in flight); 0 => 32,
+                               ///< the benchmark-tuned default (SIFT1M/NVMe: ~2x single-query
+                               ///< latency cut and +50% 8-thread throughput vs 2*beam_width,
+                               ///< recall unchanged). No-PQ issues thousands of reads/query, so a
+                               ///< deeper pipeline overlaps more I/O. Explicit values are floored
+                               ///< at 2*beam_width and capped at the libaio context size (1024).
+                               ///< Sizes the sector scratch to that many pages per thread.
+};
+
+/// Per-query search configuration.
+struct DiskANNSearchParams {
+  uint32_t search_list_size = 100;  ///< L (retset capacity)
+  bool use_pq = true;               ///< use PQ approx distances (ignored if no PQ)
+  bool rerank = true;               ///< PQ only: re-score top candidates with exact L2
+  uint32_t rerank_count = 0;        ///< PQ rerank pool size; 0 => top_k*3 (spec default)
+  bool deterministic = false;       ///< Reproducible batch==sequential via a per-expansion
+                                    ///< barrier (PQ: per-beam; ~10-15% slower). Default off =
+                                    ///< async-pipelined I/O. Applies to both PQ and No-PQ.
+};
+
+class DiskANNIndex {
+ public:
+  static constexpr uint64_t kMetaMagic = 0x414C594144534B4EULL;  // "ALYADSKN"
+  static constexpr uint32_t kMetaVersion = 1;
+  /// Default No-PQ async pipeline depth when DiskANNLoadParams::nopq_io_depth == 0.
+  /// Benchmark-tuned on SIFT1M/NVMe (knee at ~32; deeper gives no gain).
+  static constexpr uint32_t kDefaultNoPQIoDepth = 32;
+
+  DiskANNIndex() = default;
+  ~DiskANNIndex() { teardown(); }
+
+  DiskANNIndex(const DiskANNIndex &) = delete;
+  DiskANNIndex &operator=(const DiskANNIndex &) = delete;
+  DiskANNIndex(DiskANNIndex &&) = delete;
+  DiskANNIndex &operator=(DiskANNIndex &&) = delete;
+
+  // ------------------------------------------------------------------ build
+  /**
+   * @brief Build a complete index directory from vectors + external labels.
+   * @throws std::invalid_argument for dim==0 / n==0 / null inputs.
+   * @throws std::runtime_error if @p index_dir already exists.
+   */
+  static void build(const std::string &index_dir,
+                    const float *vectors,
+                    const uint64_t *labels,
+                    uint64_t n,
+                    uint64_t dim,
+                    const DiskANNBuildParams &params) {
+    if (dim == 0) {
+      throw std::invalid_argument("DiskANNIndex::build: dim must be > 0");
+    }
+    if (n == 0) {
+      throw std::invalid_argument("DiskANNIndex::build: n must be > 0");
+    }
+    if (vectors == nullptr || labels == nullptr) {
+      throw std::invalid_argument("DiskANNIndex::build: null vectors/labels");
+    }
+    if (params.pq_n_chunks > 0 && dim % params.pq_n_chunks != 0) {
+      throw std::invalid_argument("DiskANNIndex::build: dim not divisible by pq_n_chunks");
+    }
+    namespace fs = std::filesystem;
+    if (fs::exists(index_dir)) {
+      throw std::runtime_error("DiskANNIndex::build: index_dir already exists: " + index_dir);
+    }
+    if (!fs::create_directories(index_dir)) {
+      throw std::runtime_error("DiskANNIndex::build: cannot create " + index_dir);
+    }
+    // Remove the partial directory if any build phase throws, so the failed build
+    // does not block a retry with "index_dir already exists".
+    struct DirGuard {
+      const std::string &dir;
+      bool committed = false;
+      ~DirGuard() {
+        if (!committed) {
+          std::error_code ec;
+          std::filesystem::remove_all(dir, ec);
+        }
+      }
+    } dir_guard{index_dir};
+
+    // Per-phase wall-clock timing (opt-in; mirrors official build_disk_index logging).
+    using clk = std::chrono::steady_clock;
+    auto stamp = [&params](const char *name, clk::time_point a, clk::time_point b) {
+      if (params.verbose) {
+        std::cerr << "[build] " << name << ": " << std::chrono::duration<double>(b - a).count()
+                  << " s\n";
+      }
+    };
+
+    // 1. Vamana graph.
+    auto t_vamana0 = clk::now();
+    alaya::vamana::VamanaBuildParams vparams;
+    vparams.R = params.R;
+    vparams.L = params.L;
+    vparams.alpha = params.alpha;
+    vparams.num_threads = params.num_threads;
+    vparams.seed = params.seed;
+    alaya::vamana::VamanaBuilder builder(vectors, n, static_cast<uint32_t>(dim), vparams);
+    builder.build();
+    const auto &graph = builder.graph();
+    const uint32_t medoid = builder.medoid();
+    auto t_vamana1 = clk::now();
+    stamp("vamana", t_vamana0, t_vamana1);
+
+    const DiskLayoutGeometry geom = DiskLayoutGeometry::compute(dim, params.R);
+
+    // 2. Sector-aligned disk layout.  3. External labels.
+    write_disk_layout(path(index_dir, "diskann.index"), vectors, graph, {n, dim, params.R, medoid});
+    write_ids(path(index_dir, "ids.bin"), labels, n);
+    auto t_layout = clk::now();
+    stamp("layout+ids", t_vamana1, t_layout);
+
+    // 4. Optional PQ.
+    const bool has_pq = params.pq_n_chunks > 0;
+    if (has_pq) {
+      PQTable pq;
+      pq.train(vectors,
+               n,
+               dim,
+               params.pq_n_chunks,
+               params.pq_train_iters,
+               params.seed,
+               params.num_threads);
+      pq.encode(vectors, n, params.num_threads);
+      pq.save(path(index_dir, "pq_pivots.bin"), path(index_dir, "pq_compressed.bin"));
+    }
+    auto t_pq = clk::now();
+    stamp("pq(train+encode+save)", t_layout, t_pq);
+
+    // 5. BFS cache.
+    NodeCache cache;
+    cache.generate(graph, vectors, medoid, n, dim, params.R, params.cache_ratio);
+    cache.save(path(index_dir, "cache_ids.bin"), path(index_dir, "cache_nodes.bin"));
+    stamp("cache", t_pq, clk::now());
+
+    // 6. Metadata.
+    MetaHeader meta;
+    meta.num_points = n;
+    meta.dim = dim;
+    meta.max_degree = params.R;
+    meta.medoid = medoid;
+    meta.has_pq = has_pq ? 1 : 0;
+    meta.pq_n_chunks = params.pq_n_chunks;
+    meta.node_len = geom.node_len;
+    meta.nodes_per_sector = geom.nodes_per_sector;
+    write_meta(path(index_dir, "meta.bin"), meta);
+
+    dir_guard.committed = true;  // build complete — keep the directory
+  }
+
+  // ------------------------------------------------------------------- load
+  void load(const std::string &index_dir, const DiskANNLoadParams &params = {}) {
+    teardown();
+    namespace fs = std::filesystem;
+    if (!fs::exists(index_dir) || !fs::is_directory(index_dir)) {
+      throw std::runtime_error("DiskANNIndex::load: not a directory: " + index_dir);
+    }
+
+    const MetaHeader meta = read_meta(path(index_dir, "meta.bin"));
+    num_points_ = meta.num_points;
+    dim_ = meta.dim;
+    max_degree_ = meta.max_degree;
+    medoid_ = meta.medoid;
+    has_pq_ = meta.has_pq != 0;
+    pq_n_chunks_ = meta.pq_n_chunks;
+    geom_ = DiskLayoutGeometry::compute(dim_, max_degree_);
+    if (geom_.node_len != meta.node_len || geom_.nodes_per_sector != meta.nodes_per_sector) {
+      throw std::runtime_error("DiskANNIndex::load: meta geometry inconsistent");
+    }
+
+    read_ids(path(index_dir, "ids.bin"), num_points_);
+    cache_.load(path(index_dir, "cache_ids.bin"), path(index_dir, "cache_nodes.bin"));
+    if (has_pq_) {
+      pq_.load(path(index_dir, "pq_pivots.bin"),
+               path(index_dir, "pq_compressed.bin"),
+               num_points_,
+               dim_,
+               pq_n_chunks_);
+    }
+
+    // Open the disk index and pre-register one libaio I/O context + scratch
+    // buffer per pool slot. Each context is created on a short-lived
+    // registration thread, then borrowed by whichever search thread pops the
+    // slot. A libaio context is a process-wide handle, and the slot pool
+    // guarantees only one thread uses a given context at a time, so this is safe
+    // (verified by the concurrency stress test). The deterministic beam loop
+    // (beam_search.hpp) makes results independent of I/O completion timing.
+    reader_ = make_aligned_file_reader();
+    reader_->open(path(index_dir, "diskann.index"));
+    beam_width_ = std::max<uint32_t>(1, params.beam_width);
+    const uint32_t pool = std::max<uint32_t>(1, params.num_threads);
+    const uint32_t pq_table_entries = has_pq_ ? pq_n_chunks_ * kPQNumCentroids : 0;
+    // One page slot per concurrent read. nopq_io_depth = 0 resolves to the
+    // benchmark-tuned default (kDefaultNoPQIoDepth = 32); No-PQ issues far more
+    // reads than PQ, so this deeper pipeline overlaps more I/O. Floored at
+    // 2*beam_width (PQ's needs) and capped at MAX_EVENTS (libaio context size).
+    const uint64_t nopq_depth =
+        params.nopq_io_depth == 0 ? kDefaultNoPQIoDepth : params.nopq_io_depth;
+    const uint64_t scratch_slots =
+        std::min<uint64_t>(1024, std::max<uint64_t>(2ull * beam_width_, nopq_depth));
+    thread_data_storage_.resize(pool);
+    {
+      std::vector<std::thread> regs;
+      regs.reserve(pool);
+      for (uint32_t t = 0; t < pool; ++t) {
+        regs.emplace_back([this, t, pq_table_entries, scratch_slots]() {
+          reader_->register_thread();
+          auto td = std::make_unique<ThreadData>();
+          td->ctx_ = reader_->get_ctx();
+          td->alloc_scratch(scratch_slots, geom_.page_size, pq_table_entries);
+          thread_data_storage_[t] = std::move(td);
+        });
+      }
+      for (auto &th : regs) {
+        th.join();
+      }
+    }
+    for (auto &td : thread_data_storage_) {
+      ThreadData *p = td.get();
+      thread_data_pool_.push(p);
+    }
+    num_pool_ = pool;
+    loaded_ = true;
+  }
+
+  // ----------------------------------------------------------------- search
+  /**
+   * @brief Single-query search. Writes up to @p top_k external labels +
+   *        distances (ascending L2) into the caller's buffers.
+   * @return number of results written (<= top_k).
+   */
+  uint32_t search(const float *query,
+                  uint32_t top_k,
+                  uint64_t *out_labels,
+                  float *out_distances,
+                  const DiskANNSearchParams &params = {},
+                  SearchStats *stats = nullptr) const {
+    if (!loaded_) {
+      throw std::runtime_error("DiskANNIndex::search: index not loaded");
+    }
+    if (query == nullptr) {
+      throw std::invalid_argument("DiskANNIndex::search: null query");
+    }
+    if (top_k == 0) {
+      throw std::invalid_argument("DiskANNIndex::search: top_k must be > 0");
+    }
+    if (out_labels == nullptr || out_distances == nullptr) {
+      throw std::invalid_argument("DiskANNIndex::search: null output buffers");
+    }
+
+    ThreadData *td = acquire();
+    uint32_t count = 0;
+    try {
+      SearchContext ctx;
+      ctx.reader = reader_.get();
+      ctx.geom = &geom_;
+      ctx.cache = &cache_;
+      ctx.pq = has_pq_ ? &pq_ : nullptr;
+      ctx.medoid = medoid_;
+      ctx.num_points = num_points_;
+
+      SearchParams sp;
+      sp.search_list_size = params.search_list_size;
+      sp.beam_width = beam_width_;
+      sp.use_pq = params.use_pq && has_pq_;
+      sp.rerank = params.rerank;
+      sp.rerank_count = params.rerank_count;
+      sp.deterministic = params.deterministic;
+
+      const auto results = cached_beam_search(ctx, query, top_k, sp, *td, stats);
+      count = static_cast<uint32_t>(results.size());
+      for (uint32_t i = 0; i < count; ++i) {
+        out_labels[i] = labels_[results[i].first];
+        out_distances[i] = results[i].second;
+      }
+    } catch (...) {
+      release(td);
+      throw;
+    }
+    release(td);
+
+    // Pad unused slots with sentinels so callers can detect short result rows.
+    for (uint32_t i = count; i < top_k; ++i) {
+      out_labels[i] = kNoLabel;
+      out_distances[i] = std::numeric_limits<float>::max();
+    }
+    return count;
+  }
+
+  // ------------------------------------------------------------ batch search
+  /**
+   * @brief Run @p n_queries searches across @p num_threads workers; results are
+   *        written row-major into @p out_labels / @p out_distances
+   *        (n_queries * top_k).
+   */
+  void batch_search(const float *queries,
+                    uint32_t n_queries,
+                    uint32_t top_k,
+                    uint64_t *out_labels,
+                    float *out_distances,
+                    uint32_t num_threads,
+                    const DiskANNSearchParams &params = {}) const {
+    if (!loaded_) {
+      throw std::runtime_error("DiskANNIndex::batch_search: index not loaded");
+    }
+    if (queries == nullptr) {
+      throw std::invalid_argument("DiskANNIndex::batch_search: null queries");
+    }
+    if (top_k == 0) {
+      throw std::invalid_argument("DiskANNIndex::batch_search: top_k must be > 0");
+    }
+
+    auto run_one = [&](uint32_t qi) {
+      search(queries + static_cast<uint64_t>(qi) * dim_,
+             top_k,
+             out_labels + static_cast<uint64_t>(qi) * top_k,
+             out_distances + static_cast<uint64_t>(qi) * top_k,
+             params);
+    };
+
+    const uint32_t workers = std::min(std::max<uint32_t>(1, num_threads), num_pool_);
+    if (workers <= 1) {
+      for (uint32_t qi = 0; qi < n_queries; ++qi) {
+        run_one(qi);
+      }
+      return;
+    }
+
+    std::atomic<uint32_t> next{0};
+    std::vector<std::thread> pool;
+    pool.reserve(workers);
+    for (uint32_t w = 0; w < workers; ++w) {
+      pool.emplace_back([&]() {
+        for (;;) {
+          const uint32_t qi = next.fetch_add(1);
+          if (qi >= n_queries) {
+            break;
+          }
+          run_one(qi);
+        }
+      });
+    }
+    for (auto &th : pool) {
+      th.join();
+    }
+  }
+
+  // --------------------------------------------------------------- accessors
+  [[nodiscard]] uint64_t size() const { return num_points_; }
+  [[nodiscard]] uint64_t dim() const { return dim_; }
+  [[nodiscard]] bool has_pq() const { return has_pq_; }
+  [[nodiscard]] uint32_t medoid() const { return medoid_; }
+
+  /// Sentinel label for padded (missing) result slots.
+  static constexpr uint64_t kNoLabel = std::numeric_limits<uint64_t>::max();
+
+ private:
+  struct MetaHeader {
+    uint64_t num_points = 0;
+    uint64_t dim = 0;
+    uint32_t max_degree = 0;
+    uint32_t medoid = 0;
+    uint8_t has_pq = 0;
+    uint32_t pq_n_chunks = 0;
+    uint64_t node_len = 0;
+    uint64_t nodes_per_sector = 0;
+  };
+
+  static std::string path(const std::string &dir, const char *name) {
+    return (std::filesystem::path(dir) / name).string();
+  }
+
+  ThreadData *acquire() const {
+    ThreadData *td = thread_data_pool_.pop();
+    while (td == nullptr) {
+      thread_data_pool_.wait_for_push_notify();
+      td = thread_data_pool_.pop();
+    }
+    return td;
+  }
+  void release(ThreadData *td) const {
+    thread_data_pool_.push(td);
+    thread_data_pool_.push_notify_all();
+  }
+
+  void teardown() {
+    if (reader_) {
+      reader_->close();
+      reader_->deregister_all_threads();
+    }
+    for (auto &td : thread_data_storage_) {
+      if (td) {
+        td->free_scratch();
+      }
+    }
+    thread_data_storage_.clear();
+    reader_.reset();
+    loaded_ = false;
+  }
+
+  // --- meta.bin / ids.bin serialization ---
+  static void write_meta(const std::string &p, const MetaHeader &m) {
+    std::ofstream out(p, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      throw std::runtime_error("DiskANNIndex: cannot write " + p);
+    }
+    const uint64_t magic = kMetaMagic;
+    const uint32_t version = kMetaVersion;
+    auto w = [&](const void *d, size_t n) {
+      out.write(reinterpret_cast<const char *>(d), n);
+    };
+    w(&magic, sizeof(magic));
+    w(&version, sizeof(version));
+    w(&m.num_points, sizeof(m.num_points));
+    w(&m.dim, sizeof(m.dim));
+    w(&m.max_degree, sizeof(m.max_degree));
+    w(&m.medoid, sizeof(m.medoid));
+    w(&m.has_pq, sizeof(m.has_pq));
+    w(&m.pq_n_chunks, sizeof(m.pq_n_chunks));
+    w(&m.node_len, sizeof(m.node_len));
+    w(&m.nodes_per_sector, sizeof(m.nodes_per_sector));
+    if (!out) {
+      throw std::runtime_error("DiskANNIndex: meta write failed " + p);
+    }
+  }
+
+  static MetaHeader read_meta(const std::string &p) {
+    std::ifstream in(p, std::ios::binary);
+    if (!in) {
+      throw std::runtime_error("DiskANNIndex::load: cannot open meta " + p);
+    }
+    uint64_t magic = 0;
+    uint32_t version = 0;
+    MetaHeader m;
+    auto r = [&](void *d, size_t n) {
+      in.read(reinterpret_cast<char *>(d), n);
+    };
+    r(&magic, sizeof(magic));
+    r(&version, sizeof(version));
+    r(&m.num_points, sizeof(m.num_points));
+    r(&m.dim, sizeof(m.dim));
+    r(&m.max_degree, sizeof(m.max_degree));
+    r(&m.medoid, sizeof(m.medoid));
+    r(&m.has_pq, sizeof(m.has_pq));
+    r(&m.pq_n_chunks, sizeof(m.pq_n_chunks));
+    r(&m.node_len, sizeof(m.node_len));
+    r(&m.nodes_per_sector, sizeof(m.nodes_per_sector));
+    if (!in) {
+      throw std::runtime_error("DiskANNIndex::load: meta.bin truncated/corrupt " + p);
+    }
+    if (magic != kMetaMagic) {
+      throw std::runtime_error("DiskANNIndex::load: bad meta magic " + p);
+    }
+    if (version != kMetaVersion) {
+      throw std::runtime_error("DiskANNIndex::load: unsupported meta version " + p);
+    }
+    if (m.num_points == 0 || m.dim == 0) {
+      throw std::runtime_error("DiskANNIndex::load: zero num_points/dim in meta " + p);
+    }
+    return m;
+  }
+
+  static void write_ids(const std::string &p, const uint64_t *labels, uint64_t n) {
+    std::ofstream out(p, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      throw std::runtime_error("DiskANNIndex: cannot write " + p);
+    }
+    out.write(reinterpret_cast<const char *>(&n), sizeof(n));
+    out.write(reinterpret_cast<const char *>(labels),
+              static_cast<std::streamsize>(n * sizeof(uint64_t)));
+    if (!out) {
+      throw std::runtime_error("DiskANNIndex: ids write failed " + p);
+    }
+  }
+
+  void read_ids(const std::string &p, uint64_t expected_n) {
+    std::ifstream in(p, std::ios::binary);
+    if (!in) {
+      throw std::runtime_error("DiskANNIndex::load: cannot open ids " + p);
+    }
+    uint64_t count = 0;
+    in.read(reinterpret_cast<char *>(&count), sizeof(count));
+    if (!in || count != expected_n) {
+      throw std::runtime_error("DiskANNIndex::load: ids.bin count mismatch " + p);
+    }
+    labels_.assign(count, 0);
+    in.read(reinterpret_cast<char *>(labels_.data()),
+            static_cast<std::streamsize>(count * sizeof(uint64_t)));
+    if (!in) {
+      throw std::runtime_error("DiskANNIndex::load: ids.bin truncated " + p);
+    }
+  }
+
+  // metadata
+  uint64_t num_points_ = 0;
+  uint64_t dim_ = 0;
+  uint32_t max_degree_ = 0;
+  uint32_t medoid_ = 0;
+  bool has_pq_ = false;
+  uint32_t pq_n_chunks_ = 0;
+  uint32_t beam_width_ = 4;
+  uint32_t num_pool_ = 0;
+  bool loaded_ = false;
+  DiskLayoutGeometry geom_;
+
+  // in-memory artifacts
+  std::vector<uint64_t> labels_;
+  NodeCache cache_;
+  PQTable pq_;
+  std::unique_ptr<AlignedFileReader> reader_;
+
+  // thread-scratch pool
+  std::vector<std::unique_ptr<ThreadData>> thread_data_storage_;
+  mutable ::ConcurrentQueue<ThreadData *> thread_data_pool_;
+};
+
+}  // namespace alaya::diskann

--- a/include/index/graph/diskann/diskann_index.hpp
+++ b/include/index/graph/diskann/diskann_index.hpp
@@ -244,7 +244,7 @@ class DiskANNIndex {
     }
 
     const MetaHeader meta = read_meta(path(index_dir, "meta.bin"));
-    num_points_ = meta.num_points;
+    const uint64_t num_points = meta.num_points;
     dim_ = meta.dim;
     max_degree_ = meta.max_degree;
     medoid_ = meta.medoid;
@@ -262,7 +262,7 @@ class DiskANNIndex {
     if (has_pq_) {
       pq_.load(path(index_dir, "pq_pivots.bin"),
                path(index_dir, "pq_compressed.bin"),
-               num_points_,
+               num_points,
                dim_,
                pq_n_chunks_);
     }
@@ -474,7 +474,6 @@ class DiskANNIndex {
     }
     std::lock_guard<std::mutex> lock(update_mutex_);
     page_io_->clear_cache();
-    const auto l2 = alaya::simd::get_l2_sqr_func();
 
     const auto cand = run_update_search(query, update_search_l_);
 
@@ -485,10 +484,8 @@ class DiskANNIndex {
     }
     std::vector<uint32_t> pruned;
     std::vector<float> occlude_scratch;
-    auto dist_fn = [this, &l2](uint32_t a, uint32_t b) -> float {
-      const std::vector<float> &ca = page_io_->read_coords_cached(a);
-      const std::vector<float> &cb = page_io_->read_coords_cached(b);
-      return l2(ca.data(), cb.data(), dim_);
+    auto dist_fn = [this](uint32_t a, uint32_t b) -> float {
+      return cached_l2(a, b);
     };
     const uint32_t maxc = std::max<uint32_t>(max_degree_, static_cast<uint32_t>(pool.size()));
     alaya::vamana::prune_neighbors(kNoSelf,
@@ -537,7 +534,6 @@ class DiskANNIndex {
     // 1. Read coords + old neighbors before tombstoning.
     const DiskPageIO::NodeData nd = page_io_->read_node(internal_id);
     update_ctx_.removed_node_nbrs_[internal_id] = nd.nbrs;
-    update_ctx_.removed_vertices_.insert(internal_id);
 
     // 2. Tombstone + free slot.
     slot_alloc_.free(internal_id);
@@ -689,30 +685,19 @@ class DiskANNIndex {
     return results;
   }
 
-  /// Reconnect node_id's neighbor list: candidates = live old + two-hop through
-  /// deleted + inserted reverse edges, exact-L2 ranked, alpha-RNG pruned.
-  void update_node_impl(uint32_t node_id) {
+  /// Cached L2 distance between two nodes via the page IO coords cache.
+  float cached_l2(uint32_t a, uint32_t b) {
     const auto l2 = alaya::simd::get_l2_sqr_func();
-    const DiskPageIO::NodeData nd = page_io_->read_node(node_id);
+    const std::vector<float> &ca = page_io_->read_coords_cached(a);
+    const std::vector<float> &cb = page_io_->read_coords_cached(b);
+    return l2(ca.data(), cb.data(), dim_);
+  }
 
-    std::unordered_set<uint32_t> cand;
-    for (const uint32_t nbr : nd.nbrs) {
-      if (nbr == node_id) {
-        continue;
-      }
-      if (slot_alloc_.is_deleted(nbr)) {
-        const auto it = update_ctx_.removed_node_nbrs_.find(nbr);
-        if (it != update_ctx_.removed_node_nbrs_.end()) {
-          for (const uint32_t o : it->second) {  // two-hop: live old neighbors of the dead node
-            if (o != node_id && !slot_alloc_.is_deleted(o)) {
-              cand.insert(o);
-            }
-          }
-        }
-      } else {
-        cand.insert(nbr);  // live old neighbor
-      }
-    }
+  /// Shared reconnect backbone: score candidates, prune, write if changed,
+  /// consume inserted_edges for node_id.
+  void prune_and_write(uint32_t node_id,
+                       const std::vector<uint32_t> &old_nbrs,
+                       std::unordered_set<uint32_t> &cand) {
     const auto ins_it = update_ctx_.inserted_edges_.find(node_id);
     if (ins_it != update_ctx_.inserted_edges_.end()) {
       for (const uint32_t v : ins_it->second) {
@@ -723,7 +708,8 @@ class DiskANNIndex {
     }
 
     if (!cand.empty()) {
-      const std::vector<float> self_coords = page_io_->read_coords_cached(node_id);  // copy
+      const std::vector<float> self_coords = page_io_->read_coords_cached(node_id);
+      const auto l2 = alaya::simd::get_l2_sqr_func();
       std::vector<alaya::vamana::Neighbor> pool;
       pool.reserve(cand.size());
       for (const uint32_t c : cand) {
@@ -739,24 +725,20 @@ class DiskANNIndex {
         }
       } else {
         std::vector<float> occlude_scratch;
-        auto dist_fn = [this, &l2](uint32_t a, uint32_t b) -> float {
-          const std::vector<float> &ca = page_io_->read_coords_cached(a);
-          const std::vector<float> &cb = page_io_->read_coords_cached(b);
-          return l2(ca.data(), cb.data(), dim_);
+        auto dist_fn = [this](uint32_t a, uint32_t b) -> float {
+          return cached_l2(a, b);
         };
-        const uint32_t maxc = static_cast<uint32_t>(pool.size());
         alaya::vamana::prune_neighbors(node_id,
                                        pool,
                                        update_alpha_,
                                        max_degree_,
-                                       maxc,
+                                       static_cast<uint32_t>(pool.size()),
                                        new_nbrs,
                                        occlude_scratch,
                                        dist_fn);
       }
 
-      // No unnecessary disk write when the neighbor set is unchanged.
-      if (!same_neighbor_set(nd.nbrs, new_nbrs)) {
+      if (!same_neighbor_set(old_nbrs, new_nbrs)) {
         page_io_->write_node_neighbors(node_id,
                                        static_cast<uint32_t>(new_nbrs.size()),
                                        new_nbrs.data());
@@ -764,34 +746,49 @@ class DiskANNIndex {
     }
 
     if (ins_it != update_ctx_.inserted_edges_.end()) {
-      update_ctx_.inserted_edges_.erase(ins_it);  // consume the reverse edges
+      update_ctx_.inserted_edges_.erase(ins_it);
     }
+  }
+
+  /// Reconnect node_id's neighbor list: candidates = live old + two-hop through
+  /// deleted + inserted reverse edges, exact-L2 ranked, alpha-RNG pruned.
+  void update_node_impl(uint32_t node_id) {
+    const DiskPageIO::NodeData nd = page_io_->read_node(node_id);
+
+    std::unordered_set<uint32_t> cand;
+    for (const uint32_t nbr : nd.nbrs) {
+      if (nbr == node_id) {
+        continue;
+      }
+      if (slot_alloc_.is_deleted(nbr)) {
+        const auto it = update_ctx_.removed_node_nbrs_.find(nbr);
+        if (it != update_ctx_.removed_node_nbrs_.end()) {
+          for (const uint32_t o : it->second) {
+            if (o != node_id && !slot_alloc_.is_deleted(o)) {
+              cand.insert(o);
+            }
+          }
+        }
+      } else {
+        cand.insert(nbr);
+      }
+    }
+    prune_and_write(node_id, nd.nbrs, cand);
   }
 
   /// IP-DiskANN reconnect: keep live old neighbors + c closest candidates, prune.
   void update_node_ipdiskann(uint32_t node_id, const std::vector<uint32_t> &candidates) {
-    const auto l2 = alaya::simd::get_l2_sqr_func();
     const DiskPageIO::NodeData nd = page_io_->read_node(node_id);
 
     std::unordered_set<uint32_t> cand;
-
-    // Live old neighbors.
     for (const uint32_t nbr : nd.nbrs) {
       if (nbr != node_id && !slot_alloc_.is_deleted(nbr)) {
         cand.insert(nbr);
       }
     }
-    // Inserted reverse edges.
-    const auto ins_it = update_ctx_.inserted_edges_.find(node_id);
-    if (ins_it != update_ctx_.inserted_edges_.end()) {
-      for (const uint32_t v : ins_it->second) {
-        if (v != node_id && !slot_alloc_.is_deleted(v)) {
-          cand.insert(v);
-        }
-      }
-    }
-    // IP-DiskANN: add closest c candidates from the delete search.
+
     const std::vector<float> self_coords = page_io_->read_coords_cached(node_id);
+    const auto l2 = alaya::simd::get_l2_sqr_func();
     std::vector<std::pair<float, uint32_t>> scored;
     for (const uint32_t c : candidates) {
       if (c != node_id && !slot_alloc_.is_deleted(c) && cand.find(c) == cand.end()) {
@@ -799,56 +796,15 @@ class DiskANNIndex {
         scored.emplace_back(l2(self_coords.data(), cc.data(), dim_), c);
       }
     }
-    std::sort(scored.begin(), scored.end());
+    std::partial_sort(scored.begin(),
+                      scored.begin() +
+                          static_cast<ptrdiff_t>(std::min<size_t>(kIPDiskANNCopies, scored.size())),
+                      scored.end());
     for (size_t i = 0; i < std::min<size_t>(kIPDiskANNCopies, scored.size()); ++i) {
       cand.insert(scored[i].second);
     }
 
-    if (cand.empty()) {
-      if (ins_it != update_ctx_.inserted_edges_.end()) {
-        update_ctx_.inserted_edges_.erase(ins_it);
-      }
-      return;
-    }
-
-    std::vector<alaya::vamana::Neighbor> pool;
-    pool.reserve(cand.size());
-    for (const uint32_t c : cand) {
-      const std::vector<float> &cc = page_io_->read_coords_cached(c);
-      pool.emplace_back(c, l2(self_coords.data(), cc.data(), dim_));
-    }
-
-    std::vector<uint32_t> new_nbrs;
-    if (pool.size() <= max_degree_) {
-      std::sort(pool.begin(), pool.end());
-      for (const auto &nb : pool) {
-        new_nbrs.push_back(nb.id);
-      }
-    } else {
-      std::vector<float> occlude_scratch;
-      auto dist_fn = [this, &l2](uint32_t a, uint32_t b) -> float {
-        const std::vector<float> &ca = page_io_->read_coords_cached(a);
-        const std::vector<float> &cb = page_io_->read_coords_cached(b);
-        return l2(ca.data(), cb.data(), dim_);
-      };
-      alaya::vamana::prune_neighbors(node_id,
-                                     pool,
-                                     update_alpha_,
-                                     max_degree_,
-                                     static_cast<uint32_t>(pool.size()),
-                                     new_nbrs,
-                                     occlude_scratch,
-                                     dist_fn);
-    }
-
-    if (!same_neighbor_set(nd.nbrs, new_nbrs)) {
-      page_io_->write_node_neighbors(node_id,
-                                     static_cast<uint32_t>(new_nbrs.size()),
-                                     new_nbrs.data());
-    }
-    if (ins_it != update_ctx_.inserted_edges_.end()) {
-      update_ctx_.inserted_edges_.erase(ins_it);
-    }
+    prune_and_write(node_id, nd.nbrs, cand);
   }
 
   /// Lightweight consolidation: just strip dangling edges to tombstoned nodes.
@@ -893,17 +849,13 @@ class DiskANNIndex {
   }
 
   /// Order-independent equality of two neighbor id lists.
-  static bool same_neighbor_set(const std::vector<uint32_t> &a, const std::vector<uint32_t> &b) {
+  static bool same_neighbor_set(std::vector<uint32_t> a, std::vector<uint32_t> b) {
     if (a.size() != b.size()) {
       return false;
     }
-    const std::unordered_set<uint32_t> sa(a.begin(), a.end());
-    for (const uint32_t x : b) {
-      if (sa.find(x) == sa.end()) {
-        return false;
-      }
-    }
-    return true;
+    std::sort(a.begin(), a.end());
+    std::sort(b.begin(), b.end());
+    return a == b;
   }
 
   ThreadData *acquire() const {
@@ -1043,7 +995,6 @@ class DiskANNIndex {
   }
 
   // metadata
-  uint64_t num_points_ = 0;
   uint64_t dim_ = 0;
   uint32_t max_degree_ = 0;
   uint32_t medoid_ = 0;

--- a/include/index/graph/diskann/node_cache.hpp
+++ b/include/index/graph/diskann/node_cache.hpp
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * @file node_cache.hpp
+ * @brief BFS node cache for the DiskANN disk index.
+ *
+ * At build time a BFS from the medoid collects the hottest
+ * @c ceil(cache_ratio * num_points) nodes (those near the entry point, which
+ * every search traverses). Their full records (@c [coords | n_nbrs | nbr_ids],
+ * byte-identical to the on-disk layout) are serialized to @c cache_ids.bin and
+ * @c cache_nodes.bin. At load time the records are read into memory and indexed
+ * for O(1) lookup, so a cache hit during beam search costs zero disk I/O.
+ *
+ * The cache is immutable after generate()/load(); concurrent search threads
+ * only borrow read-only pointers into it.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>  // NOLINT(build/c++17)
+#include <fstream>
+#include <queue>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "index/graph/diskann/disk_layout.hpp"
+
+namespace alaya::diskann {
+
+/**
+ * @brief In-memory cache of hot node records selected by BFS from the medoid.
+ *
+ * Internally the id->record index stores byte offsets into @c node_data_ (not
+ * raw pointers), so the structure stays valid across vector growth and moves;
+ * lookup() resolves an offset to a borrowed const pointer.
+ */
+class NodeCache {
+ public:
+  NodeCache() = default;
+
+  /**
+   * @brief Select and pack the BFS cache from an in-memory graph + vectors.
+   *
+   * @param graph        Adjacency lists (graph[i] = neighbor ids of node i).
+   * @param vectors      Row-major num_points*dim float32 coordinates.
+   * @param medoid       BFS root (entry point); always included first.
+   * @param num_points   Number of graph nodes.
+   * @param dim          Vector dimension.
+   * @param max_degree   Graph degree bound (defines node_len).
+   * @param cache_ratio  Fraction of nodes to cache; count = ceil(ratio * N),
+   *                     capped at N. ratio <= 0 produces an empty cache.
+   */
+  void generate(const std::vector<std::vector<uint32_t>> &graph,
+                const float *vectors,
+                uint32_t medoid,
+                uint64_t num_points,
+                uint64_t dim,
+                uint32_t max_degree,
+                double cache_ratio) {
+    if (graph.size() != num_points) {
+      throw std::invalid_argument("NodeCache::generate: graph size != num_points");
+    }
+    if (num_points == 0 || dim == 0) {
+      throw std::invalid_argument("NodeCache::generate: num_points/dim must be > 0");
+    }
+    if (medoid >= num_points) {
+      throw std::invalid_argument("NodeCache::generate: medoid out of range");
+    }
+
+    const DiskLayoutGeometry geom = DiskLayoutGeometry::compute(dim, max_degree);
+    node_len_ = geom.node_len;
+
+    uint64_t target = 0;
+    if (cache_ratio > 0.0) {
+      target = static_cast<uint64_t>(std::ceil(cache_ratio * static_cast<double>(num_points)));
+      if (target > num_points) {
+        target = num_points;
+      }
+    }
+
+    ids_.clear();
+    map_.clear();
+    node_data_.clear();
+    if (target == 0) {
+      return;
+    }
+
+    // BFS from medoid, collecting nodes in dequeue (BFS) order.
+    std::vector<uint8_t> visited(num_points, 0);
+    std::queue<uint32_t> bfs;
+    bfs.push(medoid);
+    visited[medoid] = 1;
+    ids_.reserve(target);
+    while (!bfs.empty() && ids_.size() < target) {
+      const uint32_t u = bfs.front();
+      bfs.pop();
+      ids_.push_back(u);
+      for (const uint32_t v : graph[u]) {
+        if (v < num_points && visited[v] == 0) {
+          visited[v] = 1;
+          bfs.push(v);
+        }
+      }
+    }
+
+    // Pack records (zero-initialized so unused neighbor slots are zero-filled).
+    node_data_.assign(ids_.size() * node_len_, 0);
+    map_.reserve(ids_.size() * 2);
+    for (size_t i = 0; i < ids_.size(); ++i) {
+      const uint32_t id = ids_[i];
+      char *rec = node_data_.data() + i * node_len_;
+      const auto &nbrs = graph[id];
+      const uint32_t n_nbrs =
+          static_cast<uint32_t>(nbrs.size() > max_degree ? max_degree : nbrs.size());
+      pack_node_record(rec, vectors + static_cast<uint64_t>(id) * dim, nbrs.data(), n_nbrs, dim);
+      map_[id] = i * node_len_;
+    }
+  }
+
+  // --- Persistence ---------------------------------------------------------
+
+  /// Write cache_ids.bin and cache_nodes.bin.
+  void save(const std::string &ids_path, const std::string &nodes_path) const {
+    const uint64_t count = ids_.size();
+    {
+      std::ofstream out(ids_path, std::ios::binary | std::ios::trunc);
+      if (!out) {
+        throw std::runtime_error("NodeCache::save: cannot open " + ids_path);
+      }
+      out.write(reinterpret_cast<const char *>(&count), sizeof(count));
+      if (count > 0) {
+        out.write(reinterpret_cast<const char *>(ids_.data()),
+                  static_cast<std::streamsize>(count * sizeof(uint32_t)));
+      }
+      if (!out) {
+        throw std::runtime_error("NodeCache::save: write failed for " + ids_path);
+      }
+    }
+    {
+      std::ofstream out(nodes_path, std::ios::binary | std::ios::trunc);
+      if (!out) {
+        throw std::runtime_error("NodeCache::save: cannot open " + nodes_path);
+      }
+      out.write(reinterpret_cast<const char *>(&count), sizeof(count));
+      out.write(reinterpret_cast<const char *>(&node_len_), sizeof(node_len_));
+      if (!node_data_.empty()) {
+        out.write(node_data_.data(), static_cast<std::streamsize>(node_data_.size()));
+      }
+      if (!out) {
+        throw std::runtime_error("NodeCache::save: write failed for " + nodes_path);
+      }
+    }
+  }
+
+  /// Read cache_ids.bin and cache_nodes.bin and rebuild the lookup index.
+  void load(const std::string &ids_path, const std::string &nodes_path) {
+    uint64_t id_count = 0;
+    {
+      std::ifstream in(ids_path, std::ios::binary);
+      if (!in) {
+        throw std::runtime_error("NodeCache::load: cannot open " + ids_path);
+      }
+      in.read(reinterpret_cast<char *>(&id_count), sizeof(id_count));
+      if (!in) {
+        throw std::runtime_error("NodeCache::load: short read (ids count) " + ids_path);
+      }
+      ids_.assign(id_count, 0);
+      if (id_count > 0) {
+        in.read(reinterpret_cast<char *>(ids_.data()),
+                static_cast<std::streamsize>(id_count * sizeof(uint32_t)));
+        if (!in) {
+          throw std::runtime_error("NodeCache::load: short read (ids) " + ids_path);
+        }
+      }
+    }
+
+    uint64_t node_count = 0;
+    {
+      std::ifstream in(nodes_path, std::ios::binary);
+      if (!in) {
+        throw std::runtime_error("NodeCache::load: cannot open " + nodes_path);
+      }
+      in.read(reinterpret_cast<char *>(&node_count), sizeof(node_count));
+      in.read(reinterpret_cast<char *>(&node_len_), sizeof(node_len_));
+      if (!in) {
+        throw std::runtime_error("NodeCache::load: short read (nodes header) " + nodes_path);
+      }
+      if (node_count != id_count) {
+        throw std::runtime_error("NodeCache::load: ids/nodes count mismatch (" +
+                                 std::to_string(id_count) + " vs " + std::to_string(node_count) +
+                                 ")");
+      }
+      node_data_.assign(node_count * node_len_, 0);
+      if (!node_data_.empty()) {
+        in.read(node_data_.data(), static_cast<std::streamsize>(node_data_.size()));
+        if (!in) {
+          throw std::runtime_error("NodeCache::load: short read (node data) " + nodes_path);
+        }
+      }
+    }
+
+    map_.clear();
+    map_.reserve(ids_.size() * 2);
+    for (size_t i = 0; i < ids_.size(); ++i) {
+      map_[ids_[i]] = i * node_len_;
+    }
+  }
+
+  // --- Runtime lookup ------------------------------------------------------
+
+  /**
+   * @brief O(1) cache lookup.
+   * @return Pointer to the node's @c node_len -byte record, or nullptr on miss.
+   *         The returned pointer is read-only and owned by this cache.
+   */
+  [[nodiscard]] const char *lookup(uint32_t node_id) const {
+    const auto it = map_.find(node_id);
+    if (it == map_.end()) {
+      return nullptr;
+    }
+    return node_data_.data() + it->second;
+  }
+
+  // --- Accessors -----------------------------------------------------------
+
+  [[nodiscard]] uint64_t size() const { return ids_.size(); }
+  [[nodiscard]] uint64_t node_len() const { return node_len_; }
+  [[nodiscard]] const std::vector<uint32_t> &ids() const { return ids_; }
+
+ private:
+  uint64_t node_len_ = 0;
+  std::vector<uint32_t> ids_;                   // cached node ids, BFS order
+  std::vector<char> node_data_;                 // size() * node_len_ bytes
+  std::unordered_map<uint32_t, uint64_t> map_;  // node_id -> byte offset in node_data_
+};
+
+}  // namespace alaya::diskann

--- a/include/index/graph/diskann/pq_table.hpp
+++ b/include/index/graph/diskann/pq_table.hpp
@@ -1,0 +1,539 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * @file pq_table.hpp
+ * @brief Product Quantization (PQ) table: train / encode / per-query distance.
+ *
+ * PQ splits the @c dim -dimensional space into @c n_chunks equal sub-spaces and
+ * learns a 256-entry codebook per sub-space via k-means. Each vector becomes
+ * @c n_chunks uint8 codes. At search time, the query is turned once into an
+ * @c n_chunks x 256 distance table, and the approximate distance to any stored
+ * point is a sum of @c n_chunks table lookups (no per-neighbor arithmetic).
+ *
+ * Encoding is done on centroid-residual vectors (x - global_centroid). Because
+ * the global centroid cancels in the difference, the PQ distance approximates
+ * the true squared L2 distance between query and point.
+ *
+ * The trained table (global centroid + codebook + codes) is immutable after
+ * load and may be shared read-only across search threads; the per-query
+ * distance table is owned by each thread's scratch (see search_scratch.hpp).
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>  // NOLINT(build/c++17)
+#include <fstream>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "simd/distance_l2.hpp"
+
+namespace alaya::diskann {
+
+/// Number of centroids per chunk (uint8 codes => 256).
+inline constexpr uint32_t kPQNumCentroids = 256;
+
+class PQTable {
+ public:
+  PQTable() = default;
+
+  // --- Build-time ----------------------------------------------------------
+
+  /**
+   * @brief Train per-chunk k-means codebooks on @p n row-major vectors.
+   *
+   * @param data     Row-major @c n*dim float32 training vectors.
+   * @param n        Number of training vectors (> 0).
+   * @param dim      Vector dimension (> 0, divisible by @p n_chunks).
+   * @param n_chunks Number of PQ sub-spaces (> 0).
+   * @param n_iters  Lloyd iterations for k-means (used when n > 256).
+   * @param seed     RNG seed for reproducible k-means++ initialization.
+   * @param num_threads Workers for the per-chunk training (0 => all cores).
+   *         Chunks are independent, so the result is byte-identical to the
+   *         single-threaded run regardless of thread count.
+   *
+   * @throws std::invalid_argument if dim is not divisible by n_chunks, or any
+   *         size is zero.
+   */
+  void train(const float *data,
+             uint64_t n,
+             uint64_t dim,
+             uint32_t n_chunks,
+             uint32_t n_iters = 15,
+             uint64_t seed = 1234,
+             uint32_t num_threads = 0) {
+    if (data == nullptr) {
+      throw std::invalid_argument("PQTable::train: data is null");
+    }
+    if (n == 0 || dim == 0 || n_chunks == 0) {
+      throw std::invalid_argument("PQTable::train: n/dim/n_chunks must be > 0");
+    }
+    if (dim % n_chunks != 0) {
+      throw std::invalid_argument("PQTable::train: dim (" + std::to_string(dim) +
+                                  ") must be divisible by n_chunks (" + std::to_string(n_chunks) +
+                                  ")");
+    }
+    dim_ = dim;
+    n_chunks_ = n_chunks;
+    chunk_dim_ = static_cast<uint32_t>(dim / n_chunks);
+    ensure_l2();
+
+    // Global centroid = mean of all training vectors.
+    global_centroid_.assign(dim_, 0.0f);
+    for (uint64_t i = 0; i < n; ++i) {
+      const float *v = data + i * dim_;
+      for (uint64_t d = 0; d < dim_; ++d) {
+        global_centroid_[d] += v[d];
+      }
+    }
+    for (uint64_t d = 0; d < dim_; ++d) {
+      global_centroid_[d] /= static_cast<float>(n);
+    }
+
+    // Residuals (n * dim), contiguous so each chunk is a contiguous stride.
+    std::vector<float> residual(static_cast<size_t>(n) * dim_);
+    for (uint64_t i = 0; i < n; ++i) {
+      const float *v = data + i * dim_;
+      float *r = residual.data() + i * dim_;
+      for (uint64_t d = 0; d < dim_; ++d) {
+        r[d] = v[d] - global_centroid_[d];
+      }
+    }
+
+    codebook_.assign(static_cast<size_t>(n_chunks_) * kPQNumCentroids * chunk_dim_, 0.0f);
+
+    // Per-chunk training. Chunks are independent — each writes a disjoint codebook
+    // region and trains with its own seed (seed + c) — so they parallelize with a
+    // byte-identical result regardless of thread count (completion order is
+    // irrelevant). Each worker owns its chunk_data buffer and pulls chunks off a
+    // shared counter.
+    const uint32_t hw = std::max<uint32_t>(1, std::thread::hardware_concurrency());
+    const uint32_t workers = std::min<uint32_t>(num_threads == 0 ? hw : num_threads, n_chunks_);
+    std::atomic<uint32_t> next_chunk{0};
+    auto chunk_worker = [&]() {
+      std::vector<float> chunk_data(static_cast<size_t>(n) * chunk_dim_);
+      for (;;) {
+        const uint32_t c = next_chunk.fetch_add(1, std::memory_order_relaxed);
+        if (c >= n_chunks_) {
+          break;
+        }
+        for (uint64_t i = 0; i < n; ++i) {
+          std::memcpy(chunk_data.data() + i * chunk_dim_,
+                      residual.data() + i * dim_ + static_cast<uint64_t>(c) * chunk_dim_,
+                      chunk_dim_ * sizeof(float));
+        }
+        float *centroids = codebook_.data() + static_cast<size_t>(c) * kPQNumCentroids * chunk_dim_;
+        train_chunk(chunk_data.data(), n, centroids, n_iters, seed + c);
+      }
+    };
+    if (workers <= 1) {
+      chunk_worker();
+    } else {
+      std::vector<std::thread> pool;
+      pool.reserve(workers);
+      for (uint32_t t = 0; t < workers; ++t) {
+        pool.emplace_back(chunk_worker);
+      }
+      for (auto &th : pool) {
+        th.join();
+      }
+    }
+  }
+
+  /**
+   * @brief Encode @p n vectors into @c n*n_chunks uint8 codes (row-major).
+   *
+   * Stores the codes internally (queryable via pq_distance / codes()). Each
+   * vector's code row is independent, so encoding parallelizes across points
+   * (@p num_threads, 0 => all cores) with a byte-identical result.
+   * @throws std::logic_error if called before train()/load().
+   */
+  void encode(const float *data, uint64_t n, uint32_t num_threads = 0) {
+    if (codebook_.empty()) {
+      throw std::logic_error("PQTable::encode: not trained");
+    }
+    if (data == nullptr || n == 0) {
+      throw std::invalid_argument("PQTable::encode: data null or n == 0");
+    }
+    ensure_l2();
+    num_points_ = n;
+    codes_.assign(static_cast<size_t>(n) * n_chunks_, 0);
+
+    const uint32_t hw = std::max<uint32_t>(1, std::thread::hardware_concurrency());
+    const uint32_t want = num_threads == 0 ? hw : num_threads;
+    const uint32_t workers =
+        static_cast<uint32_t>(std::min<uint64_t>(want, std::max<uint64_t>(1, n)));
+    std::atomic<uint64_t> next_block{0};
+    constexpr uint64_t kBlock = 4096;
+    auto encode_worker = [&]() {
+      std::vector<float> r(dim_);
+      for (;;) {
+        const uint64_t start = next_block.fetch_add(kBlock, std::memory_order_relaxed);
+        if (start >= n) {
+          break;
+        }
+        const uint64_t end = std::min<uint64_t>(start + kBlock, n);
+        for (uint64_t i = start; i < end; ++i) {
+          const float *v = data + i * dim_;
+          for (uint64_t d = 0; d < dim_; ++d) {
+            r[d] = v[d] - global_centroid_[d];
+          }
+          uint8_t *code_row = codes_.data() + i * n_chunks_;
+          for (uint32_t c = 0; c < n_chunks_; ++c) {
+            code_row[c] = nearest_centroid(r.data() + static_cast<uint64_t>(c) * chunk_dim_, c);
+          }
+        }
+      }
+    };
+    if (workers <= 1) {
+      encode_worker();
+    } else {
+      std::vector<std::thread> pool;
+      pool.reserve(workers);
+      for (uint32_t t = 0; t < workers; ++t) {
+        pool.emplace_back(encode_worker);
+      }
+      for (auto &th : pool) {
+        th.join();
+      }
+    }
+  }
+
+  // --- Search-time ---------------------------------------------------------
+
+  /**
+   * @brief Precompute the @c n_chunks x 256 query distance table.
+   *
+   * @param query      Query vector (dim float32).
+   * @param table_out  Caller-owned buffer of @c n_chunks*256 float32. Entry
+   *                   [c*256 + k] = squared L2 between the query's chunk-c
+   *                   residual and centroid k of chunk c.
+   */
+  void preprocess_query(const float *query, float *table_out) const {
+    std::vector<float> qres(dim_);
+    for (uint64_t d = 0; d < dim_; ++d) {
+      qres[d] = query[d] - global_centroid_[d];
+    }
+    for (uint32_t c = 0; c < n_chunks_; ++c) {
+      const float *qchunk = qres.data() + static_cast<uint64_t>(c) * chunk_dim_;
+      const float *cent = codebook_.data() + static_cast<size_t>(c) * kPQNumCentroids * chunk_dim_;
+      float *trow = table_out + static_cast<size_t>(c) * kPQNumCentroids;
+      for (uint32_t k = 0; k < kPQNumCentroids; ++k) {
+        trow[k] = l2_(qchunk, cent + static_cast<size_t>(k) * chunk_dim_, chunk_dim_);
+      }
+    }
+  }
+
+  /**
+   * @brief Approximate distance from query to point @p point_id.
+   * @param point_id   Index into the stored code array.
+   * @param dist_table Table produced by preprocess_query().
+   * @return sum over chunks of dist_table[c*256 + code(point_id, c)].
+   */
+  [[nodiscard]] float pq_distance(uint64_t point_id, const float *dist_table) const {
+    const uint8_t *code_row = codes_.data() + point_id * n_chunks_;
+    float sum = 0.0f;
+    for (uint32_t c = 0; c < n_chunks_; ++c) {
+      sum += dist_table[static_cast<size_t>(c) * kPQNumCentroids + code_row[c]];
+    }
+    return sum;
+  }
+
+  // --- Persistence ---------------------------------------------------------
+
+  /**
+   * @brief Write pq_pivots.bin (global centroid + codebook) and
+   *        pq_compressed.bin (codes). Pure payload, no header (shape lives in
+   *        the index meta.bin).
+   */
+  void save(const std::string &pivots_path, const std::string &compressed_path) const {
+    if (codebook_.empty()) {
+      throw std::logic_error("PQTable::save: not trained");
+    }
+    {
+      std::ofstream out(pivots_path, std::ios::binary | std::ios::trunc);
+      if (!out) {
+        throw std::runtime_error("PQTable::save: cannot open " + pivots_path);
+      }
+      out.write(reinterpret_cast<const char *>(global_centroid_.data()),
+                static_cast<std::streamsize>(global_centroid_.size() * sizeof(float)));
+      out.write(reinterpret_cast<const char *>(codebook_.data()),
+                static_cast<std::streamsize>(codebook_.size() * sizeof(float)));
+      if (!out) {
+        throw std::runtime_error("PQTable::save: write failed for " + pivots_path);
+      }
+    }
+    {
+      std::ofstream out(compressed_path, std::ios::binary | std::ios::trunc);
+      if (!out) {
+        throw std::runtime_error("PQTable::save: cannot open " + compressed_path);
+      }
+      out.write(reinterpret_cast<const char *>(codes_.data()),
+                static_cast<std::streamsize>(codes_.size()));
+      if (!out) {
+        throw std::runtime_error("PQTable::save: write failed for " + compressed_path);
+      }
+    }
+  }
+
+  /**
+   * @brief Load pq_pivots.bin + pq_compressed.bin. Shape (n, dim, n_chunks) is
+   *        supplied by the caller (from meta.bin) and validated against file
+   *        sizes.
+   */
+  void load(const std::string &pivots_path,
+            const std::string &compressed_path,
+            uint64_t n,
+            uint64_t dim,
+            uint32_t n_chunks) {
+    if (n == 0 || dim == 0 || n_chunks == 0 || dim % n_chunks != 0) {
+      throw std::invalid_argument("PQTable::load: invalid shape");
+    }
+    dim_ = dim;
+    n_chunks_ = n_chunks;
+    chunk_dim_ = static_cast<uint32_t>(dim / n_chunks);
+    num_points_ = n;
+    ensure_l2();
+
+    const size_t centroid_floats = dim_;
+    const size_t codebook_floats = static_cast<size_t>(n_chunks_) * kPQNumCentroids * chunk_dim_;
+    const uint64_t expect_pivots = (centroid_floats + codebook_floats) * sizeof(float);
+
+    std::error_code ec;
+    const auto pivots_size = std::filesystem::file_size(pivots_path, ec);
+    if (ec) {
+      throw std::runtime_error("PQTable::load: cannot stat " + pivots_path);
+    }
+    if (static_cast<uint64_t>(pivots_size) != expect_pivots) {
+      throw std::runtime_error("PQTable::load: " + pivots_path + " size " +
+                               std::to_string(pivots_size) + " != expected " +
+                               std::to_string(expect_pivots));
+    }
+    std::ifstream pin(pivots_path, std::ios::binary);
+    if (!pin) {
+      throw std::runtime_error("PQTable::load: cannot open " + pivots_path);
+    }
+    global_centroid_.assign(centroid_floats, 0.0f);
+    codebook_.assign(codebook_floats, 0.0f);
+    pin.read(reinterpret_cast<char *>(global_centroid_.data()),
+             static_cast<std::streamsize>(centroid_floats * sizeof(float)));
+    pin.read(reinterpret_cast<char *>(codebook_.data()),
+             static_cast<std::streamsize>(codebook_floats * sizeof(float)));
+    if (!pin) {
+      throw std::runtime_error("PQTable::load: short read on " + pivots_path);
+    }
+
+    const uint64_t expect_codes = n * n_chunks_;
+    const auto codes_size = std::filesystem::file_size(compressed_path, ec);
+    if (ec) {
+      throw std::runtime_error("PQTable::load: cannot stat " + compressed_path);
+    }
+    if (static_cast<uint64_t>(codes_size) != expect_codes) {
+      throw std::runtime_error("PQTable::load: " + compressed_path + " size " +
+                               std::to_string(codes_size) + " != expected " +
+                               std::to_string(expect_codes));
+    }
+    std::ifstream cin(compressed_path, std::ios::binary);
+    if (!cin) {
+      throw std::runtime_error("PQTable::load: cannot open " + compressed_path);
+    }
+    codes_.assign(expect_codes, 0);
+    cin.read(reinterpret_cast<char *>(codes_.data()), static_cast<std::streamsize>(expect_codes));
+    if (!cin) {
+      throw std::runtime_error("PQTable::load: short read on " + compressed_path);
+    }
+  }
+
+  /// Build a table directly from arrays (used by tests and external codebooks).
+  static PQTable from_codebook(uint64_t dim,
+                               uint32_t n_chunks,
+                               std::vector<float> global_centroid,
+                               std::vector<float> codebook) {
+    if (dim == 0 || n_chunks == 0 || dim % n_chunks != 0) {
+      throw std::invalid_argument("PQTable::from_codebook: invalid shape");
+    }
+    PQTable t;
+    t.dim_ = dim;
+    t.n_chunks_ = n_chunks;
+    t.chunk_dim_ = static_cast<uint32_t>(dim / n_chunks);
+    if (global_centroid.size() != dim) {
+      throw std::invalid_argument("PQTable::from_codebook: global_centroid size");
+    }
+    if (codebook.size() != static_cast<size_t>(n_chunks) * kPQNumCentroids * t.chunk_dim_) {
+      throw std::invalid_argument("PQTable::from_codebook: codebook size");
+    }
+    t.global_centroid_ = std::move(global_centroid);
+    t.codebook_ = std::move(codebook);
+    t.ensure_l2();
+    return t;
+  }
+
+  // --- Accessors -----------------------------------------------------------
+
+  [[nodiscard]] uint64_t num_points() const { return num_points_; }
+  [[nodiscard]] uint64_t dim() const { return dim_; }
+  [[nodiscard]] uint32_t n_chunks() const { return n_chunks_; }
+  [[nodiscard]] uint32_t chunk_dim() const { return chunk_dim_; }
+  [[nodiscard]] const std::vector<float> &global_centroid() const { return global_centroid_; }
+  [[nodiscard]] const std::vector<float> &codebook() const { return codebook_; }
+  [[nodiscard]] const std::vector<uint8_t> &codes() const { return codes_; }
+
+ private:
+  void ensure_l2() {
+    if (l2_ == nullptr) {
+      l2_ = alaya::simd::get_l2_sqr_func();
+    }
+  }
+
+  /// argmin over the 256 centroids of chunk @p c for a chunk residual vector.
+  [[nodiscard]] uint8_t nearest_centroid(const float *chunk_residual, uint32_t c) const {
+    const float *cent = codebook_.data() + static_cast<size_t>(c) * kPQNumCentroids * chunk_dim_;
+    return static_cast<uint8_t>(argmin_centroid(chunk_residual, cent));
+  }
+
+  /**
+   * @brief Train one chunk's 256 centroids into @p centroids (256*chunk_dim).
+   *
+   * For n <= 256 the training points themselves become the centroids (padded),
+   * which makes small-input encoding exact and deterministic. For n > 256 we
+   * run k-means++ init followed by @p n_iters Lloyd iterations.
+   */
+  void train_chunk(const float *chunk_data,
+                   uint64_t n,
+                   float *centroids,
+                   uint32_t n_iters,
+                   uint64_t seed) const {
+    const uint32_t cd = chunk_dim_;
+    if (n <= kPQNumCentroids) {
+      for (uint64_t i = 0; i < n; ++i) {
+        std::memcpy(centroids + i * cd, chunk_data + i * cd, cd * sizeof(float));
+      }
+      // Pad remaining centroids with a copy of the last real point.
+      for (uint64_t k = n; k < kPQNumCentroids; ++k) {
+        std::memcpy(centroids + k * cd, chunk_data + (n - 1) * cd, cd * sizeof(float));
+      }
+      return;
+    }
+
+    std::mt19937_64 rng(seed);
+    kmeanspp_init(chunk_data, n, centroids, rng);
+
+    std::vector<uint32_t> assign(n, 0);
+    std::vector<double> sums(static_cast<size_t>(kPQNumCentroids) * cd, 0.0);
+    std::vector<uint64_t> counts(kPQNumCentroids, 0);
+    for (uint32_t iter = 0; iter < n_iters; ++iter) {
+      // Assignment step.
+      for (uint64_t i = 0; i < n; ++i) {
+        assign[i] = argmin_centroid(chunk_data + i * cd, centroids);
+      }
+      // Update step.
+      std::fill(sums.begin(), sums.end(), 0.0);
+      std::fill(counts.begin(), counts.end(), 0);
+      for (uint64_t i = 0; i < n; ++i) {
+        const uint32_t a = assign[i];
+        counts[a]++;
+        const float *p = chunk_data + i * cd;
+        double *s = sums.data() + static_cast<size_t>(a) * cd;
+        for (uint32_t d = 0; d < cd; ++d) {
+          s[d] += p[d];
+        }
+      }
+      for (uint32_t k = 0; k < kPQNumCentroids; ++k) {
+        if (counts[k] == 0) {
+          // Empty cluster: reseed to a deterministic random training point.
+          const uint64_t idx = rng() % n;
+          std::memcpy(centroids + static_cast<size_t>(k) * cd,
+                      chunk_data + idx * cd,
+                      cd * sizeof(float));
+          continue;
+        }
+        const double inv = 1.0 / static_cast<double>(counts[k]);
+        const double *s = sums.data() + static_cast<size_t>(k) * cd;
+        float *cptr = centroids + static_cast<size_t>(k) * cd;
+        for (uint32_t d = 0; d < cd; ++d) {
+          cptr[d] = static_cast<float>(s[d] * inv);
+        }
+      }
+    }
+  }
+
+  /// argmin over a chunk's 256-centroid block @p centroids (returns the index).
+  /// Shared by k-means assignment (train) and encoding.
+  [[nodiscard]] uint32_t argmin_centroid(const float *point, const float *centroids) const {
+    const uint32_t cd = chunk_dim_;
+    float best = std::numeric_limits<float>::max();
+    uint32_t best_k = 0;
+    for (uint32_t k = 0; k < kPQNumCentroids; ++k) {
+      const float d = l2_(point, centroids + static_cast<size_t>(k) * cd, cd);
+      if (d < best) {
+        best = d;
+        best_k = k;
+      }
+    }
+    return best_k;
+  }
+
+  /// k-means++ seeding of 256 centroids (D^2 weighting).
+  void kmeanspp_init(const float *chunk_data,
+                     uint64_t n,
+                     float *centroids,
+                     std::mt19937_64 &rng) const {
+    const uint32_t cd = chunk_dim_;
+    std::uniform_int_distribution<uint64_t> pick(0, n - 1);
+    const uint64_t first = pick(rng);
+    std::memcpy(centroids, chunk_data + first * cd, cd * sizeof(float));
+
+    std::vector<float> d2(n, std::numeric_limits<float>::max());
+    for (uint32_t k = 1; k < kPQNumCentroids; ++k) {
+      const float *prev = centroids + static_cast<size_t>(k - 1) * cd;
+      double total = 0.0;
+      for (uint64_t i = 0; i < n; ++i) {
+        const float dist = l2_(chunk_data + i * cd, prev, cd);
+        if (dist < d2[i]) {
+          d2[i] = dist;
+        }
+        total += d2[i];
+      }
+      uint64_t chosen = 0;
+      if (total <= 0.0) {
+        chosen = pick(rng);  // all points coincide with existing centroids
+      } else {
+        std::uniform_real_distribution<double> u(0.0, total);
+        double target = u(rng);
+        for (uint64_t i = 0; i < n; ++i) {
+          target -= d2[i];
+          if (target <= 0.0) {
+            chosen = i;
+            break;
+          }
+        }
+      }
+      std::memcpy(centroids + static_cast<size_t>(k) * cd,
+                  chunk_data + chosen * cd,
+                  cd * sizeof(float));
+    }
+  }
+
+  uint64_t dim_ = 0;
+  uint32_t n_chunks_ = 0;
+  uint32_t chunk_dim_ = 0;
+  uint64_t num_points_ = 0;
+  std::vector<float> global_centroid_;  // dim
+  std::vector<float> codebook_;         // n_chunks * 256 * chunk_dim
+  std::vector<uint8_t> codes_;          // num_points * n_chunks
+  alaya::simd::L2SqrFunc l2_ = nullptr;
+};
+
+}  // namespace alaya::diskann

--- a/include/index/graph/diskann/search_scratch.hpp
+++ b/include/index/graph/diskann/search_scratch.hpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * @file search_scratch.hpp
+ * @brief Per-thread scratch state for the DiskANN cached beam search.
+ *
+ * Each search thread borrows one @c ThreadData from a @c ConcurrentQueue for
+ * the duration of a query (LASER pattern, design D8). It bundles:
+ *   - the visited set (dedup of popped nodes),
+ *   - the @c retset frontier (NeighborPriorityQueue, reused from Vamana),
+ *   - @c exact_by_id: exact L2 distances of nodes actually read from disk/cache,
+ *   - @c pq_table: the per-query @c n_chunks x 256 PQ distance table (PQ mode),
+ *   - @c sector_scratch: a sector-aligned double buffer for async page reads,
+ *   - @c ctx_: the thread's AlignedFileReader I/O context.
+ *
+ * The scratch is owned by the index and reused across queries; reset_query()
+ * clears only the per-query state.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "index/graph/diskann/disk_layout.hpp"
+#include "index/graph/laser/utils/aligned_file_reader.hpp"
+#include "index/graph/laser/utils/memory.hpp"
+#include "index/graph/vamana/robust_prune.hpp"
+
+namespace alaya::diskann {
+
+struct ThreadData {
+  // --- Per-query mutable search state ---
+  std::unordered_set<uint32_t> visited;             ///< ids popped/seeded
+  alaya::vamana::NeighborPriorityQueue retset;      ///< exploration frontier
+  std::unordered_map<uint32_t, float> exact_by_id;  ///< read node -> exact L2 sqr
+  std::vector<float> pq_table;                      ///< n_chunks*256 (empty if no PQ)
+
+  // --- I/O scratch (allocated once, reused) ---
+  char *sector_scratch = nullptr;  ///< n_page_slots * page_size bytes, sector-aligned.
+                                   ///< One page slot per in-flight read; the No-PQ pipeline
+                                   ///< depth equals the slot count (PQ caps in-flight at
+                                   ///< beam_width, so it ignores the surplus).
+  uint64_t sector_scratch_bytes = 0;
+  IOContext ctx_{};  ///< AIO context (owned via reader.register_thread())
+
+  /// Reset only the per-query state; keeps allocated buffers.
+  void reset_query(size_t search_list_size) {
+    visited.clear();
+    exact_by_id.clear();
+    retset.reserve(search_list_size);
+    retset.clear();
+  }
+
+  /// Allocate the sector page buffer (@p n_page_slots pages, one per concurrent
+  /// read) and (optionally) the PQ table.
+  void alloc_scratch(uint64_t n_page_slots, uint64_t page_size, uint32_t pq_table_entries) {
+    sector_scratch_bytes = n_page_slots * page_size;
+    sector_scratch = reinterpret_cast<char *>(
+        alaya::laser::memory::align_allocate<kSectorLen>(sector_scratch_bytes));
+    if (pq_table_entries > 0) {
+      pq_table.assign(pq_table_entries, 0.0f);
+    }
+  }
+
+  /// Release the sector buffer (PQ table frees with the vector).
+  void free_scratch() {
+    if (sector_scratch != nullptr) {
+      alaya::laser::memory::align_free(sector_scratch);
+      sector_scratch = nullptr;
+    }
+    sector_scratch_bytes = 0;
+  }
+};
+
+}  // namespace alaya::diskann

--- a/include/index/graph/diskann/slot_allocator.hpp
+++ b/include/index/graph/diskann/slot_allocator.hpp
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <fstream>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -121,6 +122,9 @@ class SlotAllocator {
       if (!in) {
         throw std::runtime_error("SlotAllocator::load: free list truncated " + path);
       }
+    }
+    if (next > std::numeric_limits<uint32_t>::max()) {
+      throw std::runtime_error("SlotAllocator::load: next_fresh_id overflows u32 " + path);
     }
     next_fresh_id_ = static_cast<uint32_t>(next);
     tombstone_.deserialize(in);

--- a/include/index/graph/diskann/slot_allocator.hpp
+++ b/include/index/graph/diskann/slot_allocator.hpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * @file slot_allocator.hpp
+ * @brief Free-list slot allocator with an embedded tombstone bitmap.
+ *
+ * Slot lifecycle for in-place DiskANN updates (design D5):
+ *   - `alloc()` reuses the most-recently-freed slot (LIFO) if the free list is
+ *     non-empty, otherwise appends a fresh id (`next_fresh_id_++`). Either way
+ *     the returned slot is marked live.
+ *   - `free(id)` pushes the slot onto the free list and tombstones it.
+ *
+ * The allocator owns the `TombstoneBitmap` so that alloc/free keep liveness and
+ * reuse in lockstep, and so a single `save()`/`load()` round-trips the complete
+ * allocation state (free list + next id + tombstones) to one file.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "index/graph/diskann/tombstone_bitmap.hpp"
+
+namespace alaya::diskann {
+
+class SlotAllocator {
+ public:
+  static constexpr uint64_t kMagic = 0x414C59534C4F5431ULL;  // "ALYSLOT1"
+
+  SlotAllocator() = default;
+
+  /// Initialize for an index that already holds @p num_existing nodes
+  /// (ids [0, num_existing) are live; the next append id is num_existing).
+  explicit SlotAllocator(uint32_t num_existing)
+      : next_fresh_id_(num_existing), tombstone_(num_existing) {}
+
+  /// Reset to manage an index of @p num_existing live nodes with an empty free
+  /// list. Used by load() of an updatable index.
+  void reset(uint32_t num_existing) {
+    free_list_.clear();
+    next_fresh_id_ = num_existing;
+    tombstone_ = TombstoneBitmap(num_existing);
+  }
+
+  /// Allocate a slot: reuse the most recently freed id (LIFO), else append a
+  /// fresh id. The returned slot is marked live.
+  uint32_t alloc() {
+    uint32_t id;
+    if (!free_list_.empty()) {
+      id = free_list_.back();
+      free_list_.pop_back();
+    } else {
+      id = next_fresh_id_++;
+    }
+    tombstone_.clear(id);
+    return id;
+  }
+
+  /// Free @p id: push it onto the free list and tombstone it.
+  void free(uint32_t id) {
+    free_list_.push_back(id);
+    tombstone_.set(id);
+  }
+
+  [[nodiscard]] bool is_deleted(uint32_t id) const { return tombstone_.is_deleted(id); }
+  [[nodiscard]] uint32_t next_fresh_id() const { return next_fresh_id_; }
+  [[nodiscard]] uint64_t free_count() const { return free_list_.size(); }
+  [[nodiscard]] uint64_t tombstone_count() const { return tombstone_.count(); }
+
+  TombstoneBitmap &tombstone() { return tombstone_; }
+  [[nodiscard]] const TombstoneBitmap &tombstone() const { return tombstone_; }
+  [[nodiscard]] const std::vector<uint32_t> &free_list() const { return free_list_; }
+
+  /// Persist [magic | next_fresh_id | free_list | tombstone] to @p path.
+  void save(const std::string &path) const {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      throw std::runtime_error("SlotAllocator::save: cannot open " + path);
+    }
+    const uint64_t magic = kMagic;
+    const uint64_t next = next_fresh_id_;
+    const uint64_t n_free = free_list_.size();
+    out.write(reinterpret_cast<const char *>(&magic), sizeof(magic));
+    out.write(reinterpret_cast<const char *>(&next), sizeof(next));
+    out.write(reinterpret_cast<const char *>(&n_free), sizeof(n_free));
+    if (n_free > 0) {
+      out.write(reinterpret_cast<const char *>(free_list_.data()),
+                static_cast<std::streamsize>(n_free * sizeof(uint32_t)));
+    }
+    tombstone_.serialize(out);
+    if (!out) {
+      throw std::runtime_error("SlotAllocator::save: write failed " + path);
+    }
+  }
+
+  /// Restore complete allocator state from @p path.
+  void load(const std::string &path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+      throw std::runtime_error("SlotAllocator::load: cannot open " + path);
+    }
+    uint64_t magic = 0;
+    uint64_t next = 0;
+    uint64_t n_free = 0;
+    in.read(reinterpret_cast<char *>(&magic), sizeof(magic));
+    in.read(reinterpret_cast<char *>(&next), sizeof(next));
+    in.read(reinterpret_cast<char *>(&n_free), sizeof(n_free));
+    if (!in || magic != kMagic) {
+      throw std::runtime_error("SlotAllocator::load: bad magic/truncated " + path);
+    }
+    free_list_.assign(n_free, 0);
+    if (n_free > 0) {
+      in.read(reinterpret_cast<char *>(free_list_.data()),
+              static_cast<std::streamsize>(n_free * sizeof(uint32_t)));
+      if (!in) {
+        throw std::runtime_error("SlotAllocator::load: free list truncated " + path);
+      }
+    }
+    next_fresh_id_ = static_cast<uint32_t>(next);
+    tombstone_.deserialize(in);
+  }
+
+ private:
+  std::vector<uint32_t> free_list_;
+  uint32_t next_fresh_id_ = 0;
+  TombstoneBitmap tombstone_;
+};
+
+}  // namespace alaya::diskann

--- a/include/index/graph/diskann/tombstone_bitmap.hpp
+++ b/include/index/graph/diskann/tombstone_bitmap.hpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * @file tombstone_bitmap.hpp
+ * @brief Deleted-slot bitmap for in-place DiskANN updates.
+ *
+ * A word-packed bitset with one bit per slot id: `set(id)` marks a slot deleted
+ * (tombstoned), `clear(id)` marks it live, `is_deleted(id)` queries the status.
+ * The bitmap auto-grows when an id beyond the current capacity is touched, and a
+ * running deleted-bit count makes the safety-net threshold check O(1).
+ *
+ * Out-of-range ids read as *live* (`is_deleted` returns false), so a freshly
+ * appended slot whose id exceeds the saved capacity is implicitly live without
+ * forcing a grow. The on-disk format is an explicit little-endian blob with a
+ * magic header, decoupled from the host bitset representation.
+ */
+
+#pragma once
+
+#include <bit>
+#include <cstdint>
+#include <fstream>
+#include <istream>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace alaya::diskann {
+
+class TombstoneBitmap {
+ public:
+  static constexpr uint64_t kMagic = 0x414C5954424D5031ULL;  // "ALYTBMP1"
+
+  TombstoneBitmap() = default;
+
+  /// Pre-size the bitmap to hold at least @p initial_bits (all live).
+  explicit TombstoneBitmap(uint64_t initial_bits) { ensure_capacity(initial_bits); }
+
+  /// Mark slot @p id as deleted (grows the bitmap if @p id is out of range).
+  void set(uint64_t id) {
+    ensure_capacity(id + 1);
+    uint64_t &w = words_[id >> 6];
+    const uint64_t mask = uint64_t{1} << (id & 63);
+    if ((w & mask) == 0) {
+      w |= mask;
+      ++count_;
+    }
+  }
+
+  /// Mark slot @p id as live. Clearing an out-of-range id is a no-op (already
+  /// live), so no allocation is forced.
+  void clear(uint64_t id) {
+    if (id >= num_bits_) {
+      return;
+    }
+    uint64_t &w = words_[id >> 6];
+    const uint64_t mask = uint64_t{1} << (id & 63);
+    if ((w & mask) != 0) {
+      w &= ~mask;
+      --count_;
+    }
+  }
+
+  /// True iff slot @p id is tombstoned. Out-of-range ids are live (false).
+  [[nodiscard]] bool is_deleted(uint64_t id) const {
+    if (id >= num_bits_) {
+      return false;
+    }
+    return ((words_[id >> 6] >> (id & 63)) & uint64_t{1}) != 0;
+  }
+
+  /// Number of tombstoned (set) bits.
+  [[nodiscard]] uint64_t count() const { return count_; }
+
+  /// Bit capacity (word-aligned, >= the highest id ever touched + 1).
+  [[nodiscard]] uint64_t capacity() const { return num_bits_; }
+
+  /// Write [magic | num_words | words] into @p out. Reusable so an enclosing
+  /// container (e.g. SlotAllocator) can embed the bitmap in its own file.
+  void serialize(std::ostream &out) const {
+    const uint64_t magic = kMagic;
+    const uint64_t n_words = words_.size();
+    out.write(reinterpret_cast<const char *>(&magic), sizeof(magic));
+    out.write(reinterpret_cast<const char *>(&n_words), sizeof(n_words));
+    if (n_words > 0) {
+      out.write(reinterpret_cast<const char *>(words_.data()),
+                static_cast<std::streamsize>(n_words * sizeof(uint64_t)));
+    }
+  }
+
+  /// Read state previously written by serialize(). The deleted count is
+  /// recomputed via popcount, so it is never trusted from disk.
+  void deserialize(std::istream &in) {
+    uint64_t magic = 0;
+    uint64_t n_words = 0;
+    in.read(reinterpret_cast<char *>(&magic), sizeof(magic));
+    in.read(reinterpret_cast<char *>(&n_words), sizeof(n_words));
+    if (!in || magic != kMagic) {
+      throw std::runtime_error("TombstoneBitmap::deserialize: bad magic/truncated");
+    }
+    words_.assign(n_words, 0);
+    if (n_words > 0) {
+      in.read(reinterpret_cast<char *>(words_.data()),
+              static_cast<std::streamsize>(n_words * sizeof(uint64_t)));
+      if (!in) {
+        throw std::runtime_error("TombstoneBitmap::deserialize: words truncated");
+      }
+    }
+    num_bits_ = n_words * 64;
+    count_ = 0;
+    for (const uint64_t w : words_) {
+      count_ += static_cast<uint64_t>(std::popcount(w));
+    }
+  }
+
+  /// Persist to a standalone @p path (truncating).
+  void save(const std::string &path) const {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      throw std::runtime_error("TombstoneBitmap::save: cannot open " + path);
+    }
+    serialize(out);
+    if (!out) {
+      throw std::runtime_error("TombstoneBitmap::save: write failed " + path);
+    }
+  }
+
+  /// Restore from a standalone @p path written by save().
+  void load(const std::string &path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+      throw std::runtime_error("TombstoneBitmap::load: cannot open " + path);
+    }
+    deserialize(in);
+  }
+
+ private:
+  /// Grow so that bit index (bits-1) is addressable. New words are zero (live).
+  void ensure_capacity(uint64_t bits) {
+    if (bits <= num_bits_) {
+      return;
+    }
+    const uint64_t need_words = (bits + 63) / 64;
+    if (need_words > words_.size()) {
+      words_.resize(need_words, 0);
+    }
+    num_bits_ = words_.size() * 64;
+  }
+
+  std::vector<uint64_t> words_;
+  uint64_t num_bits_ = 0;
+  uint64_t count_ = 0;
+};
+
+}  // namespace alaya::diskann

--- a/include/index/graph/diskann/tombstone_bitmap.hpp
+++ b/include/index/graph/diskann/tombstone_bitmap.hpp
@@ -30,6 +30,9 @@
 
 namespace alaya::diskann {
 
+static_assert(std::endian::native == std::endian::little,
+              "TombstoneBitmap on-disk format assumes little-endian host");
+
 class TombstoneBitmap {
  public:
   static constexpr uint64_t kMagic = 0x414C5954424D5031ULL;  // "ALYTBMP1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "alayalite"
-version = "1.0.0"
+version = "1.0.1"
 authors = [{ name = "AlayaDB.AI", email = "dev@alayadb.ai" }]
 
 description = "AlayaLite Python extension module"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(disk)
+add_subdirectory(diskann)
 add_subdirectory(executor)
 add_subdirectory(index)
 add_subdirectory(recovery)

--- a/tests/diskann/CMakeLists.txt
+++ b/tests/diskann/CMakeLists.txt
@@ -1,0 +1,37 @@
+# DiskANN disk index tests.
+#
+# Layout / PQ / node-cache are header-only over std + SIMD (SIMD flags are applied globally by the top-level
+# CMakeLists), so they link only the shared third-party libs. Beam search / index / e2e use the LASER AlignedFileReader
+# (libaio on Linux) and therefore need the alaya_laser interface, its consumer compile options, and ALAYA_ENABLE_LASER.
+
+set(_diskann_plain_tests test_diskann_layout test_diskann_pq test_diskann_node_cache)
+foreach(test_target IN LISTS _diskann_plain_tests)
+  add_executable(${test_target} ${CMAKE_CURRENT_SOURCE_DIR}/${test_target}.cpp)
+  target_link_libraries(${test_target} PRIVATE ${THIRD_PARTY_LIBS} ${GTEST_LIBS})
+  add_coverage_to_target(${test_target})
+  add_test(NAME ${test_target} COMMAND $<TARGET_FILE:${test_target}>)
+  set_tests_properties(${test_target} PROPERTIES LABELS "diskann")
+endforeach()
+
+if(ALAYA_ENABLE_LASER)
+  set(_diskann_laser_tests test_diskann_beam_search test_diskann_index test_diskann_e2e)
+  foreach(test_target IN LISTS _diskann_laser_tests)
+    add_executable(${test_target} ${CMAKE_CURRENT_SOURCE_DIR}/${test_target}.cpp)
+    target_link_libraries(${test_target} PRIVATE ${PROJECT_NAME} alaya_laser ${GTEST_LIBS})
+    target_compile_options(${test_target} PRIVATE ${_ALAYA_LASER_CONSUMER_OPTIONS})
+    target_compile_definitions(${test_target} PRIVATE ALAYA_ENABLE_LASER=1)
+    add_coverage_to_target(${test_target})
+    add_test(NAME ${test_target} COMMAND $<TARGET_FILE:${test_target}>)
+    set_tests_properties(${test_target} PROPERTIES LABELS "diskann")
+  endforeach()
+  # The end-to-end build+search test is heavier; give it a generous timeout.
+  set_tests_properties(test_diskann_e2e PROPERTIES TIMEOUT 600 LABELS "diskann;e2e")
+
+  # Standalone SIFT1M benchmark (manual; NOT registered as a ctest). Measures recall / latency / disk-reads-per-query so
+  # the index can be compared against the official DiskANN `search_disk_index` tool on the same data and metrics. Run it
+  # explicitly: build target `bench_diskann_sift`, then execute the binary.
+  add_executable(bench_diskann_sift ${CMAKE_CURRENT_SOURCE_DIR}/bench_diskann_sift.cpp)
+  target_link_libraries(bench_diskann_sift PRIVATE ${PROJECT_NAME} alaya_laser)
+  target_compile_options(bench_diskann_sift PRIVATE ${_ALAYA_LASER_CONSUMER_OPTIONS})
+  target_compile_definitions(bench_diskann_sift PRIVATE ALAYA_ENABLE_LASER=1)
+endif()

--- a/tests/diskann/CMakeLists.txt
+++ b/tests/diskann/CMakeLists.txt
@@ -4,7 +4,7 @@
 # CMakeLists), so they link only the shared third-party libs. Beam search / index / e2e use the LASER AlignedFileReader
 # (libaio on Linux) and therefore need the alaya_laser interface, its consumer compile options, and ALAYA_ENABLE_LASER.
 
-set(_diskann_plain_tests test_diskann_layout test_diskann_pq test_diskann_node_cache)
+set(_diskann_plain_tests test_diskann_layout test_diskann_pq test_diskann_node_cache test_diskann_tombstone_slot)
 foreach(test_target IN LISTS _diskann_plain_tests)
   add_executable(${test_target} ${CMAKE_CURRENT_SOURCE_DIR}/${test_target}.cpp)
   target_link_libraries(${test_target} PRIVATE ${THIRD_PARTY_LIBS} ${GTEST_LIBS})
@@ -14,7 +14,14 @@ foreach(test_target IN LISTS _diskann_plain_tests)
 endforeach()
 
 if(ALAYA_ENABLE_LASER)
-  set(_diskann_laser_tests test_diskann_beam_search test_diskann_index test_diskann_e2e)
+  set(_diskann_laser_tests
+      test_diskann_beam_search
+      test_diskann_index
+      test_diskann_e2e
+      test_diskann_disk_page_io
+      test_diskann_tombstone_search
+      test_diskann_update_e2e
+  )
   foreach(test_target IN LISTS _diskann_laser_tests)
     add_executable(${test_target} ${CMAKE_CURRENT_SOURCE_DIR}/${test_target}.cpp)
     target_link_libraries(${test_target} PRIVATE ${PROJECT_NAME} alaya_laser ${GTEST_LIBS})
@@ -34,4 +41,5 @@ if(ALAYA_ENABLE_LASER)
   target_link_libraries(bench_diskann_sift PRIVATE ${PROJECT_NAME} alaya_laser)
   target_compile_options(bench_diskann_sift PRIVATE ${_ALAYA_LASER_CONSUMER_OPTIONS})
   target_compile_definitions(bench_diskann_sift PRIVATE ALAYA_ENABLE_LASER=1)
+
 endif()

--- a/tests/diskann/bench_diskann_sift.cpp
+++ b/tests/diskann/bench_diskann_sift.cpp
@@ -1,0 +1,393 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Standalone SIFT1M benchmark for alaya::diskann::DiskANNIndex.
+//
+// Builds (or reuses) a disk index on SIFT1M, then sweeps the search list size L
+// at a fixed beam width and reports, per L: recall@1, recall@10, mean / p99
+// query latency, and mean disk reads per query (graph traversal vs PQ rerank,
+// reported separately). The metrics and the ground-truth file match the
+// official DiskANN `search_disk_index` tool so the two can be compared directly.
+// Results are written as CSV.
+//
+// Usage:
+//   bench_diskann_sift [data_dir] [index_dir] [out_csv] [flags...]
+//   --rebuild         force a fresh index build (otherwise reuse index_dir)
+//   --nopq            exact disk greedy search (use_pq=false) instead of PQ+rerank
+//   --deterministic   per-expansion (No-PQ) / per-beam (PQ) barrier, batch==sequential
+//   --nq N            cap query count (0 => all queries)
+//   --io_depth N      No-PQ async pipeline depth (0 => tuned default 32)
+//   --threads N       concurrent search workers (reports aggregate QPS)
+//   --only_l L        run a single L instead of the full sweep
+//   --time_pq         time PQ train+encode at --threads then exit (no search)
+//   --pq_n N          cap train-set size for --time_pq
+// Defaults: data_dir=./sift1m  index_dir=/tmp/diskann_sift1m_alaya  out_csv=diskann_sift1m_alaya.csv
+// data_dir must hold sift_base.fbin / sift_query.fbin / sift_gt.ibin (override via argv[1]).
+// The on-disk layout always stores full-precision coords, so --nopq runs on the
+// same PQ-built index (PQ codes are simply ignored).
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include "index/graph/diskann/beam_search.hpp"  // SearchStats
+#include "index/graph/diskann/diskann_index.hpp"
+
+namespace {
+using alaya::diskann::DiskANNBuildParams;
+using alaya::diskann::DiskANNIndex;
+using alaya::diskann::DiskANNSearchParams;
+using alaya::diskann::SearchStats;
+
+// .fbin / .fvecs sibling format used by the DiskANN tooling:
+//   [int32 npts][int32 dim][npts * dim * float32]
+struct FloatMatrix {
+  std::vector<float> data;
+  uint32_t n = 0;
+  uint32_t dim = 0;
+};
+
+FloatMatrix read_fbin(const std::string &path) {
+  std::ifstream f(path, std::ios::binary);
+  if (!f) {
+    throw std::runtime_error("cannot open " + path);
+  }
+  int32_t n = 0;
+  int32_t dim = 0;
+  f.read(reinterpret_cast<char *>(&n), 4);
+  f.read(reinterpret_cast<char *>(&dim), 4);
+  if (n <= 0 || dim <= 0) {
+    throw std::runtime_error("bad fbin header: " + path);
+  }
+  FloatMatrix m;
+  m.n = static_cast<uint32_t>(n);
+  m.dim = static_cast<uint32_t>(dim);
+  m.data.resize(static_cast<size_t>(n) * dim);
+  f.read(reinterpret_cast<char *>(m.data.data()),
+         static_cast<std::streamsize>(m.data.size() * sizeof(float)));
+  if (!f) {
+    throw std::runtime_error("short read: " + path);
+  }
+  return m;
+}
+
+// .ibin ground truth: [int32 nq][int32 k][nq * k * uint32 ids].
+struct IntMatrix {
+  std::vector<uint32_t> data;
+  uint32_t n = 0;
+  uint32_t dim = 0;
+  const uint32_t *row(uint32_t i) const { return data.data() + static_cast<size_t>(i) * dim; }
+};
+
+IntMatrix read_ibin(const std::string &path) {
+  std::ifstream f(path, std::ios::binary);
+  if (!f) {
+    throw std::runtime_error("cannot open " + path);
+  }
+  int32_t n = 0;
+  int32_t dim = 0;
+  f.read(reinterpret_cast<char *>(&n), 4);
+  f.read(reinterpret_cast<char *>(&dim), 4);
+  if (n <= 0 || dim <= 0) {
+    throw std::runtime_error("bad ibin header: " + path);
+  }
+  IntMatrix m;
+  m.n = static_cast<uint32_t>(n);
+  m.dim = static_cast<uint32_t>(dim);
+  m.data.resize(static_cast<size_t>(n) * dim);
+  f.read(reinterpret_cast<char *>(m.data.data()),
+         static_cast<std::streamsize>(m.data.size() * sizeof(uint32_t)));
+  if (!f) {
+    throw std::runtime_error("short read: " + path);
+  }
+  return m;
+}
+
+double percentile(std::vector<double> v, double p) {
+  if (v.empty()) {
+    return 0.0;
+  }
+  std::sort(v.begin(), v.end());
+  size_t idx = static_cast<size_t>(std::ceil(p * static_cast<double>(v.size()))) - 1;
+  if (idx >= v.size()) {
+    idx = v.size() - 1;
+  }
+  return v[idx];
+}
+}  // namespace
+
+int main(int argc, char **argv) {
+  try {
+    std::string data_dir = "./sift1m";  // override via argv[1]; see usage above
+    std::string index_dir = "/tmp/diskann_sift1m_alaya";
+    std::string out_csv = "diskann_sift1m_alaya.csv";
+    bool rebuild = false;
+    bool nopq = false;          // --nopq: exact disk greedy search (use_pq=false)
+    bool deterministic = false;  // --deterministic: per-expansion/-beam barrier
+    uint32_t max_nq = 0;         // --nq N: cap query count (0 => all queries)
+    uint32_t io_depth = 0;       // --io_depth N: No-PQ async pipeline depth (0 => 2*beam)
+    uint32_t threads = 1;        // --threads N: concurrent search workers (aggregate QPS)
+    uint32_t only_l = 0;         // --only_l L: run a single L instead of the full sweep
+    bool time_pq = false;        // --time_pq: time PQ train+encode at --threads, then exit
+    uint64_t pq_n = 0;           // --pq_n N: cap train-set size for --time_pq (0 => all base)
+
+    std::vector<std::string> pos;
+    for (int i = 1; i < argc; ++i) {
+      std::string a = argv[i];
+      if (a == "--rebuild") {
+        rebuild = true;
+      } else if (a == "--nopq") {
+        nopq = true;
+      } else if (a == "--deterministic") {
+        deterministic = true;
+      } else if (a == "--nq" && i + 1 < argc) {
+        max_nq = static_cast<uint32_t>(std::stoul(argv[++i]));
+      } else if (a == "--io_depth" && i + 1 < argc) {
+        io_depth = static_cast<uint32_t>(std::stoul(argv[++i]));
+      } else if (a == "--threads" && i + 1 < argc) {
+        threads = std::max<uint32_t>(1, static_cast<uint32_t>(std::stoul(argv[++i])));
+      } else if (a == "--only_l" && i + 1 < argc) {
+        only_l = static_cast<uint32_t>(std::stoul(argv[++i]));
+      } else if (a == "--time_pq") {
+        time_pq = true;
+      } else if (a == "--pq_n" && i + 1 < argc) {
+        pq_n = static_cast<uint64_t>(std::stoull(argv[++i]));
+      } else {
+        pos.push_back(a);
+      }
+    }
+    if (pos.size() >= 1) {
+      data_dir = pos[0];
+    }
+    if (pos.size() >= 2) {
+      index_dir = pos[1];
+    }
+    if (pos.size() >= 3) {
+      out_csv = pos[2];
+    }
+
+    const std::string base_path = data_dir + "/sift_base.fbin";
+    const std::string query_path = data_dir + "/sift_query.fbin";
+    const std::string gt_path = data_dir + "/sift_gt.ibin";
+
+    std::cout << "[bench] loading SIFT1M from " << data_dir << "\n";
+    FloatMatrix base = read_fbin(base_path);
+    FloatMatrix query = read_fbin(query_path);
+    IntMatrix gt = read_ibin(gt_path);
+    std::cout << "[bench] base " << base.n << "x" << base.dim << "  query " << query.n << "x"
+              << query.dim << "  gt " << gt.n << "x" << gt.dim << "\n";
+    if (base.dim != query.dim) {
+      throw std::runtime_error("dim mismatch base/query");
+    }
+    if (gt.n != query.n) {
+      throw std::runtime_error("gt/query count mismatch");
+    }
+
+    const uint64_t n = base.n;
+    const uint64_t dim = base.dim;
+
+    // --- PQ training timing mode (parallel speedup measurement). ---
+    if (time_pq) {
+      const uint64_t pn = (pq_n > 0 && pq_n < n) ? pq_n : n;
+      std::cout << "[bench] --time_pq: PQ train+encode (n_chunks=32, iters=15) on " << pn
+                << " vectors, threads=" << threads << "\n";
+      alaya::diskann::PQTable pq;
+      auto t0 = std::chrono::steady_clock::now();
+      pq.train(base.data.data(), pn, dim, 32, 15, 1234, threads);
+      auto t1 = std::chrono::steady_clock::now();
+      pq.encode(base.data.data(), pn, threads);
+      auto t2 = std::chrono::steady_clock::now();
+      const double train_s = std::chrono::duration<double>(t1 - t0).count();
+      const double enc_s = std::chrono::duration<double>(t2 - t1).count();
+      std::printf("[time_pq] threads=%u  n=%llu  train=%.2fs  encode=%.2fs  total=%.2fs\n", threads,
+                  static_cast<unsigned long long>(pn), train_s, enc_s, train_s + enc_s);
+      return 0;
+    }
+
+    // --- Build (identity labels: returned label == base id == gt id). ---
+    namespace fs = std::filesystem;
+    if (rebuild && fs::exists(index_dir)) {
+      std::cout << "[bench] --rebuild: removing " << index_dir << "\n";
+      fs::remove_all(index_dir);
+    }
+    // Build params held in scope so they can be echoed for reproducibility.
+    DiskANNBuildParams bp;
+    bp.R = 64;
+    bp.L = 100;
+    bp.alpha = 1.2f;
+    bp.pq_n_chunks = 32;    // 128 / 32 => 4 dims/chunk => 32 bytes/vector PQ
+    bp.cache_ratio = 0.01;  // ~10k BFS-cached nodes; match official --num_nodes_to_cache
+    bp.num_threads = 96;
+    bp.seed = 1234;
+    bp.verbose = true;  // print per-phase build wall-times
+    if (!fs::exists(index_dir)) {
+      std::vector<uint64_t> labels(n);
+      for (uint64_t i = 0; i < n; ++i) {
+        labels[i] = i;
+      }
+      std::cout << "[bench] building index (R=" << bp.R << " L=" << bp.L << " alpha=" << bp.alpha
+                << " pq_chunks=" << bp.pq_n_chunks << " cache_ratio=" << bp.cache_ratio
+                << " threads=" << bp.num_threads << " seed=" << bp.seed << ") -> " << index_dir
+                << "\n";
+      auto t0 = std::chrono::steady_clock::now();
+      DiskANNIndex::build(index_dir, base.data.data(), labels.data(), n, dim, bp);
+      auto t1 = std::chrono::steady_clock::now();
+      std::cout << "[bench] build done in " << std::chrono::duration<double>(t1 - t0).count()
+                << " s\n";
+    } else {
+      std::cout << "[bench] reusing existing index at " << index_dir
+                << " (pass --rebuild to force)\n";
+    }
+
+    // --- Load: fixed beam width across the L sweep. ---
+    const uint32_t kBeam = 4;
+    const uint32_t pool_threads = std::max<uint32_t>(8, threads);
+    DiskANNIndex idx;
+    idx.load(index_dir,
+             {/*num_threads=*/pool_threads, /*beam_width=*/kBeam, /*nopq_io_depth=*/io_depth});
+    // Mirror DiskANNIndex's 0 => 32 resolution for display/CSV.
+    const uint32_t eff_depth = io_depth == 0 ? 32u : std::max<uint32_t>(2u * kBeam, io_depth);
+
+    const uint32_t kTopK = 10;
+    const std::vector<uint32_t> ls =
+        only_l > 0 ? std::vector<uint32_t>{only_l} : std::vector<uint32_t>{10, 20, 30, 50, 75, 100, 150, 200};
+
+    const std::string system =
+        std::string("alaya_") + (nopq ? "nopq" : "pq") + (deterministic ? "_det" : "_async");
+    std::cout << "[bench] mode: " << system << "  (use_pq=" << (!nopq)
+              << " deterministic=" << deterministic
+              << (nopq ? "  nopq_io_depth=" + std::to_string(eff_depth) : "")
+              << "  threads=" << threads << ")\n";
+
+    const uint32_t nq_run = (max_nq > 0 && max_nq < query.n) ? max_nq : query.n;
+    if (nq_run != query.n) {
+      std::cout << "[bench] limiting to first " << nq_run << " of " << query.n << " queries\n";
+    }
+
+    std::ofstream csv(out_csv);
+    csv << "system,L,beam,recall_at_1,recall_at_10,mean_lat_us,p99_lat_us,"
+           "mean_ios,mean_rerank_reads,mean_total_reads,qps_1thread,io_depth,threads,agg_qps\n";
+
+    std::printf("\n  %3s  %9s  %9s  %9s  %7s  %4s  %9s\n", "L", "recall@10", "mean us", "p99 us",
+                "ios", "thr", "aggQPS");
+    std::printf("  ---  ---------  ---------  ---------  -------  ----  ---------\n");
+
+    // Per-query outputs are row-major (nq_run * kTopK) so concurrent workers write
+    // disjoint slices; latencies are per-query, throughput is wall-clock.
+    std::vector<uint64_t> all_l(static_cast<size_t>(nq_run) * kTopK);
+    std::vector<float> all_d(static_cast<size_t>(nq_run) * kTopK);
+    std::vector<double> lat_us(nq_run, 0.0);
+
+    for (uint32_t l : ls) {
+      DiskANNSearchParams sp;
+      sp.search_list_size = l;
+      sp.use_pq = !nopq;
+      sp.deterministic = deterministic;
+      // PQ: rerank the whole explored frontier (all L candidates) by exact L2, the
+      // apples-to-apples analogue of official DiskANN returning top-K over every
+      // node it read. At termination every retset entry is already visited, so
+      // this adds compute but ~0 extra disk reads (n_rerank_reads stays ~0).
+      // No-PQ already computes exact L2 for every read node, so rerank is moot.
+      sp.rerank = !nopq;
+      sp.rerank_count = nopq ? 0 : l;
+
+      std::atomic<uint64_t> a_ios{0};
+      std::atomic<uint32_t> next{0};
+
+      // Each worker pulls queries off a shared counter (work-stealing for balance),
+      // times each search, and writes into that query's output slice.
+      auto worker = [&]() {
+        SearchStats lst;
+        lst.read_order.reserve(4096);
+        for (;;) {
+          const uint32_t q = next.fetch_add(1, std::memory_order_relaxed);
+          if (q >= nq_run) {
+            break;
+          }
+          const float *qv = query.data.data() + static_cast<size_t>(q) * dim;
+          lst.n_ios = 0;
+          lst.n_cache_hits = 0;
+          lst.n_nodes_processed = 0;
+          lst.n_rerank_reads = 0;
+          lst.read_order.clear();
+          auto a = std::chrono::steady_clock::now();
+          idx.search(qv, kTopK, all_l.data() + static_cast<size_t>(q) * kTopK,
+                     all_d.data() + static_cast<size_t>(q) * kTopK, sp, &lst);
+          auto b = std::chrono::steady_clock::now();
+          lat_us[q] = std::chrono::duration<double, std::micro>(b - a).count();
+          a_ios.fetch_add(lst.n_ios, std::memory_order_relaxed);
+        }
+      };
+
+      auto wall0 = std::chrono::steady_clock::now();
+      if (threads == 1) {
+        worker();
+      } else {
+        std::vector<std::thread> pool;
+        pool.reserve(threads);
+        for (uint32_t t = 0; t < threads; ++t) {
+          pool.emplace_back(worker);
+        }
+        for (auto &th : pool) {
+          th.join();
+        }
+      }
+      auto wall1 = std::chrono::steady_clock::now();
+      const double wall_s = std::chrono::duration<double>(wall1 - wall0).count();
+      const double agg_qps = static_cast<double>(nq_run) / wall_s;
+
+      double hit1 = 0;
+      double hit10 = 0;
+      for (uint32_t q = 0; q < nq_run; ++q) {
+        const uint64_t *row = all_l.data() + static_cast<size_t>(q) * kTopK;
+        const uint32_t *truth = gt.row(q);
+        std::unordered_set<uint32_t> t10(truth, truth + kTopK);
+        for (uint32_t i = 0; i < kTopK; ++i) {
+          if (row[i] != DiskANNIndex::kNoLabel && t10.count(static_cast<uint32_t>(row[i])) != 0) {
+            hit10 += 1.0;
+          }
+        }
+        if (row[0] != DiskANNIndex::kNoLabel && static_cast<uint32_t>(row[0]) == truth[0]) {
+          hit1 += 1.0;
+        }
+      }
+
+      const double recall1 = hit1 / nq_run;
+      const double recall10 = hit10 / (static_cast<double>(nq_run) * kTopK);
+      double total_us = 0;
+      for (double x : lat_us) {
+        total_us += x;
+      }
+      const double mean_us = total_us / nq_run;
+      const double p99_us = percentile(lat_us, 0.99);
+      const double mean_ios = static_cast<double>(a_ios.load()) / nq_run;
+      const double qps_1t = 1e6 / mean_us;
+
+      std::printf("  %3u  %9.4f  %9.1f  %9.1f  %7.1f  %4u  %9.0f\n", l, recall10, mean_us, p99_us,
+                  mean_ios, threads, agg_qps);
+      // CSV: mean_rerank_reads is 0 (PQ reranks from co-located coords; No-PQ has no
+      // rerank), and mean_total_reads == mean_ios for the same reason.
+      csv << system << "," << l << "," << kBeam << "," << recall1 << "," << recall10 << ","
+          << mean_us << "," << p99_us << "," << mean_ios << ",0," << mean_ios << "," << qps_1t
+          << "," << eff_depth << "," << threads << "," << agg_qps << "\n";
+    }
+    csv.close();
+    std::cout << "\n[bench] wrote " << out_csv << "\n";
+    return 0;
+  } catch (const std::exception &e) {
+    std::cerr << "[bench] ERROR: " << e.what() << "\n";
+    return 1;
+  }
+}

--- a/tests/diskann/test_diskann_beam_search.cpp
+++ b/tests/diskann/test_diskann_beam_search.cpp
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include "index/graph/diskann/beam_search.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <random>
+#include <unordered_set>
+#include <vector>
+
+#include "index/graph/diskann/disk_layout.hpp"
+#include "index/graph/diskann/node_cache.hpp"
+#include "index/graph/diskann/pq_table.hpp"
+#include "index/graph/diskann/search_scratch.hpp"
+#include "index/graph/laser/utils/aligned_file_reader_factory.hpp"
+#include "simd/distance_l2.hpp"
+
+namespace {
+
+using alaya::diskann::cached_beam_search;
+using alaya::diskann::DiskLayoutGeometry;
+using alaya::diskann::NodeCache;
+using alaya::diskann::PQTable;
+using alaya::diskann::scan_and_insert_neighbors;
+using alaya::diskann::SearchContext;
+using alaya::diskann::SearchParams;
+using alaya::diskann::SearchStats;
+using alaya::diskann::ThreadData;
+using alaya::diskann::write_disk_layout;
+using alaya::vamana::Neighbor;
+using alaya::vamana::NeighborPriorityQueue;
+
+std::vector<float> make_vectors(uint64_t n, uint64_t dim, uint32_t seed = 31) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  std::vector<float> v(n * dim);
+  for (auto &x : v) {
+    x = dist(rng);
+  }
+  return v;
+}
+
+// Complete graph capped at R: each node points to the first R other ids.
+std::vector<std::vector<uint32_t>> make_complete_graph(uint64_t n, uint32_t r) {
+  std::vector<std::vector<uint32_t>> g(n);
+  for (uint64_t i = 0; i < n; ++i) {
+    for (uint64_t j = 0; j < n && g[i].size() < r; ++j) {
+      if (j != i) {
+        g[i].push_back(static_cast<uint32_t>(j));
+      }
+    }
+  }
+  return g;
+}
+
+uint32_t medoid_of(const std::vector<float> &v, uint64_t n, uint64_t dim) {
+  std::vector<float> centroid(dim, 0.0f);
+  for (uint64_t i = 0; i < n; ++i) {
+    for (uint64_t d = 0; d < dim; ++d) {
+      centroid[d] += v[i * dim + d];
+    }
+  }
+  for (auto &c : centroid) {
+    c /= static_cast<float>(n);
+  }
+  uint32_t best = 0;
+  float best_d = std::numeric_limits<float>::max();
+  for (uint64_t i = 0; i < n; ++i) {
+    const float d = alaya::simd::l2_sqr<float, float>(centroid.data(), v.data() + i * dim, dim);
+    if (d < best_d) {
+      best_d = d;
+      best = static_cast<uint32_t>(i);
+    }
+  }
+  return best;
+}
+
+std::vector<std::pair<uint32_t, float>> brute_force(const std::vector<float> &v, uint64_t n,
+                                                    uint64_t dim, const float *q, uint32_t k) {
+  std::vector<std::pair<uint32_t, float>> all;
+  all.reserve(n);
+  for (uint64_t i = 0; i < n; ++i) {
+    all.emplace_back(static_cast<uint32_t>(i),
+                     alaya::simd::l2_sqr<float, float>(q, v.data() + i * dim, dim));
+  }
+  std::sort(all.begin(), all.end(), [](const auto &a, const auto &b) {
+    return a.second < b.second || (a.second == b.second && a.first < b.first);
+  });
+  if (all.size() > k) {
+    all.resize(k);
+  }
+  return all;
+}
+
+// ---- Pure neighbor-processing tests (no disk) ------------------------------
+
+TEST(BeamScanInsert, SkipsVisitedAndInsertsRest) {
+  // n <= 256 => lossless PQ; here we only check the visited/dedup bookkeeping.
+  const uint64_t n = 50, dim = 8;
+  const uint32_t n_chunks = 2;
+  const auto v = make_vectors(n, dim);
+  PQTable pq;
+  pq.train(v.data(), n, dim, n_chunks);
+  pq.encode(v.data(), n);
+  std::vector<float> table(static_cast<size_t>(n_chunks) * 256);
+  pq.preprocess_query(v.data(), table.data());
+
+  NeighborPriorityQueue retset(100);
+  std::unordered_set<uint32_t> visited;
+  for (uint32_t id = 0; id < 10; ++id) {
+    visited.insert(id);  // 10 already visited
+  }
+  std::vector<uint32_t> nbrs(32);
+  for (uint32_t i = 0; i < 32; ++i) {
+    nbrs[i] = i;  // 0..31; 0..9 are visited
+  }
+  scan_and_insert_neighbors(retset, visited, nbrs.data(), 32, pq, table.data(), /*num_points=*/n);
+  EXPECT_EQ(retset.size(), 22u);  // 32 - 10 already visited
+}
+
+TEST(BeamScanInsert, PQPrunesUncompetitiveNeighbors) {
+  const uint64_t n = 10, dim = 8;
+  const uint32_t n_chunks = 2;
+  const auto v = make_vectors(n, dim);
+  PQTable pq;  // n <= 256 => lossless: pq_distance == exact L2
+  pq.train(v.data(), n, dim, n_chunks);
+  pq.encode(v.data(), n);
+
+  std::vector<float> table(static_cast<size_t>(n_chunks) * 256);
+  pq.preprocess_query(v.data() + 0 * dim, table.data());  // query == point 0
+
+  NeighborPriorityQueue retset(4);  // capacity 4
+  std::unordered_set<uint32_t> visited;
+  std::vector<uint32_t> nbrs = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  scan_and_insert_neighbors(retset, visited, nbrs.data(),
+                            static_cast<uint32_t>(nbrs.size()), pq, table.data(), n);
+  EXPECT_EQ(retset.size(), 4u);  // bounded
+  // The globally farthest point from point 0 must have been pruned.
+  const auto bf = brute_force(v, n, dim, v.data(), n);  // sorted ascending
+  const uint32_t farthest = bf.back().first;
+  bool present = false;
+  for (size_t i = 0; i < retset.size(); ++i) {
+    if (retset[i].id == farthest) {
+      present = true;
+    }
+  }
+  EXPECT_FALSE(present) << "farthest id=" << farthest << " should be pruned";
+}
+
+// ---- Beam search over a real (tiny) on-disk index --------------------------
+
+class BeamSearchTest : public ::testing::Test {
+ protected:
+  void build(uint64_t n, uint64_t dim, uint32_t r, uint32_t n_chunks, double cache_ratio,
+             uint32_t beam = 4) {
+    n_ = n;
+    dim_ = dim;
+    r_ = r;
+    has_pq_ = n_chunks > 0;
+    vecs_ = make_vectors(n, dim);
+    graph_ = make_complete_graph(n, r);
+    medoid_ = medoid_of(vecs_, n, dim);
+    geom_ = DiskLayoutGeometry::compute(dim, r);
+
+    index_path_ = std::filesystem::temp_directory_path() /
+                  ("diskann_beam_" + std::to_string(counter_.fetch_add(1)) + ".index");
+    write_disk_layout(index_path_.string(), vecs_.data(), graph_, {n, dim, r, medoid_});
+
+    cache_.generate(graph_, vecs_.data(), medoid_, n, dim, r, cache_ratio);
+    if (has_pq_) {
+      pq_.train(vecs_.data(), n, dim, n_chunks);
+      pq_.encode(vecs_.data(), n);
+    }
+
+    reader_ = make_aligned_file_reader();
+    reader_->open(index_path_.string());
+    reader_->register_thread();
+    td_.ctx_ = reader_->get_ctx();
+    td_.alloc_scratch(2u * beam, geom_.page_size, has_pq_ ? n_chunks * 256u : 0u);
+    beam_ = beam;
+  }
+
+  void TearDown() override {
+    td_.free_scratch();
+    if (reader_) {
+      reader_->close();
+      reader_->deregister_all_threads();
+    }
+    std::error_code ec;
+    std::filesystem::remove(index_path_, ec);
+  }
+
+  std::vector<std::pair<uint32_t, float>> search(const float *q, uint32_t top_k, bool use_pq,
+                                                 bool rerank, uint32_t L = 50) {
+    SearchContext ctx;
+    ctx.reader = reader_.get();
+    ctx.geom = &geom_;
+    ctx.cache = &cache_;
+    ctx.pq = has_pq_ ? &pq_ : nullptr;
+    ctx.medoid = medoid_;
+    ctx.num_points = n_;
+    SearchParams p;
+    p.search_list_size = L;
+    p.beam_width = beam_;
+    p.use_pq = use_pq;
+    p.rerank = rerank;
+    last_stats_ = SearchStats{};
+    return cached_beam_search(ctx, q, top_k, p, td_, &last_stats_);
+  }
+
+  static std::atomic<uint64_t> counter_;
+  uint64_t n_ = 0, dim_ = 0;
+  uint32_t r_ = 0, medoid_ = 0, beam_ = 4;
+  bool has_pq_ = false;
+  std::vector<float> vecs_;
+  std::vector<std::vector<uint32_t>> graph_;
+  DiskLayoutGeometry geom_;
+  NodeCache cache_;
+  PQTable pq_;
+  std::filesystem::path index_path_;
+  std::unique_ptr<AlignedFileReader> reader_;
+  ThreadData td_;
+  SearchStats last_stats_;
+};
+std::atomic<uint64_t> BeamSearchTest::counter_{0};
+
+TEST_F(BeamSearchTest, MedoidProcessedFirst) {
+  build(/*n=*/20, /*dim=*/8, /*r=*/19, /*n_chunks=*/0, /*cache_ratio=*/0.0);
+  const auto res = search(vecs_.data() + 3 * dim_, /*top_k=*/5, /*use_pq=*/false, /*rerank=*/false);
+  ASSERT_FALSE(last_stats_.read_order.empty());
+  EXPECT_EQ(last_stats_.read_order[0], medoid_);
+}
+
+TEST_F(BeamSearchTest, NoDuplicateReads) {
+  build(20, 8, 19, 0, 0.0);
+  (void)search(vecs_.data() + 1 * dim_, 5, false, false);
+  std::unordered_set<uint32_t> seen;
+  for (uint32_t id : last_stats_.read_order) {
+    EXPECT_TRUE(seen.insert(id).second) << "duplicate read of id=" << id;
+  }
+}
+
+TEST_F(BeamSearchTest, NoPQFindsNearestNeighbor) {
+  build(20, 8, 19, 0, 0.0);  // complete graph => fully reachable
+  for (uint32_t qi = 0; qi < 20; ++qi) {
+    const float *q = vecs_.data() + qi * dim_;
+    const auto res = search(q, /*top_k=*/1, /*use_pq=*/false, /*rerank=*/false, /*L=*/40);
+    ASSERT_EQ(res.size(), 1u);
+    const auto bf = brute_force(vecs_, n_, dim_, q, 1);
+    EXPECT_EQ(res[0].first, bf[0].first) << "qi=" << qi;
+    EXPECT_NEAR(res[0].second, bf[0].second, 1e-4f);
+  }
+}
+
+TEST_F(BeamSearchTest, PQRerankGivesExactTopK) {
+  // n <= 256 => lossless PQ; with rerank the results are exact top-k.
+  build(20, 8, 19, /*n_chunks=*/4, /*cache_ratio=*/0.0);
+  const float *q = vecs_.data() + 7 * dim_;
+  const auto res = search(q, /*top_k=*/5, /*use_pq=*/true, /*rerank=*/true, /*L=*/40);
+  const auto bf = brute_force(vecs_, n_, dim_, q, 5);
+  ASSERT_EQ(res.size(), bf.size());
+  for (size_t i = 0; i < res.size(); ++i) {
+    EXPECT_EQ(res[i].first, bf[i].first) << "i=" << i;
+    EXPECT_NEAR(res[i].second, bf[i].second, 1e-3f) << "i=" << i;
+  }
+}
+
+TEST_F(BeamSearchTest, PQNoRerankReturnsSortedResults) {
+  build(20, 8, 19, 4, 0.0);
+  const float *q = vecs_.data() + 2 * dim_;
+  const auto res = search(q, /*top_k=*/5, /*use_pq=*/true, /*rerank=*/false, /*L=*/40);
+  ASSERT_EQ(res.size(), 5u);
+  for (size_t i = 1; i < res.size(); ++i) {
+    EXPECT_LE(res[i - 1].second, res[i].second);
+  }
+}
+
+TEST_F(BeamSearchTest, CacheHitPathServesAllFromMemory) {
+  build(20, 8, 19, /*n_chunks=*/0, /*cache_ratio=*/1.0);  // cache everything
+  const float *q = vecs_.data() + 4 * dim_;
+  const auto res = search(q, /*top_k=*/3, /*use_pq=*/false, /*rerank=*/false, /*L=*/40);
+  EXPECT_GT(last_stats_.n_cache_hits, 0u);
+  EXPECT_EQ(last_stats_.n_ios, 0u);  // nothing read from disk
+  const auto bf = brute_force(vecs_, n_, dim_, q, 3);
+  ASSERT_EQ(res.size(), 3u);
+  EXPECT_EQ(res[0].first, bf[0].first);
+}
+
+TEST_F(BeamSearchTest, TopKExceedingIndexSizeReturnsAll) {
+  build(12, 8, 11, 0, 0.0);
+  const auto res = search(vecs_.data(), /*top_k=*/50, false, false, /*L=*/60);
+  EXPECT_EQ(res.size(), 12u);  // only 12 points exist
+}
+
+}  // namespace

--- a/tests/diskann/test_diskann_disk_page_io.cpp
+++ b/tests/diskann/test_diskann_disk_page_io.cpp
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include "index/graph/diskann/disk_page_io.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "index/graph/diskann/disk_layout.hpp"
+#include "index/graph/diskann/diskann_index.hpp"
+
+namespace {
+
+#if defined(__linux__)
+
+using alaya::diskann::DiskANNBuildParams;
+using alaya::diskann::DiskANNIndex;
+using alaya::diskann::DiskLayoutGeometry;
+using alaya::diskann::DiskPageIO;
+
+std::vector<float> make_vectors(uint64_t n, uint64_t dim, uint32_t seed = 123) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  std::vector<float> v(n * dim);
+  for (auto &x : v) {
+    x = dist(rng);
+  }
+  return v;
+}
+
+std::vector<uint64_t> make_labels(uint64_t n) {
+  std::vector<uint64_t> labels(n);
+  for (uint64_t i = 0; i < n; ++i) {
+    labels[i] = 1000 + i;
+  }
+  return labels;
+}
+
+class DiskPageIOTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    static std::atomic<uint64_t> counter{0};
+    dir_ = std::filesystem::temp_directory_path() /
+           ("diskann_pageio_" + std::to_string(counter.fetch_add(1)));
+  }
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove_all(dir_, ec);
+  }
+
+  void build(uint64_t n, uint64_t dim, uint32_t r) {
+    n_ = n;
+    dim_ = dim;
+    r_ = r;
+    v_ = make_vectors(n, dim);
+    labels_ = make_labels(n);
+    DiskANNBuildParams bp;
+    bp.R = r;
+    bp.pq_n_chunks = 0;  // No-PQ (updates are No-PQ only)
+    DiskANNIndex::build(dir_.string(), v_.data(), labels_.data(), n, dim, bp);
+    geom_ = DiskLayoutGeometry::compute(dim, r);
+  }
+
+  std::string index_path() const { return (dir_ / "diskann.index").string(); }
+
+  std::filesystem::path dir_;
+  std::vector<float> v_;
+  std::vector<uint64_t> labels_;
+  uint64_t n_ = 0;
+  uint64_t dim_ = 0;
+  uint32_t r_ = 0;
+  DiskLayoutGeometry geom_;
+};
+
+TEST_F(DiskPageIOTest, ReadNodeMatchesBuild) {
+  build(200, 32, 32);
+  DiskPageIO io(index_path(), geom_);
+  for (uint32_t id : {0u, 1u, 50u, 199u}) {
+    const auto nd = io.read_node(id);
+    ASSERT_EQ(nd.coords.size(), dim_);
+    for (uint64_t d = 0; d < dim_; ++d) {
+      EXPECT_FLOAT_EQ(nd.coords[d], v_[id * dim_ + d]) << "id=" << id << " d=" << d;
+    }
+    EXPECT_LE(nd.nbrs.size(), r_);
+    for (const auto nb : nd.nbrs) {
+      EXPECT_LT(nb, n_);  // build neighbors are in range
+    }
+  }
+}
+
+TEST_F(DiskPageIOTest, WriteNodeRoundTrip) {
+  build(200, 32, 32);
+  DiskPageIO io(index_path(), geom_);
+  std::vector<float> coords(dim_);
+  for (uint64_t d = 0; d < dim_; ++d) {
+    coords[d] = 0.25f + 0.01f * static_cast<float>(d);
+  }
+  const std::vector<uint32_t> nbrs = {3, 7, 11, 42, 100};
+  io.write_node(5, coords.data(), static_cast<uint32_t>(nbrs.size()), nbrs.data());
+
+  const auto nd = io.read_node(5);
+  ASSERT_EQ(nd.coords.size(), dim_);
+  for (uint64_t d = 0; d < dim_; ++d) {
+    EXPECT_FLOAT_EQ(nd.coords[d], coords[d]) << "d=" << d;
+  }
+  ASSERT_EQ(nd.nbrs.size(), nbrs.size());
+  for (size_t i = 0; i < nbrs.size(); ++i) {
+    EXPECT_EQ(nd.nbrs[i], nbrs[i]) << "i=" << i;
+  }
+}
+
+TEST_F(DiskPageIOTest, WriteNodeReuseDoesNotDisturbCoResidentNodes) {
+  build(200, 32, 32);
+  DiskPageIO io(index_path(), geom_);
+  // Pick a node id that shares its page with neighbors; snapshot a co-resident.
+  const uint32_t target = 16;
+  const uint32_t sibling = target + 1;  // same sector page for nps>=2
+  ASSERT_EQ(geom_.get_page_offset(target), geom_.get_page_offset(sibling));
+  const auto sibling_before = io.read_node(sibling);
+
+  std::vector<float> coords(dim_, 0.5f);
+  const std::vector<uint32_t> nbrs = {1, 2};
+  io.write_node(target, coords.data(), static_cast<uint32_t>(nbrs.size()), nbrs.data());
+
+  const auto sibling_after = io.read_node(sibling);
+  EXPECT_EQ(sibling_before.coords, sibling_after.coords);
+  EXPECT_EQ(sibling_before.nbrs, sibling_after.nbrs);
+}
+
+TEST_F(DiskPageIOTest, WriteNodeNeighborsPreservesCoords) {
+  build(200, 32, 32);
+  DiskPageIO io(index_path(), geom_);
+  const auto before = io.read_node(10);
+  const std::vector<uint32_t> new_nbrs = {1, 2, 3};
+  io.write_node_neighbors(10, static_cast<uint32_t>(new_nbrs.size()), new_nbrs.data());
+
+  const auto after = io.read_node(10);
+  ASSERT_EQ(after.coords.size(), before.coords.size());
+  for (uint64_t d = 0; d < dim_; ++d) {
+    EXPECT_FLOAT_EQ(after.coords[d], before.coords[d]) << "d=" << d;
+  }
+  ASSERT_EQ(after.nbrs.size(), new_nbrs.size());
+  for (size_t i = 0; i < new_nbrs.size(); ++i) {
+    EXPECT_EQ(after.nbrs[i], new_nbrs[i]) << "i=" << i;
+  }
+}
+
+TEST_F(DiskPageIOTest, WriteNodeExtendsFileOnAppend) {
+  build(200, 32, 32);
+  DiskPageIO io(index_path(), geom_);
+  const uint64_t before_size = io.file_size();
+  // First id whose page does not yet exist (forces ftruncate extension).
+  const uint32_t append_id = static_cast<uint32_t>(geom_.nodes_per_sector * geom_.num_pages(n_));
+  ASSERT_GE(geom_.get_page_offset(append_id) + geom_.page_size, before_size);
+
+  std::vector<float> coords(dim_, 1.0f);
+  const std::vector<uint32_t> nbrs = {0, 1};
+  io.write_node(append_id, coords.data(), static_cast<uint32_t>(nbrs.size()), nbrs.data());
+  EXPECT_GT(io.file_size(), before_size);  // file was extended
+
+  const auto nd = io.read_node(append_id);
+  for (uint64_t d = 0; d < dim_; ++d) {
+    EXPECT_FLOAT_EQ(nd.coords[d], coords[d]) << "d=" << d;
+  }
+  ASSERT_EQ(nd.nbrs.size(), nbrs.size());
+}
+
+TEST_F(DiskPageIOTest, CoordsCacheReturnsConsistentVectors) {
+  build(100, 16, 16);
+  DiskPageIO io(index_path(), geom_);
+  const std::vector<float> first = io.read_coords_cached(7);  // value copy
+  const auto &cached = io.read_coords_cached(7);              // cache hit
+  EXPECT_EQ(first, cached);
+  ASSERT_EQ(cached.size(), dim_);
+  for (uint64_t d = 0; d < dim_; ++d) {
+    EXPECT_FLOAT_EQ(cached[d], v_[7 * dim_ + d]) << "d=" << d;
+  }
+}
+
+#else  // !__linux__
+
+TEST(DiskPageIOTest, SkippedOnNonLinux) {
+  GTEST_SKIP() << "DiskPageIO in-place updates require Linux O_DIRECT";
+}
+
+#endif  // __linux__
+
+}  // namespace

--- a/tests/diskann/test_diskann_e2e.cpp
+++ b/tests/diskann/test_diskann_e2e.cpp
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// End-to-end DiskANN index tests: build a 10K-vector index on disk, then load
+// and search it, measuring recall against brute-force ground truth.
+
+#include "index/graph/diskann/diskann_index.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <random>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include "simd/distance_l2.hpp"
+
+namespace {
+
+using alaya::diskann::DiskANNBuildParams;
+using alaya::diskann::DiskANNIndex;
+using alaya::diskann::DiskANNLoadParams;
+using alaya::diskann::DiskANNSearchParams;
+
+constexpr uint64_t kN = 10000;
+constexpr uint64_t kDim = 128;
+constexpr uint32_t kNQ = 100;
+constexpr uint32_t kTopK = 10;
+
+std::vector<float> make_vectors(uint64_t n, uint64_t dim, uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::normal_distribution<float> dist(0.0f, 1.0f);
+  std::vector<float> v(n * dim);
+  for (auto &x : v) {
+    x = dist(rng);
+  }
+  return v;
+}
+
+// Exact top-k internal ids per query (brute force ground truth).
+std::vector<std::vector<uint32_t>> ground_truth(const std::vector<float> &data, uint64_t n,
+                                                uint64_t dim, const std::vector<float> &queries,
+                                                uint32_t nq, uint32_t k) {
+  std::vector<std::vector<uint32_t>> gt(nq);
+  for (uint32_t q = 0; q < nq; ++q) {
+    const float *query = queries.data() + static_cast<uint64_t>(q) * dim;
+    std::vector<std::pair<float, uint32_t>> d;
+    d.reserve(n);
+    for (uint64_t i = 0; i < n; ++i) {
+      d.emplace_back(alaya::simd::l2_sqr<float, float>(query, data.data() + i * dim, dim),
+                     static_cast<uint32_t>(i));
+    }
+    std::partial_sort(d.begin(), d.begin() + k, d.end());
+    gt[q].reserve(k);
+    for (uint32_t i = 0; i < k; ++i) {
+      gt[q].push_back(d[i].second);
+    }
+  }
+  return gt;
+}
+
+class DiskANNE2ETest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    data_ = make_vectors(kN, kDim, /*seed=*/1);
+    queries_ = make_vectors(kNQ, kDim, /*seed=*/999);
+    labels_.resize(kN);
+    for (uint64_t i = 0; i < kN; ++i) {
+      labels_[i] = 5000 + i;  // offset labels exercise the id map
+    }
+    gt_ = ground_truth(data_, kN, kDim, queries_, kNQ, kTopK);
+
+    auto base = std::filesystem::temp_directory_path();
+    pq_dir_ = (base / "diskann_e2e_pq").string();
+    nopq_dir_ = (base / "diskann_e2e_nopq").string();
+    std::error_code ec;
+    std::filesystem::remove_all(pq_dir_, ec);
+    std::filesystem::remove_all(nopq_dir_, ec);
+
+    DiskANNBuildParams bp;
+    bp.R = 64;
+    bp.L = 125;
+    bp.alpha = 1.2f;
+    bp.cache_ratio = 0.05;
+    bp.pq_n_chunks = 32;  // 128 / 32 = chunk_dim 4
+    DiskANNIndex::build(pq_dir_, data_.data(), labels_.data(), kN, kDim, bp);
+
+    bp.pq_n_chunks = 0;  // no-PQ variant on the same data
+    DiskANNIndex::build(nopq_dir_, data_.data(), labels_.data(), kN, kDim, bp);
+  }
+
+  static void TearDownTestSuite() {
+    std::error_code ec;
+    std::filesystem::remove_all(pq_dir_, ec);
+    std::filesystem::remove_all(nopq_dir_, ec);
+    data_.clear();
+    queries_.clear();
+    labels_.clear();
+    gt_.clear();
+  }
+
+  // Recall@k of a returned label set vs ground-truth internal ids.
+  double recall_at_k(const std::vector<uint64_t> &out_labels, uint32_t q, uint32_t k) const {
+    std::unordered_set<uint32_t> truth(gt_[q].begin(), gt_[q].end());
+    uint32_t hit = 0;
+    for (uint32_t i = 0; i < k; ++i) {
+      if (out_labels[i] == DiskANNIndex::kNoLabel) {
+        continue;
+      }
+      const uint32_t internal = static_cast<uint32_t>(out_labels[i] - 5000);
+      if (truth.count(internal) != 0) {
+        ++hit;
+      }
+    }
+    return static_cast<double>(hit) / static_cast<double>(k);
+  }
+
+  double mean_recall(DiskANNIndex &idx, const DiskANNSearchParams &sp, uint32_t nq = kNQ) const {
+    double sum = 0.0;
+    std::vector<uint64_t> out_l(kTopK);
+    std::vector<float> out_d(kTopK);
+    for (uint32_t q = 0; q < nq; ++q) {
+      idx.search(queries_.data() + static_cast<uint64_t>(q) * kDim, kTopK, out_l.data(),
+                 out_d.data(), sp);
+      sum += recall_at_k(out_l, q, kTopK);
+    }
+    return sum / nq;
+  }
+
+  static std::vector<float> data_;
+  static std::vector<float> queries_;
+  static std::vector<uint64_t> labels_;
+  static std::vector<std::vector<uint32_t>> gt_;
+  static std::string pq_dir_;
+  static std::string nopq_dir_;
+};
+
+std::vector<float> DiskANNE2ETest::data_;
+std::vector<float> DiskANNE2ETest::queries_;
+std::vector<uint64_t> DiskANNE2ETest::labels_;
+std::vector<std::vector<uint32_t>> DiskANNE2ETest::gt_;
+std::string DiskANNE2ETest::pq_dir_;
+std::string DiskANNE2ETest::nopq_dir_;
+
+TEST_F(DiskANNE2ETest, RecallAbovePoint9_PQRerank) {
+  DiskANNIndex idx;
+  idx.load(pq_dir_, {/*num_threads=*/4, /*beam_width=*/8});
+  const DiskANNSearchParams sp{/*L=*/150, /*use_pq=*/true, /*rerank=*/true, /*rerank_count=*/100};
+  const double recall = mean_recall(idx, sp);
+  std::cout << "[e2e] PQ+rerank recall@10 = " << recall << std::endl;
+  EXPECT_GT(recall, 0.9);
+}
+
+TEST_F(DiskANNE2ETest, NoPQReturnsCorrectResults) {
+  // No-PQ is exact disk greedy search, so recall is high at a moderate L. It
+  // reads every discovered node (higher I/O than PQ, design D5), so this uses a
+  // smaller query subset to keep the test fast.
+  DiskANNIndex idx;
+  idx.load(nopq_dir_, {/*num_threads=*/4, /*beam_width=*/8});
+  const DiskANNSearchParams sp{/*L=*/150, /*use_pq=*/false, /*rerank=*/false};
+  const double recall = mean_recall(idx, sp, /*nq=*/25);
+  std::cout << "[e2e] No-PQ (exact greedy) recall@10 = " << recall << std::endl;
+  EXPECT_GT(recall, 0.9);
+}
+
+TEST_F(DiskANNE2ETest, NoPQAsyncMatchesDeterministicRecall) {
+  // No-PQ distances are exact and the frontier insert is order-independent, so
+  // the async-pipelined default and the deterministic barrier reach the same
+  // recall (they may differ only in tie-ordering, to which recall@k is blind;
+  // the relaxed expansion order can perturb the visited set marginally, hence a
+  // small tolerance rather than exact equality).
+  DiskANNIndex idx;
+  idx.load(nopq_dir_, {/*num_threads=*/4, /*beam_width=*/8});
+  const double r_async = mean_recall(
+      idx, {/*L=*/150, /*use_pq=*/false, /*rerank=*/false, /*rerank_count=*/0,
+            /*deterministic=*/false},
+      /*nq=*/25);
+  const double r_det = mean_recall(
+      idx, {/*L=*/150, /*use_pq=*/false, /*rerank=*/false, /*rerank_count=*/0,
+            /*deterministic=*/true},
+      /*nq=*/25);
+  std::cout << "[e2e] No-PQ recall async=" << r_async << " deterministic=" << r_det << std::endl;
+  EXPECT_NEAR(r_async, r_det, 0.02);
+}
+
+TEST_F(DiskANNE2ETest, RerankImprovesRecall) {
+  DiskANNIndex idx;
+  idx.load(pq_dir_, {/*num_threads=*/4, /*beam_width=*/8});
+  const double r_no = mean_recall(idx, {/*L=*/150, /*use_pq=*/true, /*rerank=*/false});
+  const double r_yes = mean_recall(idx, {/*L=*/150, /*use_pq=*/true, /*rerank=*/true});
+  std::cout << "[e2e] recall no-rerank=" << r_no << " rerank=" << r_yes << std::endl;
+  EXPECT_GE(r_yes, r_no);
+}
+
+TEST_F(DiskANNE2ETest, BatchMatchesSequential) {
+  DiskANNIndex idx;
+  idx.load(pq_dir_, {/*num_threads=*/4, /*beam_width=*/8});
+  // deterministic=true: this test asserts byte-exact batch/sequential equality,
+  // which is exactly the guarantee the deterministic per-beam barrier provides.
+  const DiskANNSearchParams sp{/*L=*/120, /*use_pq=*/true, /*rerank=*/true,
+                               /*rerank_count=*/0, /*deterministic=*/true};
+
+  std::vector<uint64_t> seq_l(static_cast<uint64_t>(kNQ) * kTopK);
+  std::vector<float> seq_d(static_cast<uint64_t>(kNQ) * kTopK);
+  for (uint32_t q = 0; q < kNQ; ++q) {
+    idx.search(queries_.data() + static_cast<uint64_t>(q) * kDim, kTopK,
+               seq_l.data() + static_cast<uint64_t>(q) * kTopK,
+               seq_d.data() + static_cast<uint64_t>(q) * kTopK, sp);
+  }
+
+  std::vector<uint64_t> bat_l(static_cast<uint64_t>(kNQ) * kTopK);
+  std::vector<float> bat_d(static_cast<uint64_t>(kNQ) * kTopK);
+  idx.batch_search(queries_.data(), kNQ, kTopK, bat_l.data(), bat_d.data(), /*num_threads=*/4, sp);
+
+  EXPECT_EQ(seq_l, bat_l);
+  for (size_t i = 0; i < seq_d.size(); ++i) {
+    EXPECT_FLOAT_EQ(seq_d[i], bat_d[i]) << "i=" << i;
+  }
+}
+
+TEST_F(DiskANNE2ETest, ConcurrentSearchCorrect) {
+  DiskANNIndex idx;
+  idx.load(pq_dir_, {/*num_threads=*/4, /*beam_width=*/8});
+  // deterministic=true: this test asserts byte-exact batch/sequential equality,
+  // which is exactly the guarantee the deterministic per-beam barrier provides.
+  const DiskANNSearchParams sp{/*L=*/120, /*use_pq=*/true, /*rerank=*/true,
+                               /*rerank_count=*/0, /*deterministic=*/true};
+
+  // Sequential reference.
+  std::vector<uint64_t> ref(static_cast<uint64_t>(kNQ) * kTopK);
+  for (uint32_t q = 0; q < kNQ; ++q) {
+    std::vector<float> d(kTopK);
+    idx.search(queries_.data() + static_cast<uint64_t>(q) * kDim, kTopK,
+               ref.data() + static_cast<uint64_t>(q) * kTopK, d.data(), sp);
+  }
+
+  // 4 threads each run a disjoint slice concurrently.
+  std::vector<uint64_t> conc(static_cast<uint64_t>(kNQ) * kTopK);
+  auto worker = [&](uint32_t begin, uint32_t end) {
+    std::vector<float> d(kTopK);
+    for (uint32_t q = begin; q < end; ++q) {
+      idx.search(queries_.data() + static_cast<uint64_t>(q) * kDim, kTopK,
+                 conc.data() + static_cast<uint64_t>(q) * kTopK, d.data(), sp);
+    }
+  };
+  std::vector<std::thread> threads;
+  const uint32_t chunk = (kNQ + 3) / 4;
+  for (uint32_t t = 0; t < 4; ++t) {
+    const uint32_t b = t * chunk;
+    const uint32_t e = std::min(kNQ, b + chunk);
+    if (b < e) {
+      threads.emplace_back(worker, b, e);
+    }
+  }
+  for (auto &th : threads) {
+    th.join();
+  }
+  EXPECT_EQ(ref, conc);
+}
+
+TEST_F(DiskANNE2ETest, ConcurrentDefaultPathValid) {
+  // The default (deterministic=false) async-pipelined path is non-deterministic
+  // in tie-ordering, so byte-equality cannot be asserted. Instead run every query
+  // concurrently and require recall to stay high: a data race in the async
+  // pipeline (free_slots / inflight / scratch reuse) would corrupt results and
+  // tank recall.
+  DiskANNIndex idx;
+  idx.load(pq_dir_, {/*num_threads=*/4, /*beam_width=*/8});
+  const DiskANNSearchParams sp{/*L=*/150, /*use_pq=*/true, /*rerank=*/true,
+                               /*rerank_count=*/100, /*deterministic=*/false};
+
+  std::vector<uint64_t> out(static_cast<uint64_t>(kNQ) * kTopK);
+  auto worker = [&](uint32_t begin, uint32_t end) {
+    std::vector<float> d(kTopK);
+    for (uint32_t q = begin; q < end; ++q) {
+      idx.search(queries_.data() + static_cast<uint64_t>(q) * kDim, kTopK,
+                 out.data() + static_cast<uint64_t>(q) * kTopK, d.data(), sp);
+    }
+  };
+  std::vector<std::thread> threads;
+  const uint32_t chunk = (kNQ + 3) / 4;
+  for (uint32_t t = 0; t < 4; ++t) {
+    const uint32_t b = t * chunk;
+    const uint32_t e = std::min(kNQ, b + chunk);
+    if (b < e) {
+      threads.emplace_back(worker, b, e);
+    }
+  }
+  for (auto &th : threads) {
+    th.join();
+  }
+
+  double sum = 0.0;
+  std::vector<uint64_t> row(kTopK);
+  for (uint32_t q = 0; q < kNQ; ++q) {
+    for (uint32_t i = 0; i < kTopK; ++i) {
+      row[i] = out[static_cast<uint64_t>(q) * kTopK + i];
+    }
+    sum += recall_at_k(row, q, kTopK);
+  }
+  const double recall = sum / kNQ;
+  std::cout << "[e2e] concurrent default-path recall@10 = " << recall << std::endl;
+  EXPECT_GT(recall, 0.9);
+}
+
+TEST_F(DiskANNE2ETest, NoPQConcurrentDefaultPathValid) {
+  // Same race check for the No-PQ async pipeline, which adds a `pending` deque on
+  // top of the free_slots/inflight machinery. Run all queries concurrently on the
+  // default path and require high recall (a data race would corrupt and tank it).
+  DiskANNIndex idx;
+  idx.load(nopq_dir_, {/*num_threads=*/4, /*beam_width=*/8});
+  const DiskANNSearchParams sp{/*L=*/150, /*use_pq=*/false, /*rerank=*/false,
+                               /*rerank_count=*/0, /*deterministic=*/false};
+
+  std::vector<uint64_t> out(static_cast<uint64_t>(kNQ) * kTopK);
+  auto worker = [&](uint32_t begin, uint32_t end) {
+    std::vector<float> d(kTopK);
+    for (uint32_t q = begin; q < end; ++q) {
+      idx.search(queries_.data() + static_cast<uint64_t>(q) * kDim, kTopK,
+                 out.data() + static_cast<uint64_t>(q) * kTopK, d.data(), sp);
+    }
+  };
+  std::vector<std::thread> threads;
+  const uint32_t chunk = (kNQ + 3) / 4;
+  for (uint32_t t = 0; t < 4; ++t) {
+    const uint32_t b = t * chunk;
+    const uint32_t e = std::min(kNQ, b + chunk);
+    if (b < e) {
+      threads.emplace_back(worker, b, e);
+    }
+  }
+  for (auto &th : threads) {
+    th.join();
+  }
+
+  double sum = 0.0;
+  std::vector<uint64_t> row(kTopK);
+  for (uint32_t q = 0; q < kNQ; ++q) {
+    for (uint32_t i = 0; i < kTopK; ++i) {
+      row[i] = out[static_cast<uint64_t>(q) * kTopK + i];
+    }
+    sum += recall_at_k(row, q, kTopK);
+  }
+  const double recall = sum / kNQ;
+  std::cout << "[e2e] No-PQ concurrent default-path recall@10 = " << recall << std::endl;
+  EXPECT_GT(recall, 0.9);
+}
+
+}  // namespace

--- a/tests/diskann/test_diskann_index.cpp
+++ b/tests/diskann/test_diskann_index.cpp
@@ -1,0 +1,347 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include "index/graph/diskann/diskann_index.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <vector>
+
+#include "simd/distance_l2.hpp"
+
+namespace {
+
+using alaya::diskann::DiskANNBuildParams;
+using alaya::diskann::DiskANNIndex;
+using alaya::diskann::DiskANNLoadParams;
+using alaya::diskann::DiskANNSearchParams;
+
+std::vector<float> make_vectors(uint64_t n, uint64_t dim, uint32_t seed = 123) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  std::vector<float> v(n * dim);
+  for (auto &x : v) {
+    x = dist(rng);
+  }
+  return v;
+}
+
+// External labels deliberately offset from internal ids to exercise the map.
+std::vector<uint64_t> make_labels(uint64_t n) {
+  std::vector<uint64_t> labels(n);
+  for (uint64_t i = 0; i < n; ++i) {
+    labels[i] = 1000 + i;
+  }
+  return labels;
+}
+
+std::vector<uint32_t> brute_force_ids(const std::vector<float> &v, uint64_t n, uint64_t dim,
+                                      const float *q, uint32_t k) {
+  std::vector<std::pair<float, uint32_t>> all;
+  for (uint64_t i = 0; i < n; ++i) {
+    all.emplace_back(alaya::simd::l2_sqr<float, float>(q, v.data() + i * dim, dim),
+                     static_cast<uint32_t>(i));
+  }
+  std::sort(all.begin(), all.end());
+  std::vector<uint32_t> ids;
+  for (uint32_t i = 0; i < k && i < all.size(); ++i) {
+    ids.push_back(all[i].second);
+  }
+  return ids;
+}
+
+class DiskANNIndexTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    static std::atomic<uint64_t> counter{0};
+    dir_ = std::filesystem::temp_directory_path() /
+           ("diskann_idx_" + std::to_string(counter.fetch_add(1)));
+  }
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove_all(dir_, ec);
+  }
+  std::string dir() const { return dir_.string(); }
+  std::filesystem::path dir_;
+};
+
+// ----------------------------- build --------------------------------------
+
+TEST_F(DiskANNIndexTest, BuildWithoutPQProducesExpectedFiles) {
+  const uint64_t n = 200, dim = 32;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  DiskANNBuildParams bp;
+  bp.R = 32;
+  bp.pq_n_chunks = 0;
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, bp);
+
+  namespace fs = std::filesystem;
+  EXPECT_TRUE(fs::exists(dir_ / "meta.bin"));
+  EXPECT_TRUE(fs::exists(dir_ / "diskann.index"));
+  EXPECT_TRUE(fs::exists(dir_ / "ids.bin"));
+  EXPECT_TRUE(fs::exists(dir_ / "cache_ids.bin"));
+  EXPECT_TRUE(fs::exists(dir_ / "cache_nodes.bin"));
+  EXPECT_FALSE(fs::exists(dir_ / "pq_pivots.bin"));
+  EXPECT_FALSE(fs::exists(dir_ / "pq_compressed.bin"));
+}
+
+TEST_F(DiskANNIndexTest, BuildWithPQProducesPQFiles) {
+  const uint64_t n = 300, dim = 32;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  DiskANNBuildParams bp;
+  bp.R = 32;
+  bp.pq_n_chunks = 8;
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, bp);
+
+  namespace fs = std::filesystem;
+  EXPECT_TRUE(fs::exists(dir_ / "pq_pivots.bin"));
+  EXPECT_TRUE(fs::exists(dir_ / "pq_compressed.bin"));
+}
+
+TEST_F(DiskANNIndexTest, BuildRejectsZeroDim) {
+  const auto v = make_vectors(10, 4);
+  const auto labels = make_labels(10);
+  EXPECT_THROW(DiskANNIndex::build(dir(), v.data(), labels.data(), 10, /*dim=*/0, {}),
+               std::invalid_argument);
+}
+
+TEST_F(DiskANNIndexTest, BuildRejectsEmptyInput) {
+  const auto v = make_vectors(1, 4);
+  const auto labels = make_labels(1);
+  EXPECT_THROW(DiskANNIndex::build(dir(), v.data(), labels.data(), /*n=*/0, 4, {}),
+               std::invalid_argument);
+}
+
+TEST_F(DiskANNIndexTest, BuildRejectsExistingDirectoryBeforeWriting) {
+  std::filesystem::create_directories(dir_);
+  const auto v = make_vectors(10, 4);
+  const auto labels = make_labels(10);
+  EXPECT_THROW(DiskANNIndex::build(dir(), v.data(), labels.data(), 10, 4, {}), std::runtime_error);
+  // Nothing should have been written into the pre-existing directory.
+  EXPECT_FALSE(std::filesystem::exists(dir_ / "meta.bin"));
+}
+
+// ----------------------------- load ---------------------------------------
+
+TEST_F(DiskANNIndexTest, LoadNoPQHasNoPQAndSearches) {
+  const uint64_t n = 200, dim = 32;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  DiskANNBuildParams bp;
+  bp.R = 32;
+  bp.pq_n_chunks = 0;
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, bp);
+
+  DiskANNIndex idx;
+  idx.load(dir(), {/*num_threads=*/2, /*beam_width=*/4});
+  EXPECT_FALSE(idx.has_pq());
+  EXPECT_EQ(idx.size(), n);
+  EXPECT_EQ(idx.dim(), dim);
+
+  std::vector<uint64_t> out_l(10);
+  std::vector<float> out_d(10);
+  const uint32_t cnt = idx.search(v.data(), 10, out_l.data(), out_d.data(),
+                                  {/*L=*/64, /*use_pq=*/false, /*rerank=*/false});
+  EXPECT_EQ(cnt, 10u);
+}
+
+TEST_F(DiskANNIndexTest, LoadPQHasPQ) {
+  const uint64_t n = 300, dim = 32;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  DiskANNBuildParams bp;
+  bp.R = 32;
+  bp.pq_n_chunks = 8;
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, bp);
+
+  DiskANNIndex idx;
+  idx.load(dir());
+  EXPECT_TRUE(idx.has_pq());
+}
+
+TEST_F(DiskANNIndexTest, LoadRejectsMissingDirectory) {
+  DiskANNIndex idx;
+  EXPECT_THROW(idx.load((dir_ / "does_not_exist").string()), std::runtime_error);
+}
+
+TEST_F(DiskANNIndexTest, LoadRejectsTruncatedMeta) {
+  const uint64_t n = 100, dim = 16;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, {});
+  // Truncate meta.bin to a few bytes.
+  {
+    std::ofstream out((dir_ / "meta.bin").string(), std::ios::binary | std::ios::trunc);
+    const char junk[4] = {1, 2, 3, 4};
+    out.write(junk, sizeof(junk));
+  }
+  DiskANNIndex idx;
+  EXPECT_THROW(idx.load(dir()), std::runtime_error);
+}
+
+// ----------------------------- search -------------------------------------
+
+TEST_F(DiskANNIndexTest, SearchReturnsSortedValidTopK) {
+  const uint64_t n = 400, dim = 32;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  DiskANNBuildParams bp;
+  bp.R = 32;
+  bp.pq_n_chunks = 8;
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, bp);
+
+  DiskANNIndex idx;
+  idx.load(dir(), {2, 4});
+  const float *q = v.data() + 17 * dim;
+  std::vector<uint64_t> out_l(10);
+  std::vector<float> out_d(10);
+  // deterministic=true: this asserts the exact nearest neighbour is found, an
+  // exactness guarantee the reproducible barrier path provides; the default
+  // async path's recall is covered statistically by the e2e tests.
+  const uint32_t cnt = idx.search(q, 10, out_l.data(), out_d.data(),
+                                  {/*L=*/96, /*use_pq=*/true, /*rerank=*/true,
+                                   /*rerank_count=*/0, /*deterministic=*/true});
+  ASSERT_EQ(cnt, 10u);
+  for (uint32_t i = 0; i < cnt; ++i) {
+    EXPECT_GE(out_d[i], 0.0f);
+    EXPECT_GE(out_l[i], 1000u);  // labels are 1000+id
+    if (i > 0) {
+      EXPECT_LE(out_d[i - 1], out_d[i]);  // ascending
+    }
+    // Reported distance must equal the exact L2 to that label's vector.
+    const uint32_t internal = static_cast<uint32_t>(out_l[i] - 1000);
+    const float exact = alaya::simd::l2_sqr<float, float>(q, v.data() + internal * dim, dim);
+    EXPECT_NEAR(out_d[i], exact, 1e-2f * (1.0f + exact)) << "i=" << i;
+  }
+  // The nearest neighbour (the query is point 17) should be found.
+  const auto truth = brute_force_ids(v, n, dim, q, 1);
+  EXPECT_EQ(out_l[0] - 1000, truth[0]);
+}
+
+TEST_F(DiskANNIndexTest, SearchTopKExceedingSizeReturnsAll) {
+  const uint64_t n = 50, dim = 16;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  DiskANNBuildParams bp;
+  bp.R = 24;
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, bp);
+  DiskANNIndex idx;
+  idx.load(dir());
+  std::vector<uint64_t> out_l(200);
+  std::vector<float> out_d(200);
+  const uint32_t cnt = idx.search(v.data(), 200, out_l.data(), out_d.data(), {/*L=*/200});
+  EXPECT_EQ(cnt, n);
+}
+
+TEST_F(DiskANNIndexTest, SearchRejectsNullQueryAndZeroTopK) {
+  const uint64_t n = 60, dim = 16;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, {});
+  DiskANNIndex idx;
+  idx.load(dir());
+  std::vector<uint64_t> out_l(10);
+  std::vector<float> out_d(10);
+  EXPECT_THROW(idx.search(nullptr, 10, out_l.data(), out_d.data()), std::invalid_argument);
+  EXPECT_THROW(idx.search(v.data(), 0, out_l.data(), out_d.data()), std::invalid_argument);
+}
+
+// ----------------------------- batch --------------------------------------
+
+TEST_F(DiskANNIndexTest, BatchSearchMatchesSequential) {
+  const uint64_t n = 400, dim = 32;
+  const uint32_t nq = 40, k = 10;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  const auto queries = make_vectors(nq, dim, /*seed=*/777);
+  DiskANNBuildParams bp;
+  bp.R = 32;
+  bp.pq_n_chunks = 8;
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, bp);
+
+  DiskANNIndex idx;
+  idx.load(dir(), {/*num_threads=*/4, /*beam_width=*/4});
+  // deterministic=true: asserts byte-exact batch==sequential (the barrier's job).
+  const DiskANNSearchParams sp{/*L=*/96, /*use_pq=*/true, /*rerank=*/true,
+                               /*rerank_count=*/0, /*deterministic=*/true};
+
+  std::vector<uint64_t> seq_l(nq * k);
+  std::vector<float> seq_d(nq * k);
+  for (uint32_t qi = 0; qi < nq; ++qi) {
+    idx.search(queries.data() + qi * dim, k, seq_l.data() + qi * k, seq_d.data() + qi * k, sp);
+  }
+
+  std::vector<uint64_t> bat_l(nq * k);
+  std::vector<float> bat_d(nq * k);
+  idx.batch_search(queries.data(), nq, k, bat_l.data(), bat_d.data(), /*num_threads=*/4, sp);
+
+  EXPECT_EQ(seq_l, bat_l);
+  for (size_t i = 0; i < seq_d.size(); ++i) {
+    EXPECT_FLOAT_EQ(seq_d[i], bat_d[i]) << "i=" << i;
+  }
+}
+
+TEST_F(DiskANNIndexTest, NoPQBatchDeterministicMatchesSequential) {
+  // No-PQ greedy search: with deterministic = true the batched per-expansion
+  // barrier must reproduce sequential search() byte for byte across threads
+  // (the async default may reorder equally-distant ties, so it is not asserted
+  // here — its recall equivalence is covered by the e2e suite).
+  const uint64_t n = 400, dim = 32;
+  const uint32_t nq = 40, k = 10;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  const auto queries = make_vectors(nq, dim, /*seed=*/777);
+  DiskANNBuildParams bp;
+  bp.R = 32;
+  bp.pq_n_chunks = 0;  // No-PQ index
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, bp);
+
+  DiskANNIndex idx;
+  idx.load(dir(), {/*num_threads=*/4, /*beam_width=*/4});
+  const DiskANNSearchParams sp{/*L=*/96, /*use_pq=*/false, /*rerank=*/false,
+                               /*rerank_count=*/0, /*deterministic=*/true};
+
+  std::vector<uint64_t> seq_l(nq * k);
+  std::vector<float> seq_d(nq * k);
+  for (uint32_t qi = 0; qi < nq; ++qi) {
+    idx.search(queries.data() + qi * dim, k, seq_l.data() + qi * k, seq_d.data() + qi * k, sp);
+  }
+
+  std::vector<uint64_t> bat_l(nq * k);
+  std::vector<float> bat_d(nq * k);
+  idx.batch_search(queries.data(), nq, k, bat_l.data(), bat_d.data(), /*num_threads=*/4, sp);
+
+  EXPECT_EQ(seq_l, bat_l);
+  for (size_t i = 0; i < seq_d.size(); ++i) {
+    EXPECT_FLOAT_EQ(seq_d[i], bat_d[i]) << "i=" << i;
+  }
+}
+
+TEST_F(DiskANNIndexTest, BatchSearchSingleThread) {
+  const uint64_t n = 200, dim = 16;
+  const uint32_t nq = 8, k = 5;
+  const auto v = make_vectors(n, dim);
+  const auto labels = make_labels(n);
+  const auto queries = make_vectors(nq, dim, /*seed=*/9);
+  DiskANNIndex::build(dir(), v.data(), labels.data(), n, dim, {});
+  DiskANNIndex idx;
+  idx.load(dir(), {/*num_threads=*/2, /*beam_width=*/4});
+  std::vector<uint64_t> out_l(nq * k);
+  std::vector<float> out_d(nq * k);
+  idx.batch_search(queries.data(), nq, k, out_l.data(), out_d.data(), /*num_threads=*/1,
+                   {/*L=*/64, /*use_pq=*/false, /*rerank=*/false});
+  for (uint32_t qi = 0; qi < nq; ++qi) {
+    EXPECT_GE(out_l[qi * k], 1000u);  // each query produced results
+  }
+}
+
+}  // namespace

--- a/tests/diskann/test_diskann_layout.cpp
+++ b/tests/diskann/test_diskann_layout.cpp
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include "index/graph/diskann/disk_layout.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+using alaya::diskann::DiskLayoutGeometry;
+using alaya::diskann::DiskLayoutHeader;
+using alaya::diskann::kSectorLen;
+using alaya::diskann::read_disk_layout_header;
+using alaya::diskann::write_disk_layout;
+using alaya::diskann::WriteDiskLayoutParams;
+
+// Generate deterministic row-major vectors.
+std::vector<float> make_vectors(uint64_t n, uint64_t dim, uint32_t seed = 7) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  std::vector<float> v(n * dim);
+  for (auto &x : v) {
+    x = dist(rng);
+  }
+  return v;
+}
+
+// A simple ring graph so every node has a deterministic, in-range neighbor set.
+std::vector<std::vector<uint32_t>> make_ring_graph(uint64_t n, uint32_t degree) {
+  std::vector<std::vector<uint32_t>> g(n);
+  for (uint64_t i = 0; i < n; ++i) {
+    for (uint32_t d = 1; d <= degree && d < n; ++d) {
+      g[i].push_back(static_cast<uint32_t>((i + d) % n));
+    }
+  }
+  return g;
+}
+
+class DiskLayoutTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    for (const auto &p : owned_) {
+      std::error_code ec;
+      std::filesystem::remove(p, ec);
+    }
+  }
+
+  std::filesystem::path temp_path(const std::string &tag) {
+    static std::atomic<uint64_t> counter{0};
+    auto p = std::filesystem::temp_directory_path() /
+             ("diskann_layout_" + tag + "_" + std::to_string(counter.fetch_add(1)) + ".index");
+    owned_.push_back(p);
+    return p;
+  }
+
+  std::vector<std::filesystem::path> owned_;
+};
+
+// --- Geometry math ----------------------------------------------------------
+
+TEST_F(DiskLayoutTest, GeometryMultiNodePerSector) {
+  const auto g = DiskLayoutGeometry::compute(/*dim=*/128, /*max_degree=*/64);
+  EXPECT_EQ(g.node_len, 128u * 4 + 4 + 64u * 4);  // 772
+  EXPECT_EQ(g.node_len, 772u);
+  EXPECT_EQ(g.nodes_per_sector, 5u);  // floor(4096 / 772)
+  EXPECT_EQ(g.page_size, 4096u);      // ceil(5*772 / 4096) * 4096
+}
+
+TEST_F(DiskLayoutTest, GeometryMultiSectorPerNode) {
+  const auto g = DiskLayoutGeometry::compute(/*dim=*/1024, /*max_degree=*/64);
+  EXPECT_EQ(g.node_len, 1024u * 4 + 4 + 64u * 4);  // 4356 > 4096
+  EXPECT_EQ(g.node_len, 4356u);
+  EXPECT_EQ(g.nodes_per_sector, 1u);  // max(1, 4096/4356)
+  EXPECT_EQ(g.page_size, 8192u);      // ceil(4356 / 4096) * 4096
+}
+
+TEST_F(DiskLayoutTest, GeometryRejectsZeroDim) {
+  EXPECT_THROW(DiskLayoutGeometry::compute(0, 64), std::invalid_argument);
+}
+
+// --- Offset calculation -----------------------------------------------------
+
+TEST_F(DiskLayoutTest, OffsetFirstNodeAtSectorOne) {
+  const auto g = DiskLayoutGeometry::compute(128, 64);
+  EXPECT_EQ(g.file_offset(0), kSectorLen);  // immediately after header
+  EXPECT_EQ(g.get_page_offset(0), kSectorLen);
+  EXPECT_EQ(g.offset_to_node(0), 0u);
+}
+
+TEST_F(DiskLayoutTest, OffsetCrossPageBoundaryMultiNode) {
+  const auto g = DiskLayoutGeometry::compute(128, 64);  // nodes_per_sector = 5
+  // First node of the second page is node id == nodes_per_sector.
+  const uint64_t first_of_page2 = g.nodes_per_sector;
+  EXPECT_EQ(g.get_page_offset(first_of_page2), kSectorLen + g.page_size);
+  EXPECT_EQ(g.offset_to_node(first_of_page2), 0u);
+  EXPECT_EQ(g.file_offset(first_of_page2), kSectorLen + g.page_size);
+  // Last node of the first page packs at slot (nodes_per_sector - 1).
+  EXPECT_EQ(g.file_offset(g.nodes_per_sector - 1),
+            kSectorLen + (g.nodes_per_sector - 1) * g.node_len);
+}
+
+TEST_F(DiskLayoutTest, OffsetCrossPageBoundaryMultiSector) {
+  const auto g = DiskLayoutGeometry::compute(1024, 64);  // nodes_per_sector = 1, page = 8192
+  EXPECT_EQ(g.file_offset(0), kSectorLen);
+  EXPECT_EQ(g.file_offset(1), kSectorLen + g.page_size);
+  EXPECT_EQ(g.file_offset(2), kSectorLen + 2 * g.page_size);
+}
+
+TEST_F(DiskLayoutTest, AllPageOffsetsAre512Aligned) {
+  for (uint64_t dim : {2u, 16u, 100u, 128u, 200u, 960u, 1024u}) {
+    for (uint32_t r : {8u, 32u, 64u}) {
+      const auto g = DiskLayoutGeometry::compute(dim, r);
+      EXPECT_EQ(g.page_size % 512, 0u) << "dim=" << dim << " r=" << r;
+      // The page that holds any node id begins at a 512-aligned file offset.
+      for (uint64_t id : {0u, 1u, 4u, 5u, 9u, 10u, 100u}) {
+        EXPECT_EQ(g.get_page_offset(id) % 512, 0u) << "dim=" << dim << " r=" << r << " id=" << id;
+      }
+    }
+  }
+}
+
+// --- Header roundtrip -------------------------------------------------------
+
+TEST_F(DiskLayoutTest, HeaderRoundtripMultiNode) {
+  const uint64_t n = 23, dim = 128;
+  const uint32_t r = 64, medoid = 7;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_ring_graph(n, r);
+  const auto path = temp_path("hdr_mn");
+
+  write_disk_layout(path.string(), vecs.data(), graph, {n, dim, r, medoid});
+  const DiskLayoutHeader h = read_disk_layout_header(path.string());
+
+  EXPECT_EQ(h.num_points, n);
+  EXPECT_EQ(h.dim, dim);
+  EXPECT_EQ(h.medoid, medoid);
+  EXPECT_EQ(h.max_degree, r);
+  EXPECT_EQ(h.node_len, 772u);
+  EXPECT_EQ(h.nodes_per_sector, 5u);
+
+  const auto g = DiskLayoutGeometry::compute(dim, r);
+  EXPECT_EQ(h.total_file_size, g.total_file_size(n));
+}
+
+TEST_F(DiskLayoutTest, HeaderRoundtripMultiSector) {
+  const uint64_t n = 4, dim = 1024;
+  const uint32_t r = 64, medoid = 2;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_ring_graph(n, r);
+  const auto path = temp_path("hdr_ms");
+
+  write_disk_layout(path.string(), vecs.data(), graph, {n, dim, r, medoid});
+  const DiskLayoutHeader h = read_disk_layout_header(path.string());
+
+  EXPECT_EQ(h.num_points, n);
+  EXPECT_EQ(h.dim, dim);
+  EXPECT_EQ(h.medoid, medoid);
+  EXPECT_EQ(h.node_len, 4356u);
+  EXPECT_EQ(h.nodes_per_sector, 1u);
+}
+
+TEST_F(DiskLayoutTest, TotalFileSizeMatchesActualOnDisk) {
+  const uint64_t n = 17, dim = 64;
+  const uint32_t r = 32;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_ring_graph(n, r);
+  const auto path = temp_path("size");
+
+  write_disk_layout(path.string(), vecs.data(), graph, {n, dim, r, 0});
+  const DiskLayoutHeader h = read_disk_layout_header(path.string());
+
+  const auto actual = std::filesystem::file_size(path);
+  EXPECT_EQ(static_cast<uint64_t>(actual), h.total_file_size);
+  EXPECT_EQ(actual % kSectorLen, 0u);  // whole file is sector-aligned
+}
+
+// --- Node data roundtrip (validates the actual packing) ---------------------
+
+TEST_F(DiskLayoutTest, NodeDataRoundtripMultiNode) {
+  const uint64_t n = 13, dim = 16;
+  const uint32_t r = 8, medoid = 3;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_ring_graph(n, r);
+  const auto path = temp_path("node_mn");
+
+  write_disk_layout(path.string(), vecs.data(), graph, {n, dim, r, medoid});
+  const auto g = DiskLayoutGeometry::compute(dim, r);
+
+  std::ifstream in(path.string(), std::ios::binary);
+  ASSERT_TRUE(in.good());
+  std::vector<char> rec(g.node_len);
+  const uint64_t coords_bytes = dim * sizeof(float);
+
+  for (uint64_t id = 0; id < n; ++id) {
+    in.seekg(static_cast<std::streamoff>(g.file_offset(id)));
+    in.read(rec.data(), static_cast<std::streamsize>(g.node_len));
+    ASSERT_EQ(in.gcount(), static_cast<std::streamsize>(g.node_len));
+
+    // coords
+    std::vector<float> coords(dim);
+    std::memcpy(coords.data(), rec.data(), coords_bytes);
+    for (uint64_t d = 0; d < dim; ++d) {
+      EXPECT_FLOAT_EQ(coords[d], vecs[id * dim + d]) << "id=" << id << " d=" << d;
+    }
+
+    // n_nbrs
+    uint32_t n_nbrs = 0;
+    std::memcpy(&n_nbrs, rec.data() + coords_bytes, sizeof(n_nbrs));
+    ASSERT_EQ(n_nbrs, graph[id].size()) << "id=" << id;
+
+    // neighbor ids
+    std::vector<uint32_t> nbrs(n_nbrs);
+    std::memcpy(nbrs.data(), rec.data() + coords_bytes + sizeof(uint32_t),
+                n_nbrs * sizeof(uint32_t));
+    for (uint32_t k = 0; k < n_nbrs; ++k) {
+      EXPECT_EQ(nbrs[k], graph[id][k]) << "id=" << id << " k=" << k;
+    }
+  }
+}
+
+TEST_F(DiskLayoutTest, NodeDataRoundtripMultiSector) {
+  const uint64_t n = 5, dim = 1024;
+  const uint32_t r = 64;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_ring_graph(n, r);
+  const auto path = temp_path("node_ms");
+
+  write_disk_layout(path.string(), vecs.data(), graph, {n, dim, r, 0});
+  const auto g = DiskLayoutGeometry::compute(dim, r);
+
+  std::ifstream in(path.string(), std::ios::binary);
+  ASSERT_TRUE(in.good());
+  std::vector<char> rec(g.node_len);
+  const uint64_t coords_bytes = dim * sizeof(float);
+
+  for (uint64_t id = 0; id < n; ++id) {
+    in.seekg(static_cast<std::streamoff>(g.file_offset(id)));
+    in.read(rec.data(), static_cast<std::streamsize>(g.node_len));
+    ASSERT_EQ(in.gcount(), static_cast<std::streamsize>(g.node_len));
+    std::vector<float> coords(dim);
+    std::memcpy(coords.data(), rec.data(), coords_bytes);
+    for (uint64_t d = 0; d < dim; ++d) {
+      EXPECT_FLOAT_EQ(coords[d], vecs[id * dim + d]) << "id=" << id << " d=" << d;
+    }
+    uint32_t n_nbrs = 0;
+    std::memcpy(&n_nbrs, rec.data() + coords_bytes, sizeof(n_nbrs));
+    EXPECT_EQ(n_nbrs, graph[id].size()) << "id=" << id;
+  }
+}
+
+// --- Fail-loudly edge cases -------------------------------------------------
+
+TEST_F(DiskLayoutTest, WriteRejectsGraphSizeMismatch) {
+  const uint64_t n = 10, dim = 8;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_ring_graph(n - 1, 4);  // wrong size
+  const auto path = temp_path("bad_graph");
+  EXPECT_THROW(write_disk_layout(path.string(), vecs.data(), graph, {n, dim, 4, 0}),
+               std::invalid_argument);
+}
+
+TEST_F(DiskLayoutTest, WriteRejectsMedoidOutOfRange) {
+  const uint64_t n = 10, dim = 8;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_ring_graph(n, 4);
+  const auto path = temp_path("bad_medoid");
+  EXPECT_THROW(write_disk_layout(path.string(), vecs.data(), graph, {n, dim, 4, /*medoid=*/n}),
+               std::invalid_argument);
+}
+
+TEST_F(DiskLayoutTest, WriteRejectsDegreeOverMax) {
+  const uint64_t n = 10, dim = 8;
+  const uint32_t max_degree = 4;
+  const auto vecs = make_vectors(n, dim);
+  auto graph = make_ring_graph(n, max_degree);
+  graph[0].push_back(5);  // node 0 now has max_degree + 1 neighbors
+  const auto path = temp_path("over_degree");
+  EXPECT_THROW(write_disk_layout(path.string(), vecs.data(), graph, {n, dim, max_degree, 0}),
+               std::invalid_argument);
+}
+
+TEST_F(DiskLayoutTest, ReadRejectsTruncatedHeader) {
+  const auto path = temp_path("truncated");
+  {
+    std::ofstream out(path.string(), std::ios::binary);
+    const char tiny[16] = {0};
+    out.write(tiny, sizeof(tiny));  // far smaller than a sector
+  }
+  EXPECT_THROW(read_disk_layout_header(path.string()), std::runtime_error);
+}
+
+TEST_F(DiskLayoutTest, ReadRejectsSizeMismatch) {
+  const uint64_t n = 12, dim = 16;
+  const uint32_t r = 8;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_ring_graph(n, r);
+  const auto path = temp_path("appended");
+  write_disk_layout(path.string(), vecs.data(), graph, {n, dim, r, 0});
+  // Corrupt the file by appending bytes so on-disk size != header total_file_size.
+  {
+    std::ofstream out(path.string(), std::ios::binary | std::ios::app);
+    std::vector<char> extra(4096, 1);
+    out.write(extra.data(), static_cast<std::streamsize>(extra.size()));
+  }
+  EXPECT_THROW(read_disk_layout_header(path.string()), std::runtime_error);
+}
+
+}  // namespace

--- a/tests/diskann/test_diskann_node_cache.cpp
+++ b/tests/diskann/test_diskann_node_cache.cpp
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include "index/graph/diskann/node_cache.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <random>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include "index/graph/diskann/disk_layout.hpp"
+
+namespace {
+
+using alaya::diskann::DiskLayoutGeometry;
+using alaya::diskann::NodeCache;
+using alaya::diskann::NodeRecordView;
+
+std::vector<float> make_vectors(uint64_t n, uint64_t dim, uint32_t seed = 19) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  std::vector<float> v(n * dim);
+  for (auto &x : v) {
+    x = dist(rng);
+  }
+  return v;
+}
+
+// Connected graph: ring forward edges + a few deterministic random edges.
+std::vector<std::vector<uint32_t>> make_connected_graph(uint64_t n, uint32_t degree,
+                                                        uint32_t seed = 5) {
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<uint32_t> pick(0, static_cast<uint32_t>(n - 1));
+  std::vector<std::vector<uint32_t>> g(n);
+  for (uint64_t i = 0; i < n; ++i) {
+    std::unordered_set<uint32_t> nb;
+    nb.insert(static_cast<uint32_t>((i + 1) % n));  // keep it connected
+    while (nb.size() < degree && nb.size() < n - 1) {
+      uint32_t v = pick(rng);
+      if (v != i) {
+        nb.insert(v);
+      }
+    }
+    g[i].assign(nb.begin(), nb.end());
+  }
+  return g;
+}
+
+class NodeCacheTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    for (const auto &p : owned_) {
+      std::error_code ec;
+      std::filesystem::remove(p, ec);
+    }
+  }
+  std::filesystem::path temp_path(const std::string &tag) {
+    static std::atomic<uint64_t> counter{0};
+    auto p = std::filesystem::temp_directory_path() /
+             ("diskann_cache_" + tag + "_" + std::to_string(counter.fetch_add(1)) + ".bin");
+    owned_.push_back(p);
+    return p;
+  }
+  std::vector<std::filesystem::path> owned_;
+};
+
+TEST_F(NodeCacheTest, CacheIncludesMedoidFirst) {
+  const uint64_t n = 1000, dim = 16;
+  const uint32_t r = 16, medoid = 421;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_connected_graph(n, r);
+  NodeCache cache;
+  cache.generate(graph, vecs.data(), medoid, n, dim, r, /*cache_ratio=*/0.05);
+  ASSERT_GT(cache.size(), 0u);
+  EXPECT_EQ(cache.ids()[0], medoid);
+  EXPECT_NE(cache.lookup(medoid), nullptr);
+}
+
+TEST_F(NodeCacheTest, CacheRespectsRatio) {
+  const uint64_t n = 10000, dim = 8;
+  const uint32_t r = 8, medoid = 0;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_connected_graph(n, r);
+  NodeCache cache;
+  cache.generate(graph, vecs.data(), medoid, n, dim, r, /*cache_ratio=*/0.05);
+  const uint64_t expected = static_cast<uint64_t>(std::ceil(0.05 * n));  // 500
+  EXPECT_LE(cache.size(), expected);
+  EXPECT_EQ(cache.size(), expected);  // ring keeps the graph reachable
+}
+
+TEST_F(NodeCacheTest, CacheRatioZeroIsEmpty) {
+  const uint64_t n = 100, dim = 8;
+  const uint32_t r = 8;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_connected_graph(n, r);
+  NodeCache cache;
+  cache.generate(graph, vecs.data(), 0, n, dim, r, /*cache_ratio=*/0.0);
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_EQ(cache.lookup(0), nullptr);
+}
+
+TEST_F(NodeCacheTest, CacheRatioCappedAtN) {
+  const uint64_t n = 200, dim = 8;
+  const uint32_t r = 8;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_connected_graph(n, r);
+  NodeCache cache;
+  cache.generate(graph, vecs.data(), 3, n, dim, r, /*cache_ratio=*/2.0);  // >1 caps at n
+  EXPECT_EQ(cache.size(), n);
+}
+
+TEST_F(NodeCacheTest, LookupReturnsCorrectNodeData) {
+  const uint64_t n = 500, dim = 24;
+  const uint32_t r = 12, medoid = 100;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_connected_graph(n, r);
+  NodeCache cache;
+  cache.generate(graph, vecs.data(), medoid, n, dim, r, /*cache_ratio=*/0.2);
+
+  for (const uint32_t id : cache.ids()) {
+    const char *rec = cache.lookup(id);
+    ASSERT_NE(rec, nullptr) << "id=" << id;
+    NodeRecordView view{rec, dim};
+    for (uint64_t d = 0; d < dim; ++d) {
+      EXPECT_FLOAT_EQ(view.coords()[d], vecs[id * dim + d]) << "id=" << id << " d=" << d;
+    }
+    const uint32_t expect_nbrs =
+        static_cast<uint32_t>(graph[id].size() > r ? r : graph[id].size());
+    ASSERT_EQ(view.n_nbrs(), expect_nbrs) << "id=" << id;
+    for (uint32_t k = 0; k < expect_nbrs; ++k) {
+      EXPECT_EQ(view.nbrs()[k], graph[id][k]) << "id=" << id << " k=" << k;
+    }
+  }
+}
+
+TEST_F(NodeCacheTest, CacheMissReturnsNullptr) {
+  const uint64_t n = 5000, dim = 8;
+  const uint32_t r = 6, medoid = 0;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_connected_graph(n, r);
+  NodeCache cache;
+  cache.generate(graph, vecs.data(), medoid, n, dim, r, /*cache_ratio=*/0.02);  // 100 nodes
+
+  std::unordered_set<uint32_t> cached(cache.ids().begin(), cache.ids().end());
+  uint32_t uncached = 0;
+  for (uint32_t id = 0; id < n; ++id) {
+    if (cached.find(id) == cached.end()) {
+      uncached = id;
+      break;
+    }
+  }
+  EXPECT_EQ(cache.lookup(uncached), nullptr);
+}
+
+TEST_F(NodeCacheTest, FileRoundtrip) {
+  const uint64_t n = 800, dim = 16;
+  const uint32_t r = 10, medoid = 55;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_connected_graph(n, r);
+  NodeCache cache;
+  cache.generate(graph, vecs.data(), medoid, n, dim, r, /*cache_ratio=*/0.15);
+
+  const auto ids_path = temp_path("ids");
+  const auto nodes_path = temp_path("nodes");
+  cache.save(ids_path.string(), nodes_path.string());
+
+  NodeCache loaded;
+  loaded.load(ids_path.string(), nodes_path.string());
+
+  ASSERT_EQ(loaded.size(), cache.size());
+  EXPECT_EQ(loaded.node_len(), cache.node_len());
+  EXPECT_EQ(loaded.ids(), cache.ids());
+  for (const uint32_t id : cache.ids()) {
+    const char *a = cache.lookup(id);
+    const char *b = loaded.lookup(id);
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr) << "id=" << id;
+    EXPECT_EQ(std::memcmp(a, b, cache.node_len()), 0) << "id=" << id;
+  }
+}
+
+TEST_F(NodeCacheTest, ConcurrentReadSafety) {
+  const uint64_t n = 2000, dim = 32;
+  const uint32_t r = 16, medoid = 7;
+  const auto vecs = make_vectors(n, dim);
+  const auto graph = make_connected_graph(n, r);
+  NodeCache cache;
+  cache.generate(graph, vecs.data(), medoid, n, dim, r, /*cache_ratio=*/0.25);
+
+  const std::vector<uint32_t> ids = cache.ids();
+  std::atomic<int> mismatches{0};
+  auto worker = [&]() {
+    for (int rep = 0; rep < 50; ++rep) {
+      for (const uint32_t id : ids) {
+        const char *rec = cache.lookup(id);
+        if (rec == nullptr) {
+          mismatches.fetch_add(1);
+          continue;
+        }
+        NodeRecordView view{rec, dim};
+        // Spot-check a few coordinates against the ground truth.
+        if (view.coords()[0] != vecs[id * dim + 0] ||
+            view.coords()[dim - 1] != vecs[id * dim + dim - 1]) {
+          mismatches.fetch_add(1);
+        }
+      }
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(4);
+  for (int t = 0; t < 4; ++t) {
+    threads.emplace_back(worker);
+  }
+  for (auto &th : threads) {
+    th.join();
+  }
+  EXPECT_EQ(mismatches.load(), 0);
+}
+
+}  // namespace

--- a/tests/diskann/test_diskann_pq.cpp
+++ b/tests/diskann/test_diskann_pq.cpp
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include "index/graph/diskann/pq_table.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <random>
+#include <vector>
+
+#include "simd/distance_l2.hpp"
+
+namespace {
+
+using alaya::diskann::kPQNumCentroids;
+using alaya::diskann::PQTable;
+
+std::vector<float> make_vectors(uint64_t n, uint64_t dim, uint32_t seed = 11) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> dist(-5.0f, 5.0f);
+  std::vector<float> v(n * dim);
+  for (auto &x : v) {
+    x = dist(rng);
+  }
+  return v;
+}
+
+float exact_l2_sqr(const float *a, const float *b, uint64_t dim) {
+  return alaya::simd::l2_sqr<float, float>(a, b, dim);
+}
+
+class PQTableTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    for (const auto &p : owned_) {
+      std::error_code ec;
+      std::filesystem::remove(p, ec);
+    }
+  }
+  std::filesystem::path temp_path(const std::string &tag) {
+    static std::atomic<uint64_t> counter{0};
+    auto p = std::filesystem::temp_directory_path() /
+             ("diskann_pq_" + tag + "_" + std::to_string(counter.fetch_add(1)) + ".bin");
+    owned_.push_back(p);
+    return p;
+  }
+  std::vector<std::filesystem::path> owned_;
+};
+
+// --- train shape / validation -----------------------------------------------
+
+TEST_F(PQTableTest, TrainRejectsIndivisibleDim) {
+  const auto data = make_vectors(10, 100);
+  PQTable pq;
+  EXPECT_THROW(pq.train(data.data(), 10, /*dim=*/100, /*n_chunks=*/64), std::invalid_argument);
+}
+
+TEST_F(PQTableTest, TrainBalancedChunks) {
+  const uint64_t n = 300, dim = 128;
+  const uint32_t n_chunks = 64;
+  const auto data = make_vectors(n, dim);
+  PQTable pq;
+  pq.train(data.data(), n, dim, n_chunks);
+  EXPECT_EQ(pq.dim(), dim);
+  EXPECT_EQ(pq.n_chunks(), n_chunks);
+  EXPECT_EQ(pq.chunk_dim(), 2u);  // 128 / 64
+  EXPECT_EQ(pq.codebook().size(),
+            static_cast<size_t>(n_chunks) * kPQNumCentroids * 2);  // n_chunks*256*chunk_dim
+  EXPECT_EQ(pq.global_centroid().size(), dim);
+}
+
+TEST_F(PQTableTest, EncodeShape) {
+  const uint64_t n = 1000, dim = 64;
+  const uint32_t n_chunks = 32;
+  const auto data = make_vectors(n, dim);
+  PQTable pq;
+  pq.train(data.data(), n, dim, n_chunks);
+  pq.encode(data.data(), n);
+  EXPECT_EQ(pq.codes().size(), static_cast<size_t>(n) * n_chunks);
+  EXPECT_EQ(pq.num_points(), n);
+}
+
+// --- encode correctness (deterministic small example) -----------------------
+
+TEST_F(PQTableTest, EncodeSmallExampleIsDeterministic) {
+  // With n <= 256, centroids == training residuals, so each point encodes to
+  // its own unique index in every chunk.
+  const uint64_t n = 10, dim = 8;
+  const uint32_t n_chunks = 2;
+  const auto data = make_vectors(n, dim, /*seed=*/42);
+  PQTable pq;
+  pq.train(data.data(), n, dim, n_chunks);
+  pq.encode(data.data(), n);
+  const auto &codes = pq.codes();
+  for (uint64_t i = 0; i < n; ++i) {
+    for (uint32_t c = 0; c < n_chunks; ++c) {
+      EXPECT_EQ(codes[i * n_chunks + c], static_cast<uint8_t>(i)) << "i=" << i << " c=" << c;
+    }
+  }
+}
+
+// --- PQ distance equals true L2 in the lossless (n <= 256) regime ------------
+
+TEST_F(PQTableTest, PQDistanceEqualsTrueL2WhenLossless) {
+  const uint64_t n = 50, dim = 16;
+  const uint32_t n_chunks = 4;
+  const auto data = make_vectors(n, dim, /*seed=*/7);
+  PQTable pq;
+  pq.train(data.data(), n, dim, n_chunks);
+  pq.encode(data.data(), n);
+
+  std::vector<float> table(static_cast<size_t>(n_chunks) * kPQNumCentroids);
+  for (uint64_t qi = 0; qi < n; ++qi) {
+    pq.preprocess_query(data.data() + qi * dim, table.data());
+    for (uint64_t pi = 0; pi < n; ++pi) {
+      const float approx = pq.pq_distance(pi, table.data());
+      const float truth = exact_l2_sqr(data.data() + qi * dim, data.data() + pi * dim, dim);
+      EXPECT_NEAR(approx, truth, 1e-2f * (1.0f + truth)) << "qi=" << qi << " pi=" << pi;
+    }
+  }
+}
+
+// --- distance table values against a hand-built codebook --------------------
+
+TEST_F(PQTableTest, PreprocessQueryMatchesManualTable) {
+  const uint64_t dim = 4;
+  const uint32_t n_chunks = 2, chunk_dim = 2;
+  std::vector<float> gc(dim, 0.0f);  // zero global centroid => residual == query
+  std::vector<float> codebook(static_cast<size_t>(n_chunks) * kPQNumCentroids * chunk_dim, 0.0f);
+  // centroid (c, k) = (k, k)
+  for (uint32_t c = 0; c < n_chunks; ++c) {
+    for (uint32_t k = 0; k < kPQNumCentroids; ++k) {
+      float *cent = codebook.data() + (static_cast<size_t>(c) * kPQNumCentroids + k) * chunk_dim;
+      cent[0] = static_cast<float>(k);
+      cent[1] = static_cast<float>(k);
+    }
+  }
+  PQTable pq = PQTable::from_codebook(dim, n_chunks, gc, codebook);
+
+  const std::vector<float> query = {3.0f, 3.0f, 5.0f, 5.0f};  // chunk0=(3,3) chunk1=(5,5)
+  std::vector<float> table(static_cast<size_t>(n_chunks) * kPQNumCentroids);
+  pq.preprocess_query(query.data(), table.data());
+
+  for (uint32_t k = 0; k < kPQNumCentroids; ++k) {
+    const float e0 = 2.0f * (3.0f - k) * (3.0f - k);
+    const float e1 = 2.0f * (5.0f - k) * (5.0f - k);
+    EXPECT_NEAR(table[0 * kPQNumCentroids + k], e0, 1e-3f) << "chunk0 k=" << k;
+    EXPECT_NEAR(table[1 * kPQNumCentroids + k], e1, 1e-3f) << "chunk1 k=" << k;
+  }
+}
+
+TEST_F(PQTableTest, PQDistanceIsSumOfTableLookups) {
+  const uint64_t n = 400, dim = 32;  // n > 256 exercises real k-means
+  const uint32_t n_chunks = 8;
+  const auto data = make_vectors(n, dim);
+  PQTable pq;
+  pq.train(data.data(), n, dim, n_chunks);
+  pq.encode(data.data(), n);
+
+  std::vector<float> table(static_cast<size_t>(n_chunks) * kPQNumCentroids);
+  pq.preprocess_query(data.data() + 5 * dim, table.data());
+  const auto &codes = pq.codes();
+  for (uint64_t pi : {0ull, 1ull, 100ull, 399ull}) {
+    float expected = 0.0f;
+    for (uint32_t c = 0; c < n_chunks; ++c) {
+      expected += table[static_cast<size_t>(c) * kPQNumCentroids + codes[pi * n_chunks + c]];
+    }
+    EXPECT_FLOAT_EQ(pq.pq_distance(pi, table.data()), expected) << "pi=" << pi;
+  }
+}
+
+// --- parallel train/encode is byte-identical to serial ----------------------
+
+TEST_F(PQTableTest, ParallelTrainEncodeByteIdenticalToSerial) {
+  // Chunks train independently (own seed seed+c, disjoint codebook region) and
+  // each point encodes independently, so multi-threaded train()/encode() must
+  // produce a byte-identical codebook and codes to the single-threaded run. (Each
+  // chunk's k-means stays serial internally, so there is no FP-reduction reorder.)
+  const uint64_t n = 2000, dim = 64;  // n > 256 => real k-means
+  const uint32_t n_chunks = 16;
+  const auto data = make_vectors(n, dim, /*seed=*/123);
+
+  PQTable serial;
+  serial.train(data.data(), n, dim, n_chunks, /*n_iters=*/15, /*seed=*/1234, /*num_threads=*/1);
+  serial.encode(data.data(), n, /*num_threads=*/1);
+
+  PQTable parallel;
+  parallel.train(data.data(), n, dim, n_chunks, /*n_iters=*/15, /*seed=*/1234, /*num_threads=*/8);
+  parallel.encode(data.data(), n, /*num_threads=*/8);
+
+  ASSERT_EQ(serial.codebook().size(), parallel.codebook().size());
+  EXPECT_EQ(serial.codebook(), parallel.codebook());  // bit-identical float codebook
+  ASSERT_EQ(serial.codes().size(), parallel.codes().size());
+  EXPECT_EQ(serial.codes(), parallel.codes());
+  EXPECT_EQ(serial.global_centroid(), parallel.global_centroid());
+}
+
+// --- persistence ------------------------------------------------------------
+
+TEST_F(PQTableTest, FileRoundtripBitIdentical) {
+  const uint64_t n = 500, dim = 48;
+  const uint32_t n_chunks = 12;
+  const auto data = make_vectors(n, dim);
+  PQTable pq;
+  pq.train(data.data(), n, dim, n_chunks);
+  pq.encode(data.data(), n);
+
+  const auto pivots = temp_path("pivots");
+  const auto compressed = temp_path("compressed");
+  pq.save(pivots.string(), compressed.string());
+
+  PQTable loaded;
+  loaded.load(pivots.string(), compressed.string(), n, dim, n_chunks);
+
+  ASSERT_EQ(loaded.global_centroid().size(), pq.global_centroid().size());
+  for (size_t i = 0; i < pq.global_centroid().size(); ++i) {
+    EXPECT_EQ(loaded.global_centroid()[i], pq.global_centroid()[i]) << "gc i=" << i;
+  }
+  ASSERT_EQ(loaded.codebook().size(), pq.codebook().size());
+  for (size_t i = 0; i < pq.codebook().size(); ++i) {
+    EXPECT_EQ(loaded.codebook()[i], pq.codebook()[i]) << "cb i=" << i;
+  }
+  ASSERT_EQ(loaded.codes().size(), pq.codes().size());
+  EXPECT_EQ(loaded.codes(), pq.codes());
+
+  // And the loaded table produces identical distances.
+  std::vector<float> t0(static_cast<size_t>(n_chunks) * kPQNumCentroids);
+  std::vector<float> t1(static_cast<size_t>(n_chunks) * kPQNumCentroids);
+  pq.preprocess_query(data.data(), t0.data());
+  loaded.preprocess_query(data.data(), t1.data());
+  for (uint64_t pi : {0ull, 250ull, 499ull}) {
+    EXPECT_FLOAT_EQ(pq.pq_distance(pi, t0.data()), loaded.pq_distance(pi, t1.data())) << "pi=" << pi;
+  }
+}
+
+TEST_F(PQTableTest, LoadRejectsWrongSize) {
+  const uint64_t n = 100, dim = 16;
+  const uint32_t n_chunks = 4;
+  const auto data = make_vectors(n, dim);
+  PQTable pq;
+  pq.train(data.data(), n, dim, n_chunks);
+  pq.encode(data.data(), n);
+  const auto pivots = temp_path("pivots_bad");
+  const auto compressed = temp_path("compressed_bad");
+  pq.save(pivots.string(), compressed.string());
+
+  PQTable loaded;
+  // Wrong n => pq_compressed.bin size check fails.
+  EXPECT_THROW(loaded.load(pivots.string(), compressed.string(), n + 1, dim, n_chunks),
+               std::runtime_error);
+  // Wrong dim => pq_pivots.bin size check fails.
+  EXPECT_THROW(loaded.load(pivots.string(), compressed.string(), n, dim * 2, n_chunks),
+               std::runtime_error);
+}
+
+TEST_F(PQTableTest, FromCodebookRejectsBadShapes) {
+  EXPECT_THROW(PQTable::from_codebook(4, 3, std::vector<float>(4), std::vector<float>(4)),
+               std::invalid_argument);  // 4 % 3 != 0
+  EXPECT_THROW(
+      PQTable::from_codebook(4, 2, std::vector<float>(3), std::vector<float>(2 * 256 * 2)),
+      std::invalid_argument);  // global centroid wrong size
+  EXPECT_THROW(PQTable::from_codebook(4, 2, std::vector<float>(4), std::vector<float>(10)),
+               std::invalid_argument);  // codebook wrong size
+}
+
+}  // namespace

--- a/tests/diskann/test_diskann_tombstone_search.cpp
+++ b/tests/diskann/test_diskann_tombstone_search.cpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include "index/graph/diskann/beam_search.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <vector>
+
+#include "index/graph/diskann/disk_layout.hpp"
+#include "index/graph/diskann/node_cache.hpp"
+#include "index/graph/diskann/search_scratch.hpp"
+#include "index/graph/diskann/tombstone_bitmap.hpp"
+#include "index/graph/laser/utils/aligned_file_reader_factory.hpp"
+
+namespace {
+
+using alaya::diskann::disk_greedy_search;
+using alaya::diskann::DiskLayoutGeometry;
+using alaya::diskann::NodeCache;
+using alaya::diskann::SearchContext;
+using alaya::diskann::SearchParams;
+using alaya::diskann::SearchStats;
+using alaya::diskann::ThreadData;
+using alaya::diskann::TombstoneBitmap;
+using alaya::diskann::write_disk_layout;
+
+// Engineered 6-node layout (dim=2) where node 4 is reachable ONLY through
+// node 1: medoid 0 -> 1 -> 4.
+//
+//   id : position        neighbors
+//    0 : (0, 0)  medoid   {1, 2, 3, 5}
+//    1 : (1, 0)           {0, 4}
+//    2 : (0, 1)           {0}
+//    3 : (0,-1)           {0}
+//    4 : (2, 0)  hidden   {1}
+//    5 : (-1,0)           {0}
+struct Scenario {
+  std::vector<float> vecs = {0, 0, 1, 0, 0, 1, 0, -1, 2, 0, -1, 0};
+  std::vector<std::vector<uint32_t>> graph = {{1, 2, 3, 5}, {0, 4}, {0}, {0}, {1}, {0}};
+  uint32_t medoid = 0;
+  uint64_t dim = 2;
+  uint32_t r = 4;
+};
+
+class TombstoneSearchTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    static std::atomic<uint64_t> counter{0};
+    index_path_ = std::filesystem::temp_directory_path() /
+                  ("diskann_tomb_" + std::to_string(counter.fetch_add(1)) + ".index");
+    n_ = scn_.graph.size();
+    geom_ = DiskLayoutGeometry::compute(scn_.dim, scn_.r);
+    write_disk_layout(index_path_.string(),
+                      scn_.vecs.data(),
+                      scn_.graph,
+                      {n_, scn_.dim, scn_.r, scn_.medoid});
+    cache_.generate(scn_.graph,
+                    scn_.vecs.data(),
+                    scn_.medoid,
+                    n_,
+                    scn_.dim,
+                    scn_.r,
+                    /*cache_ratio=*/0.0);
+    reader_ = make_aligned_file_reader();
+    reader_->open(index_path_.string());
+    reader_->register_thread();
+    td_.ctx_ = reader_->get_ctx();
+    td_.alloc_scratch(/*n_page_slots=*/8, geom_.page_size, /*pq_table_entries=*/0);
+  }
+
+  void TearDown() override {
+    td_.free_scratch();
+    if (reader_) {
+      reader_->close();
+      reader_->deregister_all_threads();
+    }
+    std::error_code ec;
+    std::filesystem::remove(index_path_, ec);
+  }
+
+  std::vector<std::pair<uint32_t, float>> search(const float *q,
+                                                 uint32_t top_k,
+                                                 const TombstoneBitmap *tomb,
+                                                 bool deterministic,
+                                                 uint32_t l = 50) {
+    SearchContext ctx;
+    ctx.reader = reader_.get();
+    ctx.geom = &geom_;
+    ctx.cache = &cache_;
+    ctx.pq = nullptr;
+    ctx.medoid = scn_.medoid;
+    ctx.num_points = n_;
+    ctx.tombstone = tomb;
+    SearchParams p;
+    p.search_list_size = l;
+    p.beam_width = 4;
+    p.use_pq = false;
+    p.rerank = false;
+    p.deterministic = deterministic;
+    SearchStats stats;
+    return disk_greedy_search(ctx, q, top_k, p, td_, &stats);
+  }
+
+  static bool contains(const std::vector<std::pair<uint32_t, float>> &res, uint32_t id) {
+    return std::any_of(res.begin(), res.end(), [id](const auto &p) {
+      return p.first == id;
+    });
+  }
+
+  Scenario scn_;
+  uint64_t n_ = 0;
+  DiskLayoutGeometry geom_;
+  NodeCache cache_;
+  std::filesystem::path index_path_;
+  std::unique_ptr<AlignedFileReader> reader_;
+  ThreadData td_;
+};
+
+const std::vector<float> kQuery = {2.0f, 0.0f};
+
+TEST_F(TombstoneSearchTest, NullTombstoneFindsHiddenNeighborUnchanged) {
+  for (bool det : {true, false}) {
+    const auto res = search(kQuery.data(), 1, /*tomb=*/nullptr, det);
+    ASSERT_EQ(res.size(), 1u);
+    EXPECT_EQ(res[0].first, 4u) << "deterministic=" << det;
+  }
+}
+
+// IP-DiskANN: deleting the bridge node makes node 4 unreachable.
+// Graph repair is done at delete time (by DiskANNIndex::remove), not at search time.
+TEST_F(TombstoneSearchTest, DeletedBridgeMakesNodeUnreachable) {
+  TombstoneBitmap tomb;
+  tomb.set(1);
+  for (bool det : {true, false}) {
+    const auto res = search(kQuery.data(), 1, &tomb, det);
+    ASSERT_EQ(res.size(), 1u);
+    EXPECT_FALSE(contains(res, 4u)) << "node 4 unreachable; deterministic=" << det;
+    EXPECT_FALSE(contains(res, 1u));
+  }
+}
+
+TEST_F(TombstoneSearchTest, DeletedNearestNeighborIsNotReturned) {
+  TombstoneBitmap tomb;
+  tomb.set(4);
+  for (bool det : {true, false}) {
+    const auto res = search(kQuery.data(), 3, &tomb, det);
+    EXPECT_FALSE(contains(res, 4u)) << "deleted NN must not appear; deterministic=" << det;
+    ASSERT_FALSE(res.empty());
+    EXPECT_EQ(res[0].first, 1u);
+  }
+}
+
+TEST_F(TombstoneSearchTest, ResultCountReflectsLiveNodesOnly) {
+  TombstoneBitmap tomb;
+  for (uint32_t id : {1u, 2u, 3u, 4u, 5u}) {
+    tomb.set(id);
+  }
+  const auto res = search(kQuery.data(), /*top_k=*/3, &tomb, /*deterministic=*/true);
+  ASSERT_EQ(res.size(), 1u) << "only the medoid (node 0) is live";
+  EXPECT_EQ(res[0].first, 0u);
+}
+
+}  // namespace

--- a/tests/diskann/test_diskann_tombstone_slot.cpp
+++ b/tests/diskann/test_diskann_tombstone_slot.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include "index/graph/diskann/slot_allocator.hpp"
+#include "index/graph/diskann/tombstone_bitmap.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace {
+
+using alaya::diskann::SlotAllocator;
+using alaya::diskann::TombstoneBitmap;
+
+// Unique temp path per call so save/load tests never collide across the suite.
+std::string temp_path(const char *stem) {
+  static std::atomic<uint64_t> counter{0};
+  auto p = std::filesystem::temp_directory_path() / ("diskann_ts_" + std::string(stem) + "_" +
+                                                     std::to_string(counter.fetch_add(1)) + ".bin");
+  return p.string();
+}
+
+struct ScopedFile {
+  std::string path;
+  explicit ScopedFile(const char *stem) : path(temp_path(stem)) {}
+  ~ScopedFile() {
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  }
+};
+
+// --------------------------- TombstoneBitmap (task 1.3) ---------------------
+
+TEST(TombstoneBitmapTest, SetClearQuery) {
+  TombstoneBitmap bm;
+  EXPECT_FALSE(bm.is_deleted(5));
+  bm.set(5);
+  EXPECT_TRUE(bm.is_deleted(5));
+  bm.clear(5);
+  EXPECT_FALSE(bm.is_deleted(5));
+}
+
+TEST(TombstoneBitmapTest, AutoGrowBeyondInitialCapacity) {
+  TombstoneBitmap bm(64);
+  EXPECT_GE(bm.capacity(), 64u);
+  EXPECT_FALSE(bm.is_deleted(100));  // out of range reads live
+  bm.set(100);
+  EXPECT_GE(bm.capacity(), 101u);
+  EXPECT_TRUE(bm.is_deleted(100));
+}
+
+TEST(TombstoneBitmapTest, CountAfterMixedOperations) {
+  TombstoneBitmap bm;
+  bm.set(1);
+  bm.set(5);
+  bm.set(10);
+  bm.clear(5);
+  EXPECT_EQ(bm.count(), 2u);
+  // Idempotent set/clear must not skew the running count.
+  bm.set(1);
+  bm.clear(999);  // never set, out of range
+  EXPECT_EQ(bm.count(), 2u);
+}
+
+TEST(TombstoneBitmapTest, SaveLoadRoundTrip) {
+  ScopedFile f("bm");
+  {
+    TombstoneBitmap bm(128);
+    bm.set(3);
+    bm.set(7);
+    bm.set(200);  // forces a grow past the saved 128
+    bm.save(f.path);
+  }
+  TombstoneBitmap reloaded;
+  reloaded.load(f.path);
+  EXPECT_TRUE(reloaded.is_deleted(3));
+  EXPECT_TRUE(reloaded.is_deleted(7));
+  EXPECT_TRUE(reloaded.is_deleted(200));
+  EXPECT_FALSE(reloaded.is_deleted(4));
+  EXPECT_EQ(reloaded.count(), 3u);
+}
+
+TEST(TombstoneBitmapTest, LoadRejectsGarbage) {
+  ScopedFile f("bad");
+  {
+    std::ofstream out(f.path, std::ios::binary | std::ios::trunc);
+    const char junk[4] = {1, 2, 3, 4};
+    out.write(junk, sizeof(junk));
+  }
+  TombstoneBitmap bm;
+  EXPECT_THROW(bm.load(f.path), std::runtime_error);
+}
+
+// --------------------------- SlotAllocator (task 1.4) -----------------------
+
+TEST(SlotAllocatorTest, AllocFromFreeListLIFO) {
+  SlotAllocator a;
+  a.free(7);
+  a.free(3);
+  a.free(12);  // free list (top -> bottom): 12, 3, 7
+  EXPECT_EQ(a.alloc(), 12u);
+  EXPECT_EQ(a.alloc(), 3u);
+  EXPECT_EQ(a.alloc(), 7u);
+  EXPECT_EQ(a.free_count(), 0u);
+}
+
+TEST(SlotAllocatorTest, AllocAppendMode) {
+  SlotAllocator a(1000);  // next_fresh_id_ = 1000, empty free list
+  EXPECT_EQ(a.alloc(), 1000u);
+  EXPECT_EQ(a.next_fresh_id(), 1001u);
+  EXPECT_EQ(a.alloc(), 1001u);
+}
+
+TEST(SlotAllocatorTest, FreeThenReallocReturnsSameSlotAndTogglesTombstone) {
+  SlotAllocator a(10);
+  a.free(5);
+  EXPECT_TRUE(a.is_deleted(5));
+  EXPECT_EQ(a.free_count(), 1u);
+  EXPECT_EQ(a.alloc(), 5u);       // reuse the freed slot
+  EXPECT_FALSE(a.is_deleted(5));  // alloc marks it live again
+}
+
+TEST(SlotAllocatorTest, SaveLoadRoundTripWithBitmap) {
+  ScopedFile f("slot");
+  {
+    SlotAllocator a(100);  // next_fresh_id_ = 100
+    a.free(3);
+    a.free(7);  // free list (top -> bottom): 7, 3; tombstones {3,7}
+    a.save(f.path);
+  }
+  SlotAllocator b;
+  b.load(f.path);
+  EXPECT_EQ(b.next_fresh_id(), 100u);
+  EXPECT_EQ(b.free_count(), 2u);
+  EXPECT_TRUE(b.is_deleted(3));
+  EXPECT_TRUE(b.is_deleted(7));
+  EXPECT_EQ(b.tombstone_count(), 2u);
+  // LIFO order survives the round trip.
+  EXPECT_EQ(b.alloc(), 7u);
+  EXPECT_EQ(b.alloc(), 3u);
+}
+
+}  // namespace

--- a/tests/diskann/test_diskann_update_e2e.cpp
+++ b/tests/diskann/test_diskann_update_e2e.cpp
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: 2025 AlayaDB.AI
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#include "index/graph/diskann/diskann_index.hpp"
+
+#include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <random>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "simd/distance_l2.hpp"
+
+namespace {
+
+#if defined(__linux__)
+
+using alaya::diskann::DiskANNBuildParams;
+using alaya::diskann::DiskANNIndex;
+using alaya::diskann::DiskANNLoadParams;
+using alaya::diskann::DiskANNSearchParams;
+
+std::vector<float> make_vectors(uint64_t n, uint64_t dim, uint32_t seed) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  std::vector<float> v(n * dim);
+  for (auto &x : v) {
+    x = dist(rng);
+  }
+  return v;
+}
+
+// End-to-end fixture: builds a No-PQ index, loads it updatable, and mirrors the
+// live (label -> vector) contents so recall can be measured against the actual
+// current set after arbitrary insert/delete sequences.
+class UpdateE2ETest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { spdlog::set_level(spdlog::level::warn); }
+
+  void SetUp() override {
+    static std::atomic<uint64_t> counter{0};
+    dir_ = std::filesystem::temp_directory_path() /
+           ("diskann_upd_" + std::to_string(counter.fetch_add(1)));
+  }
+  void TearDown() override {
+    idx_.reset();
+    std::error_code ec;
+    std::filesystem::remove_all(dir_, ec);
+  }
+  std::string dir() const { return dir_.string(); }
+
+  void build_and_load(uint64_t n, uint64_t dim, uint32_t r, DiskANNLoadParams lp) {
+    dim_ = dim;
+    base_vecs_ = make_vectors(n, dim, /*seed=*/1);
+    std::vector<uint64_t> labels(n);
+    for (uint64_t i = 0; i < n; ++i) {
+      labels[i] = 1000 + i;
+    }
+    DiskANNBuildParams bp;
+    bp.R = r;
+    bp.pq_n_chunks = 0;  // updates are No-PQ only
+    DiskANNIndex::build(dir(), base_vecs_.data(), labels.data(), n, dim, bp);
+
+    lp.updatable = true;
+    idx_ = std::make_unique<DiskANNIndex>();
+    idx_->load(dir(), lp);
+
+    next_label_ = 1000 + n;
+    medoid_ = idx_->medoid();
+    live_.clear();
+    id_label_.clear();
+    deletable_.clear();
+    for (uint64_t i = 0; i < n; ++i) {
+      const uint64_t label = 1000 + i;
+      live_[label] = vec_at(base_vecs_, i);
+      id_label_[static_cast<uint32_t>(i)] = label;
+      if (i != medoid_) {
+        deletable_.push_back(static_cast<uint32_t>(i));
+      }
+    }
+  }
+
+  std::vector<float> vec_at(const std::vector<float> &flat, uint64_t i) const {
+    return std::vector<float>(flat.begin() + i * dim_, flat.begin() + (i + 1) * dim_);
+  }
+
+  uint32_t do_insert(const std::vector<float> &v) {
+    const uint64_t label = next_label_++;
+    const uint32_t id = idx_->insert(v.data(), label);
+    id_label_[id] = label;
+    live_[label] = v;
+    return id;
+  }
+
+  void do_remove(uint32_t id) {
+    const auto it = id_label_.find(id);
+    live_.erase(it->second);
+    idx_->remove(id);
+  }
+
+  // Ground-truth top-k labels by exact L2 over the *current* live set.
+  std::vector<uint64_t> ground_truth(const float *q, uint32_t k) const {
+    std::vector<std::pair<float, uint64_t>> all;
+    all.reserve(live_.size());
+    for (const auto &[label, vec] : live_) {
+      all.emplace_back(alaya::simd::l2_sqr<float, float>(q, vec.data(), dim_), label);
+    }
+    std::sort(all.begin(), all.end());
+    std::vector<uint64_t> out;
+    for (uint32_t i = 0; i < k && i < all.size(); ++i) {
+      out.push_back(all[i].second);
+    }
+    return out;
+  }
+
+  double recall_at_k(const std::vector<float> &queries, uint32_t nq, uint32_t k, uint32_t l) const {
+    uint64_t hits = 0;
+    uint64_t total = 0;
+    std::vector<uint64_t> out_l(k);
+    std::vector<float> out_d(k);
+    const DiskANNSearchParams sp{/*L=*/l,
+                                 /*use_pq=*/false,
+                                 /*rerank=*/false,
+                                 /*rerank_count=*/0,
+                                 /*deterministic=*/true};
+    for (uint32_t qi = 0; qi < nq; ++qi) {
+      const float *q = queries.data() + qi * dim_;
+      const auto truth = ground_truth(q, k);
+      idx_->search(q, k, out_l.data(), out_d.data(), sp);
+      const std::unordered_set<uint64_t> res(out_l.begin(), out_l.end());
+      for (const uint64_t t : truth) {
+        if (res.count(t) != 0) {
+          ++hits;
+        }
+        ++total;
+      }
+    }
+    return total != 0 ? static_cast<double>(hits) / static_cast<double>(total) : 1.0;
+  }
+
+  bool top1_is(const float *q, uint64_t label) const {
+    uint64_t out_l[5];
+    float out_d[5];
+    idx_->search(q,
+                 5,
+                 out_l,
+                 out_d,
+                 {/*L=*/64, /*use_pq=*/false, /*rerank=*/false, 0, /*deterministic=*/true});
+    return out_l[0] == label;
+  }
+
+  std::filesystem::path dir_;
+  uint64_t dim_ = 0;
+  uint32_t medoid_ = 0;
+  uint64_t next_label_ = 0;
+  std::vector<float> base_vecs_;
+  std::unique_ptr<DiskANNIndex> idx_;
+  std::map<uint64_t, std::vector<float>> live_;      // label -> vector (live only)
+  std::unordered_map<uint32_t, uint64_t> id_label_;  // internal id -> current label
+  std::vector<uint32_t> deletable_;                  // live, non-medoid internal ids
+};
+
+// 7.1 -----------------------------------------------------------------------
+TEST_F(UpdateE2ETest, InsertFindsNewVectorsWithCorrectLabels) {
+  build_and_load(/*n=*/1000, /*dim=*/32, /*r=*/32, {});
+  const auto nv = make_vectors(100, 32, /*seed=*/99);
+  std::vector<uint64_t> labels;
+  for (uint32_t i = 0; i < 100; ++i) {
+    labels.push_back(0);
+  }
+  for (uint32_t i = 0; i < 100; ++i) {
+    const uint32_t id = do_insert(vec_at(nv, i));
+    labels[i] = id_label_[id];
+  }
+  EXPECT_EQ(idx_->live_count(), 1100u);
+
+  uint32_t found = 0;
+  for (uint32_t i = 0; i < 100; ++i) {
+    if (top1_is(nv.data() + i * 32, labels[i])) {
+      ++found;
+    }
+  }
+  EXPECT_GE(found, 95u) << "inserted vectors should be findable as their own NN";
+}
+
+// 7.2 -----------------------------------------------------------------------
+TEST_F(UpdateE2ETest, DeleteHidesVectorsAndPreservesRecall) {
+  build_and_load(1000, 32, 32, {});
+  const auto queries = make_vectors(50, 32, /*seed=*/7);
+
+  std::vector<uint32_t> deleted;
+  for (uint32_t i = 0; i < 100; ++i) {
+    deleted.push_back(deletable_[i]);
+  }
+  for (const uint32_t id : deleted) {
+    do_remove(id);
+  }
+  EXPECT_EQ(idx_->live_count(), 900u);
+  EXPECT_EQ(idx_->tombstone_count(), 100u);
+
+  for (const uint32_t id : {deleted[0], deleted[50], deleted[99]}) {
+    uint64_t out_l[10];
+    float out_d[10];
+    idx_->search(base_vecs_.data() + id * 32, 10, out_l, out_d, {100, false, false, 0, true});
+    for (const uint64_t l : out_l) {
+      EXPECT_NE(l, static_cast<uint64_t>(1000 + id)) << "deleted vector must not be returned";
+    }
+  }
+  EXPECT_GE(recall_at_k(queries, 50, 10, 100), 0.90);
+}
+
+// 7.3 -----------------------------------------------------------------------
+TEST_F(UpdateE2ETest, MixedWorkloadKeepsRecallAbove90) {
+  build_and_load(1000, 32, 32, {});
+  const auto queries = make_vectors(50, 32, /*seed=*/7);
+  const auto extra = make_vectors(400, 32, /*seed=*/555);  // 30 rounds * 10 inserts
+  uint32_t extra_idx = 0;
+  std::mt19937 rng(2024);
+
+  for (int round = 0; round < 30; ++round) {
+    for (int i = 0; i < 10; ++i) {  // 1% insert
+      const uint32_t id = do_insert(vec_at(extra, extra_idx++));
+      deletable_.push_back(id);
+    }
+    for (int i = 0; i < 10; ++i) {  // 1% delete (random live, non-medoid)
+      std::uniform_int_distribution<size_t> pick(0, deletable_.size() - 1);
+      const size_t j = pick(rng);
+      const uint32_t id = deletable_[j];
+      deletable_[j] = deletable_.back();
+      deletable_.pop_back();
+      do_remove(id);
+    }
+    const double r = recall_at_k(queries, 50, 10, 100);
+    EXPECT_GE(r, 0.90) << "recall collapsed at round " << round;
+  }
+  EXPECT_EQ(idx_->live_count(), 1000u);  // balanced insert/delete
+}
+
+// 7.4 -----------------------------------------------------------------------
+TEST_F(UpdateE2ETest, SlotReuseDrainsFreeListAndReoccupiesSlots) {
+  build_and_load(/*n=*/200, /*dim=*/16, /*r=*/16, {});
+  std::vector<uint32_t> deleted;
+  for (uint32_t i = 0; i < 20; ++i) {
+    deleted.push_back(deletable_[i]);
+    do_remove(deletable_[i]);
+  }
+  EXPECT_EQ(idx_->free_slot_count(), 20u);
+  const uint64_t cap_before = idx_->max_slot_id();
+
+  const auto nv = make_vectors(20, 16, /*seed=*/321);
+  std::unordered_set<uint32_t> reused;
+  for (uint32_t i = 0; i < 20; ++i) {
+    reused.insert(do_insert(vec_at(nv, i)));
+  }
+  EXPECT_EQ(idx_->free_slot_count(), 0u);      // free list drained
+  EXPECT_EQ(idx_->max_slot_id(), cap_before);  // no append: capacity unchanged
+  for (const uint32_t id : deleted) {
+    EXPECT_TRUE(reused.count(id) != 0) << "freed slot " << id << " should have been reused";
+  }
+}
+
+// 7.5 -----------------------------------------------------------------------
+TEST_F(UpdateE2ETest, PersistenceAcrossFlushReload) {
+  build_and_load(500, 32, 32, {});
+  const auto nv = make_vectors(50, 32, /*seed=*/654);
+  std::vector<uint64_t> inserted_labels;
+  for (uint32_t i = 0; i < 50; ++i) {
+    inserted_labels.push_back(id_label_[do_insert(vec_at(nv, i))]);
+  }
+  std::vector<uint32_t> deleted;
+  for (uint32_t i = 0; i < 50; ++i) {
+    deleted.push_back(deletable_[i]);
+    do_remove(deletable_[i]);
+  }
+  const uint64_t live_before = idx_->live_count();
+  const uint64_t tomb_before = idx_->tombstone_count();
+
+  idx_->flush();
+  idx_ = std::make_unique<DiskANNIndex>();
+  DiskANNLoadParams lp;
+  lp.updatable = true;
+  idx_->load(dir(), lp);
+
+  EXPECT_EQ(idx_->live_count(), live_before);
+  EXPECT_EQ(idx_->tombstone_count(), tomb_before);
+  for (const uint32_t id : deleted) {
+    EXPECT_TRUE(idx_->is_deleted(id)) << "tombstone for " << id << " must survive reload";
+  }
+  for (const uint32_t id : {deleted[0], deleted[25], deleted[49]}) {
+    uint64_t out_l[10];
+    float out_d[10];
+    idx_->search(base_vecs_.data() + id * 32, 10, out_l, out_d, {100, false, false, 0, true});
+    for (const uint64_t l : out_l) {
+      EXPECT_NE(l, static_cast<uint64_t>(1000 + id));
+    }
+  }
+  uint32_t found = 0;
+  for (uint32_t i = 0; i < 50; ++i) {
+    if (top1_is(nv.data() + i * 32, inserted_labels[i])) {
+      ++found;
+    }
+  }
+  EXPECT_GE(found, 45u) << "inserted vectors must remain findable after reload";
+}
+
+// 7.6 -----------------------------------------------------------------------
+TEST_F(UpdateE2ETest, SafetyNetReconnectFiresOnPureDeletes) {
+  DiskANNLoadParams lp;
+  lp.safety_net_ratio = 0.05;
+  lp.safety_net_ops = 8;
+  build_and_load(1000, 32, 32, lp);
+  const auto queries = make_vectors(50, 32, /*seed=*/7);
+
+  for (uint32_t i = 0; i < 80; ++i) {  // 8% pure deletes (exceeds 5% threshold)
+    do_remove(deletable_[i]);
+  }
+  EXPECT_GT(idx_->safety_net_fire_count(), 0u) << "proactive reconnect should fire";
+  EXPECT_GE(recall_at_k(queries, 50, 10, 100), 0.85) << "recall must not collapse";
+}
+
+#else  // !__linux__
+
+TEST(UpdateE2ETest, SkippedOnNonLinux) {
+  GTEST_SKIP() << "DiskANN in-place updates require Linux O_DIRECT";
+}
+
+#endif  // __linux__
+
+}  // namespace

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "alayalite"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "pandas" },


### PR DESCRIPTION
## Summary

Adds a complete self-contained DiskANN disk index (`alaya::diskann::DiskANNIndex`) with in-place update support, across 3 commits:

### Commit 1: DiskANN disk index foundation (`4eeba8a`)
- In-memory Vamana build → sector-aligned disk layout → optional PQ → BFS node cache → cached beam search
- **PQ beam search**: async-pipelined I/O with opt-in deterministic mode for byte-exact batch/sequential reproducibility
- **No-PQ greedy search**: faithful disk port of Vamana greedy with exact L2, async pipeline (tunable `nopq_io_depth`, default 32)
- PQ training parallelized across chunks and encoding across points, byte-identical to single-threaded
- 6 test files + standalone SIFT1M benchmark, all green under `-fsanitize=address,undefined`

### Commit 2: IP-DiskANN in-place updates (`5fab865`)
- `insert()` / `remove()` / `flush()` on the No-PQ disk index following the IP-DiskANN design
- Deletions repair the graph at delete-time (search + c=3 replacement edges) rather than deferring to search-time two-hop bypass
- New components: `TombstoneBitmap` (word-packed bitset with popcount), `SlotAllocator` (LIFO free-list), `DiskPageIO` (O_DIRECT sector-aligned RMW), `DiskUpdateContext`
- Safety-net dangling-edge cleanup, Meta v2 with backward-compatible v1 read
- 4 new test files covering tombstone, slot allocation, and end-to-end update scenarios

### Commit 3: Simplify update internals (`0a15a18`)
- Extract shared reconnect backbone (`cached_l2`, `prune_and_write`) from `update_node_impl` / `update_node_ipdiskann`, eliminating ~60 lines of duplication
- Remove redundant `removed_vertices_` set (derivable from `removed_node_nbrs_` keys)
- Demote `num_points_` to a `load()`-local variable
- Replace `unordered_set` with sorted comparison in `same_neighbor_set`
- Reuse `AlignedRead` in PQ rerank loop, use `partial_sort` for top-3 selection

## New files

| File | Description |
|------|-------------|
| `beam_search.hpp` | PQ + No-PQ disk search with async I/O |
| `disk_layout.hpp` | Sector-aligned on-disk layout |
| `diskann_index.hpp` | Build / load / search / update index |
| `disk_page_io.hpp` | O_DIRECT page read/write for updates |
| `disk_update_context.hpp` | Transient update bookkeeping |
| `node_cache.hpp` | BFS node cache |
| `pq_table.hpp` | PQ train / encode / distance |
| `search_scratch.hpp` | Per-thread search scratch |
| `slot_allocator.hpp` | Free-list slot allocator |
| `tombstone_bitmap.hpp` | Deleted-slot bitmap |

## Test plan

- [x] All 48 DiskANN tests pass (tombstone_slot, disk_page_io, tombstone_search, beam_search, layout, pq, node_cache, index, e2e, update_e2e)
- [x] Full project compiles clean with `-DALAYA_ENABLE_LASER=ON -DBUILD_TESTING=ON`
- [x] All tests pass under `-fsanitize=address,undefined`
- [x] pre-commit hooks (clang-format, cpplint, conventional commit) pass