### PR TITLE
chore(release): single-source version management and release automation

### DIFF
--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -1,9 +1,9 @@
 ---
 name       : Prepare Release
 
-# Manual trigger: input the target version, and this workflow will bump all
-# version files, update CHANGELOG.md, commit, tag, and push. The tag push
-# then triggers the existing cibuildwheel workflow to build wheels and publish.
+# Manual trigger: input the target version, and this workflow will bump
+# pyproject.toml (single source of truth), update CHANGELOG.md, commit,
+# tag, and push. The tag push triggers cibuildwheel to build and publish.
 on         :
   workflow_dispatch:
     inputs:
@@ -37,17 +37,22 @@ jobs       :
     - name: Validate version format
       run: |
         VERSION="${{ inputs.version }}"
-        if ! echo "$VERSION" | grep -qP '^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?$'; then
+        if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?$'; then
           echo "::error::Invalid version format: $VERSION (expected X.Y.Z or X.Y.Za1/b1)"
           exit 1
         fi
 
-    - name: Read current version
+    - name: Read current version and fail-fast on no-op
       id: current
       run: |
-        OLD=$(grep -oP '(?<=^version = ")[^"]+' pyproject.toml | head -1)
+        OLD=$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1)
         echo "version=$OLD" >> "$GITHUB_OUTPUT"
         echo "Current version: $OLD"
+        VERSION="${{ inputs.version }}"
+        if [ "$OLD" = "$VERSION" ]; then
+          echo "::error::Version $VERSION is already current — nothing to bump"
+          exit 1
+        fi
 
     - name: Bump version in pyproject.toml
       run: |
@@ -70,6 +75,9 @@ jobs       :
         VERSION="${{ inputs.version }}"
         OLD="${{ steps.current.outputs.version }}"
         DATE=$(date +%Y-%m-%d)
+
+        # Escape dots in OLD for safe use in sed regex
+        OLD_ESC=$(echo "$OLD" | sed 's/\./\\./g')
 
         # Collect conventional commit summaries since last tag
         LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -113,8 +121,8 @@ jobs       :
         # Insert after "## [Unreleased]" line
         sed -i "/^## \[Unreleased\]/r /tmp/changelog_entry.md" CHANGELOG.md
 
-        # Update footer links
-        sed -i "s|\[Unreleased\]: \(.*\)/compare/v${OLD}\.\.\.HEAD|[Unreleased]: \1/compare/v${VERSION}...HEAD\n[${VERSION}]: \1/compare/v${OLD}...v${VERSION}|" CHANGELOG.md
+        # Update footer links (dots in OLD_ESC are escaped for sed)
+        sed -i "s|\[Unreleased\]: \(.*\)/compare/v${OLD_ESC}\.\.\.HEAD|[Unreleased]: \1/compare/v${VERSION}...HEAD\n[${VERSION}]: \1/compare/v${OLD}...v${VERSION}|" CHANGELOG.md
 
     - name: Show diff (dry run)
       if: inputs.dry_run

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -49,24 +49,18 @@ jobs       :
         echo "version=$OLD" >> "$GITHUB_OUTPUT"
         echo "Current version: $OLD"
 
-    - name: Bump version in all files
+    - name: Bump version in pyproject.toml
       run: |
         VERSION="${{ inputs.version }}"
         OLD="${{ steps.current.outputs.version }}"
 
         echo "Bumping: $OLD → $VERSION"
-
         sed -i "s/^version = \"$OLD\"/version = \"$VERSION\"/" pyproject.toml
-        sed -i "s/^__version__ = \"$OLD\"/__version__ = \"$VERSION\"/" python/src/alayalite/__init__.py
-        sed -i "s/version = \"$OLD\"/version = \"$VERSION\"/" conanfile.py
 
-        # Verify all files were updated
-        for f in pyproject.toml python/src/alayalite/__init__.py conanfile.py; do
-          if ! grep -q "$VERSION" "$f"; then
-            echo "::error::Version not updated in $f"
-            exit 1
-          fi
-        done
+        if ! grep -q "version = \"$VERSION\"" pyproject.toml; then
+          echo "::error::Version not updated in pyproject.toml"
+          exit 1
+        fi
 
     - name: Sync uv.lock
       run: uv lock
@@ -137,7 +131,7 @@ jobs       :
         VERSION="${{ inputs.version }}"
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add pyproject.toml python/src/alayalite/__init__.py conanfile.py uv.lock CHANGELOG.md
+        git add pyproject.toml uv.lock CHANGELOG.md
         git commit -m "chore(release): bump version to ${VERSION}"
         git tag "v${VERSION}"
         git push origin main

--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -1,0 +1,145 @@
+---
+name       : Prepare Release
+
+# Manual trigger: input the target version, and this workflow will bump all
+# version files, update CHANGELOG.md, commit, tag, and push. The tag push
+# then triggers the existing cibuildwheel workflow to build wheels and publish.
+on         :
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version (e.g. 1.0.2)
+        required: true
+        type: string
+      dry_run:
+        description: Dry run — show changes without committing
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs       :
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+
+    - name: Validate version format
+      run: |
+        VERSION="${{ inputs.version }}"
+        if ! echo "$VERSION" | grep -qP '^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?$'; then
+          echo "::error::Invalid version format: $VERSION (expected X.Y.Z or X.Y.Za1/b1)"
+          exit 1
+        fi
+
+    - name: Read current version
+      id: current
+      run: |
+        OLD=$(grep -oP '(?<=^version = ")[^"]+' pyproject.toml | head -1)
+        echo "version=$OLD" >> "$GITHUB_OUTPUT"
+        echo "Current version: $OLD"
+
+    - name: Bump version in all files
+      run: |
+        VERSION="${{ inputs.version }}"
+        OLD="${{ steps.current.outputs.version }}"
+
+        echo "Bumping: $OLD → $VERSION"
+
+        sed -i "s/^version = \"$OLD\"/version = \"$VERSION\"/" pyproject.toml
+        sed -i "s/^__version__ = \"$OLD\"/__version__ = \"$VERSION\"/" python/src/alayalite/__init__.py
+        sed -i "s/version = \"$OLD\"/version = \"$VERSION\"/" conanfile.py
+
+        # Verify all files were updated
+        for f in pyproject.toml python/src/alayalite/__init__.py conanfile.py; do
+          if ! grep -q "$VERSION" "$f"; then
+            echo "::error::Version not updated in $f"
+            exit 1
+          fi
+        done
+
+    - name: Sync uv.lock
+      run: uv lock
+
+    - name: Generate CHANGELOG entry
+      run: |
+        VERSION="${{ inputs.version }}"
+        OLD="${{ steps.current.outputs.version }}"
+        DATE=$(date +%Y-%m-%d)
+
+        # Collect conventional commit summaries since last tag
+        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        if [ -n "$LAST_TAG" ]; then
+          RANGE="${LAST_TAG}..HEAD"
+        else
+          RANGE="HEAD"
+        fi
+
+        # Generate grouped entries from conventional commits
+        {
+          echo "## [$VERSION] - $DATE"
+          echo ""
+
+          ADDED=$(git log "$RANGE" --pretty=format:"%s" --no-merges | grep -iE "^feat" | sed 's/^/- /' || true)
+          if [ -n "$ADDED" ]; then
+            echo "### Added"
+            echo "$ADDED"
+            echo ""
+          fi
+
+          CHANGED=$(git log "$RANGE" --pretty=format:"%s" --no-merges | grep -iE "^(refactor|perf|chore)" | sed 's/^/- /' || true)
+          if [ -n "$CHANGED" ]; then
+            echo "### Changed"
+            echo "$CHANGED"
+            echo ""
+          fi
+
+          FIXED=$(git log "$RANGE" --pretty=format:"%s" --no-merges | grep -iE "^fix" | sed 's/^/- /' || true)
+          if [ -n "$FIXED" ]; then
+            echo "### Fixed"
+            echo "$FIXED"
+            echo ""
+          fi
+        } > /tmp/changelog_entry.md
+
+        echo "--- Generated CHANGELOG entry ---"
+        cat /tmp/changelog_entry.md
+        echo "---"
+
+        # Insert after "## [Unreleased]" line
+        sed -i "/^## \[Unreleased\]/r /tmp/changelog_entry.md" CHANGELOG.md
+
+        # Update footer links
+        sed -i "s|\[Unreleased\]: \(.*\)/compare/v${OLD}\.\.\.HEAD|[Unreleased]: \1/compare/v${VERSION}...HEAD\n[${VERSION}]: \1/compare/v${OLD}...v${VERSION}|" CHANGELOG.md
+
+    - name: Show diff (dry run)
+      if: inputs.dry_run
+      run: |
+        echo "::notice::Dry run — showing changes without committing"
+        git diff
+        echo ""
+        echo "Files changed:"
+        git diff --stat
+
+    - name: Commit, tag, and push
+      if: '!inputs.dry_run'
+      run: |
+        VERSION="${{ inputs.version }}"
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add pyproject.toml python/src/alayalite/__init__.py conanfile.py uv.lock CHANGELOG.md
+        git commit -m "chore(release): bump version to ${VERSION}"
+        git tag "v${VERSION}"
+        git push origin main
+        git push origin "v${VERSION}"
+        echo "::notice::Released v${VERSION} — cibuildwheel will build and publish automatically"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 .PHONY: help build build-debug build-release build-san build-coverage \
         test test-cpp test-cpp-debug test-san test-py test-py-integration test-py-cov \
         lint format configure conan-install conan-install-debug \
-        install dev-install wheel clean clean-release clean-debug clean-all codegen
+        install dev-install wheel clean clean-release clean-debug clean-all codegen \
+        bump-version release-dry version
 
 # Configuration
 BUILD_RELEASE_DIR := build/Release
@@ -37,6 +38,8 @@ help: ## Show this help message
 	@echo "  make test                   # Run all tests (C++ release + Python)"
 	@echo "  make build-san test-san     # Sanitizer build + test"
 	@echo "  make configure BUILD_TYPE=Debug"
+	@echo "  make bump-version V=1.0.2   # Bump version + sync lockfile"
+	@echo "  make release-dry V=1.0.2    # Preview version bump (no write)"
 
 # ============================================================================
 # Build
@@ -120,6 +123,21 @@ dev-install: ## Install package with all dev dependencies
 
 wheel: ## Build wheel (PYTHON_VERSION=3.x to target a specific interpreter)
 	@uv build $(if $(PYTHON_VERSION),--python $(PYTHON_VERSION))
+
+# ============================================================================
+# Release
+# ============================================================================
+
+version: ## Show current project version
+	@grep -oP '(?<=^version = ")[^"]+' pyproject.toml | head -1
+
+bump-version: ## Bump version: make bump-version V=1.0.2
+	@test -n "$(V)" || { echo "Usage: make bump-version V=1.0.2"; exit 1; }
+	@scripts/bump_version.sh $(V)
+
+release-dry: ## Preview version bump without writing: make release-dry V=1.0.2
+	@test -n "$(V)" || { echo "Usage: make release-dry V=1.0.2"; exit 1; }
+	@scripts/bump_version.sh $(V) --dry
 
 # ============================================================================
 # Clean

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ wheel: ## Build wheel (PYTHON_VERSION=3.x to target a specific interpreter)
 # ============================================================================
 
 version: ## Show current project version
-	@grep -oP '(?<=^version = ")[^"]+' pyproject.toml | head -1
+	@sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml | head -1
 
 bump-version: ## Bump version: make bump-version V=1.0.2
 	@test -n "$(V)" || { echo "Usage: make bump-version V=1.0.2"; exit 1; }

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ from conan.tools.files import copy
 
 class AlayaLiteConan(ConanFile):
     name = "AlayaLite"
-    version = "1.0.0"
+    version = "1.0.1"
     settings = "os", "compiler", "build_type", "arch"
     package_type = "header-library"
     exports_sources = "include/*"

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ from conan.tools.files import copy
 
 def _read_version():
     pyproject = os.path.join(os.path.dirname(__file__), "pyproject.toml")
-    with open(pyproject) as f:
+    with open(pyproject, encoding="utf-8") as f:
         m = re.search(r'^version\s*=\s*"([^"]+)"', f.read(), re.MULTILINE)
     return m.group(1) if m else "0.0.0"
 
@@ -22,6 +22,7 @@ class AlayaLiteConan(ConanFile):
     version = _read_version()
     settings = "os", "compiler", "build_type", "arch"
     package_type = "header-library"
+    exports = "pyproject.toml"
     exports_sources = "include/*"
     platform_tool_requires = "cmake/3.23.5"  # cmake version
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,15 +3,23 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 import os
+import re
 
 from conan import ConanFile
 from conan.tools.cmake import CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy
 
 
+def _read_version():
+    pyproject = os.path.join(os.path.dirname(__file__), "pyproject.toml")
+    with open(pyproject) as f:
+        m = re.search(r'^version\s*=\s*"([^"]+)"', f.read(), re.MULTILINE)
+    return m.group(1) if m else "0.0.0"
+
+
 class AlayaLiteConan(ConanFile):
     name = "AlayaLite"
-    version = "1.0.1"
+    version = _read_version()
     settings = "os", "compiler", "build_type", "arch"
     package_type = "header-library"
     exports_sources = "include/*"

--- a/python/src/alayalite/__init__.py
+++ b/python/src/alayalite/__init__.py
@@ -45,5 +45,5 @@ try:
     from importlib.metadata import version as _pkg_version
 
     __version__ = _pkg_version("alayalite")
-except PackageNotFoundError:
+except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0.dev"

--- a/python/src/alayalite/__init__.py
+++ b/python/src/alayalite/__init__.py
@@ -40,4 +40,10 @@ __all__ = [
     "calc_gt",
 ]
 
-__version__ = "1.0.1"
+try:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    __version__ = _pkg_version("alayalite")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev"

--- a/python/src/alayalite/__init__.py
+++ b/python/src/alayalite/__init__.py
@@ -40,4 +40,4 @@ __all__ = [
     "calc_gt",
 ]
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025 AlayaDB.AI
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Bump the project version across all source-of-truth files, update uv.lock,
+# commit, and create a git tag.
+#
+# Usage:
+#   ./scripts/bump_version.sh 1.0.2          # bump + commit + tag
+#   ./scripts/bump_version.sh 1.0.2 --dry    # preview changes, don't write
+#
+# Files updated:
+#   pyproject.toml                       version = "X.Y.Z"
+#   python/src/alayalite/__init__.py     __version__ = "X.Y.Z"
+#   conanfile.py                         version = "X.Y.Z"
+
+set -euo pipefail
+
+VERSION="${1:-}"
+DRY="${2:-}"
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version> [--dry]"
+  echo "Example: $0 1.0.2"
+  exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?$ ]]; then
+  echo "Error: version '$VERSION' does not match X.Y.Z or X.Y.Za1/b1 pattern"
+  exit 1
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+
+PYPROJECT="$ROOT/pyproject.toml"
+INIT_PY="$ROOT/python/src/alayalite/__init__.py"
+CONANFILE="$ROOT/conanfile.py"
+
+for f in "$PYPROJECT" "$INIT_PY" "$CONANFILE"; do
+  if [[ ! -f "$f" ]]; then
+    echo "Error: $f not found"
+    exit 1
+  fi
+done
+
+OLD_VERSION=$(grep -oP '(?<=^version = ")[^"]+' "$PYPROJECT" | head -1)
+if [[ -z "$OLD_VERSION" ]]; then
+  echo "Error: cannot read current version from $PYPROJECT"
+  exit 1
+fi
+
+if [[ "$OLD_VERSION" == "$VERSION" ]]; then
+  echo "Already at version $VERSION, nothing to do."
+  exit 0
+fi
+
+echo "Bumping: $OLD_VERSION → $VERSION"
+echo ""
+echo "Files:"
+echo "  $PYPROJECT"
+echo "  $INIT_PY"
+echo "  $CONANFILE"
+
+if [[ "$DRY" == "--dry" ]]; then
+  echo ""
+  echo "(dry run — no files changed)"
+  exit 0
+fi
+
+sed -i "s/^version = \"$OLD_VERSION\"/version = \"$VERSION\"/" "$PYPROJECT"
+sed -i "s/^__version__ = \"$OLD_VERSION\"/__version__ = \"$VERSION\"/" "$INIT_PY"
+sed -i "s/version = \"$OLD_VERSION\"/version = \"$VERSION\"/" "$CONANFILE"
+
+for f in "$PYPROJECT" "$INIT_PY" "$CONANFILE"; do
+  if ! grep -q "$VERSION" "$f"; then
+    echo "Error: version not updated in $f — check manually"
+    exit 1
+  fi
+done
+
+echo "Syncing uv.lock..."
+(cd "$ROOT" && uv lock --quiet 2>/dev/null || true)
+
+echo ""
+echo "Version updated to $VERSION in all files."
+echo ""
+echo "Next steps:"
+echo "  1. Update CHANGELOG.md with the new [${VERSION}] section"
+echo "  2. git add -A && git commit -m 'chore(release): bump version to ${VERSION}'"
+echo "  3. git tag v${VERSION}"
+echo "  4. git push upstream main && git push upstream v${VERSION}"

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -2,17 +2,13 @@
 # SPDX-FileCopyrightText: 2025 AlayaDB.AI
 # SPDX-License-Identifier: AGPL-3.0-only
 #
-# Bump the project version across all source-of-truth files, update uv.lock,
-# commit, and create a git tag.
+# Bump the project version in pyproject.toml (the single source of truth)
+# and sync uv.lock. Other files (conanfile.py, __init__.py) read the version
+# dynamically at build/runtime — no manual sync needed.
 #
 # Usage:
-#   ./scripts/bump_version.sh 1.0.2          # bump + commit + tag
+#   ./scripts/bump_version.sh 1.0.2          # bump + sync lockfile
 #   ./scripts/bump_version.sh 1.0.2 --dry    # preview changes, don't write
-#
-# Files updated:
-#   pyproject.toml                       version = "X.Y.Z"
-#   python/src/alayalite/__init__.py     __version__ = "X.Y.Z"
-#   conanfile.py                         version = "X.Y.Z"
 
 set -euo pipefail
 
@@ -31,17 +27,7 @@ if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?$ ]]; then
 fi
 
 ROOT="$(git rev-parse --show-toplevel)"
-
 PYPROJECT="$ROOT/pyproject.toml"
-INIT_PY="$ROOT/python/src/alayalite/__init__.py"
-CONANFILE="$ROOT/conanfile.py"
-
-for f in "$PYPROJECT" "$INIT_PY" "$CONANFILE"; do
-  if [[ ! -f "$f" ]]; then
-    echo "Error: $f not found"
-    exit 1
-  fi
-done
 
 OLD_VERSION=$(grep -oP '(?<=^version = ")[^"]+' "$PYPROJECT" | head -1)
 if [[ -z "$OLD_VERSION" ]]; then
@@ -55,11 +41,7 @@ if [[ "$OLD_VERSION" == "$VERSION" ]]; then
 fi
 
 echo "Bumping: $OLD_VERSION → $VERSION"
-echo ""
-echo "Files:"
-echo "  $PYPROJECT"
-echo "  $INIT_PY"
-echo "  $CONANFILE"
+echo "  pyproject.toml (single source of truth)"
 
 if [[ "$DRY" == "--dry" ]]; then
   echo ""
@@ -68,15 +50,11 @@ if [[ "$DRY" == "--dry" ]]; then
 fi
 
 sed -i "s/^version = \"$OLD_VERSION\"/version = \"$VERSION\"/" "$PYPROJECT"
-sed -i "s/^__version__ = \"$OLD_VERSION\"/__version__ = \"$VERSION\"/" "$INIT_PY"
-sed -i "s/version = \"$OLD_VERSION\"/version = \"$VERSION\"/" "$CONANFILE"
 
-for f in "$PYPROJECT" "$INIT_PY" "$CONANFILE"; do
-  if ! grep -q "$VERSION" "$f"; then
-    echo "Error: version not updated in $f — check manually"
-    exit 1
-  fi
-done
+if ! grep -q "version = \"$VERSION\"" "$PYPROJECT"; then
+  echo "Error: version not updated in pyproject.toml"
+  exit 1
+fi
 
 echo "Syncing uv.lock..."
 if ! (cd "$ROOT" && uv lock --quiet); then
@@ -85,17 +63,15 @@ if ! (cd "$ROOT" && uv lock --quiet); then
 fi
 
 echo ""
-echo "Version updated to $VERSION in all files."
-echo ""
-echo "Files changed:"
+echo "Done. Files changed:"
 echo "  pyproject.toml"
-echo "  python/src/alayalite/__init__.py"
-echo "  conanfile.py"
 echo "  uv.lock"
 echo ""
 echo "Next steps:"
 echo "  1. Update CHANGELOG.md with the new [${VERSION}] section"
-echo "  2. git add pyproject.toml python/src/alayalite/__init__.py conanfile.py uv.lock CHANGELOG.md"
+echo "  2. git add pyproject.toml uv.lock CHANGELOG.md"
 echo "  3. git commit -m 'chore(release): bump version to ${VERSION}'"
 echo "  4. git tag v${VERSION}"
 echo "  5. git push upstream main && git push upstream v${VERSION}"
+echo ""
+echo "Or use: GitHub Actions → Prepare Release → version=${VERSION}"

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -29,7 +29,16 @@ fi
 ROOT="$(git rev-parse --show-toplevel)"
 PYPROJECT="$ROOT/pyproject.toml"
 
-OLD_VERSION=$(grep -oP '(?<=^version = ")[^"]+' "$PYPROJECT" | head -1)
+# Portable sed -i: GNU sed uses -i without arg, BSD sed requires -i ''
+_sed_i() {
+  if sed --version >/dev/null 2>&1; then
+    sed -i "$@"
+  else
+    sed -i '' "$@"
+  fi
+}
+
+OLD_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' "$PYPROJECT" | head -1)
 if [[ -z "$OLD_VERSION" ]]; then
   echo "Error: cannot read current version from $PYPROJECT"
   exit 1
@@ -49,7 +58,7 @@ if [[ "$DRY" == "--dry" ]]; then
   exit 0
 fi
 
-sed -i "s/^version = \"$OLD_VERSION\"/version = \"$VERSION\"/" "$PYPROJECT"
+_sed_i "s/^version = \"$OLD_VERSION\"/version = \"$VERSION\"/" "$PYPROJECT"
 
 if ! grep -q "version = \"$VERSION\"" "$PYPROJECT"; then
   echo "Error: version not updated in pyproject.toml"

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -79,13 +79,23 @@ for f in "$PYPROJECT" "$INIT_PY" "$CONANFILE"; do
 done
 
 echo "Syncing uv.lock..."
-(cd "$ROOT" && uv lock --quiet 2>/dev/null || true)
+if ! (cd "$ROOT" && uv lock --quiet); then
+  echo "Error: uv lock failed — fix pyproject.toml and retry"
+  exit 1
+fi
 
 echo ""
 echo "Version updated to $VERSION in all files."
 echo ""
+echo "Files changed:"
+echo "  pyproject.toml"
+echo "  python/src/alayalite/__init__.py"
+echo "  conanfile.py"
+echo "  uv.lock"
+echo ""
 echo "Next steps:"
 echo "  1. Update CHANGELOG.md with the new [${VERSION}] section"
-echo "  2. git add -A && git commit -m 'chore(release): bump version to ${VERSION}'"
-echo "  3. git tag v${VERSION}"
-echo "  4. git push upstream main && git push upstream v${VERSION}"
+echo "  2. git add pyproject.toml python/src/alayalite/__init__.py conanfile.py uv.lock CHANGELOG.md"
+echo "  3. git commit -m 'chore(release): bump version to ${VERSION}'"
+echo "  4. git tag v${VERSION}"
+echo "  5. git push upstream main && git push upstream v${VERSION}"


### PR DESCRIPTION
## Summary

- **Single-source version**: `pyproject.toml` is the only file where version is defined. `__init__.py` reads it via `importlib.metadata` at runtime; `conanfile.py` parses it with regex. No more version mismatch risk across 3 files.
- **Release-prepare workflow**: manual-dispatch GitHub Action that bumps version in `pyproject.toml`, syncs `uv.lock`, generates CHANGELOG entry from conventional commits, commits, tags, and pushes. Tag push triggers the existing `cibuildwheel` workflow to build and publish to PyPI.
- **Local tooling**: `scripts/bump_version.sh` for local version bumps; Makefile targets `make version`, `make bump-version V=X.Y.Z`, `make release-dry V=X.Y.Z`.
- **Version 1.0.1**: bumps version to 1.0.1 for the DiskANN release.

## Test plan

- [x] `make version` → `1.0.1`
- [x] `make release-dry V=1.0.2` → shows correct preview
- [x] `importlib.metadata.version("alayalite")` returns `1.0.1` in `uv run` environment
- [x] `conanfile.py` dynamic read returns `1.0.1`
- [x] All pre-commit hooks pass