### PR TITLE
feat(diskann): expose Python update APIs

### DIFF
--- a/include/index/graph/diskann/diskann_index.hpp
+++ b/include/index/graph/diskann/diskann_index.hpp
@@ -200,6 +200,7 @@ class DiskANNIndex {
     if (vectors == nullptr || labels == nullptr) {
       throw std::invalid_argument("DiskANNIndex::build: null vectors/labels");
     }
+    validate_unique_external_labels(labels, n, "build");
     if (params.pq_n_chunks > 0 && dim % params.pq_n_chunks != 0) {
       throw std::invalid_argument("DiskANNIndex::build: dim not divisible by pq_n_chunks");
     }
@@ -794,6 +795,10 @@ class DiskANNIndex {
     std::shared_lock<std::shared_mutex> lock(update_mutex_);
     return slot_alloc_.is_deleted(id);
   }
+  [[nodiscard]] bool contains_label(uint64_t label) const {
+    std::shared_lock<std::shared_mutex> lock(update_mutex_);
+    return label_to_slot_.contains(label);
+  }
 
   /// Sentinel label for padded (missing) result slots.
   static constexpr uint64_t kNoLabel = std::numeric_limits<uint64_t>::max();
@@ -811,6 +816,10 @@ class DiskANNIndex {
       throw std::invalid_argument("DiskANNIndex::insert: null query");
     }
     std::lock_guard<std::mutex> update_guard(update_serial_mutex_);
+    {
+      std::shared_lock<std::shared_mutex> state_lock(update_mutex_);
+      validate_insert_label_unlocked(label);
+    }
     page_io_->clear_cache();
 
     const std::vector<uint32_t> pruned = select_insert_neighbors(query);
@@ -839,6 +848,10 @@ class DiskANNIndex {
     }
 
     std::lock_guard<std::mutex> update_guard(update_serial_mutex_);
+    {
+      std::shared_lock<std::shared_mutex> state_lock(update_mutex_);
+      validate_insert_labels_unlocked(labels, count);
+    }
     page_io_->clear_cache();
 
     const uint32_t workers = std::min({batch_size, count, update_insert_threads_});
@@ -870,6 +883,10 @@ class DiskANNIndex {
     }
 
     std::lock_guard<std::mutex> update_guard(update_serial_mutex_);
+    {
+      std::shared_lock<std::shared_mutex> state_lock(update_mutex_);
+      validate_insert_labels_unlocked(labels, count);
+    }
     page_io_->clear_cache();
     return batch_insert_locked_with_pool(vectors, labels, count, batch_size, pool);
   }
@@ -881,15 +898,21 @@ class DiskANNIndex {
       throw std::runtime_error("DiskANNIndex::remove: index not loaded in updatable mode");
     }
     std::lock_guard<std::mutex> update_guard(update_serial_mutex_);
+    remove_internal_locked(internal_id);
+  }
+
+  /// Lazy-delete by external label.
+  void remove_by_label(uint64_t label) {
+    if (!updatable_) {
+      throw std::runtime_error("DiskANNIndex::remove_by_label: index not loaded in updatable mode");
+    }
+    std::lock_guard<std::mutex> update_guard(update_serial_mutex_);
+    uint32_t internal_id = 0;
     {
       std::shared_lock<std::shared_mutex> state_lock(update_mutex_);
-      validate_removable_slot(internal_id);
+      internal_id = lookup_label_unlocked(label, "remove_by_label");
     }
-    page_io_->clear_cache();
-    remove_unlocked(internal_id);
-    if (maybe_safety_net_reconnect()) {
-      page_io_->flush_dirty_pages();
-    }
+    remove_internal_locked(internal_id);
   }
 
   /// Lazy-delete a batch using a caller-owned coroutine pool. This mirrors
@@ -902,22 +925,7 @@ class DiskANNIndex {
       return;
     }
     std::lock_guard<std::mutex> update_guard(update_serial_mutex_);
-    {
-      std::shared_lock<std::shared_mutex> state_lock(update_mutex_);
-      validate_remove_batch(internal_ids, count);
-    }
-    page_io_->clear_cache();
-    std::vector<std::vector<uint32_t>> old_neighbors =
-        read_delete_neighbors(internal_ids, count, &pool);
-    {
-      std::unique_lock<std::shared_mutex> state_lock(update_mutex_);
-      for (uint32_t i = 0; i < count; ++i) {
-        remove_unlocked_with_neighbors(internal_ids[i], std::move(old_neighbors[i]));
-      }
-    }
-    if (maybe_safety_net_reconnect()) {
-      page_io_->flush_dirty_pages();
-    }
+    batch_remove_internal_locked(internal_ids, count, &pool);
   }
 
   /// Lazy-delete a batch of internal ids using the same semantics as remove().
@@ -934,22 +942,37 @@ class DiskANNIndex {
       throw std::invalid_argument("DiskANNIndex::batch_remove: null ids");
     }
     std::lock_guard<std::mutex> update_guard(update_serial_mutex_);
+    batch_remove_internal_locked(internal_ids, count, nullptr);
+  }
+
+  /// Lazy-delete a batch of external labels using the same semantics as remove_by_label().
+  void batch_remove_by_labels(const uint64_t *labels, uint32_t count) {
+    if (!updatable_) {
+      throw std::runtime_error(
+          "DiskANNIndex::batch_remove_by_labels: index not loaded in updatable mode");
+    }
+    if (count == 0) {
+      return;
+    }
+    if (labels == nullptr) {
+      throw std::invalid_argument("DiskANNIndex::batch_remove_by_labels: null labels");
+    }
+    std::lock_guard<std::mutex> update_guard(update_serial_mutex_);
+    std::vector<uint32_t> internal_ids;
+    internal_ids.reserve(count);
     {
       std::shared_lock<std::shared_mutex> state_lock(update_mutex_);
-      validate_remove_batch(internal_ids, count);
-    }
-    page_io_->clear_cache();
-    std::vector<std::vector<uint32_t>> old_neighbors =
-        read_delete_neighbors(internal_ids, count, nullptr);
-    {
-      std::unique_lock<std::shared_mutex> state_lock(update_mutex_);
+      std::unordered_set<uint64_t> seen;
+      seen.reserve(count);
       for (uint32_t i = 0; i < count; ++i) {
-        remove_unlocked_with_neighbors(internal_ids[i], std::move(old_neighbors[i]));
+        if (!seen.insert(labels[i]).second) {
+          throw std::invalid_argument(
+              "DiskANNIndex::batch_remove_by_labels: duplicate external label");
+        }
+        internal_ids.push_back(lookup_label_unlocked(labels[i], "batch_remove_by_labels"));
       }
     }
-    if (maybe_safety_net_reconnect()) {
-      page_io_->flush_dirty_pages();
-    }
+    batch_remove_internal_locked(internal_ids.data(), count, nullptr);
   }
 
   /**
@@ -1148,6 +1171,7 @@ class DiskANNIndex {
     } else {
       slot_alloc_.reset(static_cast<uint32_t>(max_slot_id_));
     }
+    rebuild_label_lookup_unlocked();
     updatable_ = true;
   }
 
@@ -1469,6 +1493,68 @@ class DiskANNIndex {
     return slot;
   }
 
+  static void validate_unique_external_labels(const uint64_t *labels,
+                                              uint64_t count,
+                                              const char *method) {
+    std::unordered_set<uint64_t> seen;
+    seen.reserve(static_cast<size_t>(count));
+    for (uint64_t i = 0; i < count; ++i) {
+      if (labels[i] == kNoLabel) {
+        throw std::invalid_argument(std::string("DiskANNIndex::") + method +
+                                    ": external label is reserved");
+      }
+      if (!seen.insert(labels[i]).second) {
+        throw std::invalid_argument(std::string("DiskANNIndex::") + method +
+                                    ": duplicate external label");
+      }
+    }
+  }
+
+  void validate_insert_label_unlocked(uint64_t label) const {
+    if (label == kNoLabel) {
+      throw std::invalid_argument("DiskANNIndex::insert: external label is reserved");
+    }
+    if (label_to_slot_.contains(label)) {
+      throw std::invalid_argument("DiskANNIndex::insert: duplicate external label");
+    }
+  }
+
+  void validate_insert_labels_unlocked(const uint64_t *labels, uint32_t count) const {
+    validate_unique_external_labels(labels, count, "batch_insert");
+    for (uint32_t i = 0; i < count; ++i) {
+      if (label_to_slot_.contains(labels[i])) {
+        throw std::invalid_argument("DiskANNIndex::batch_insert: duplicate external label");
+      }
+    }
+  }
+
+  uint32_t lookup_label_unlocked(uint64_t label, const char *method) const {
+    const auto it = label_to_slot_.find(label);
+    if (it == label_to_slot_.end()) {
+      throw std::out_of_range(std::string("DiskANNIndex::") + method +
+                              ": external label not found: " + std::to_string(label));
+    }
+    return it->second;
+  }
+
+  void rebuild_label_lookup_unlocked() {
+    label_to_slot_.clear();
+    label_to_slot_.reserve(static_cast<size_t>(live_count_));
+    for (uint32_t slot = 0; slot < labels_.size(); ++slot) {
+      if (slot_alloc_.is_deleted(slot)) {
+        continue;
+      }
+      const uint64_t label = labels_[slot];
+      if (label == kNoLabel) {
+        throw std::runtime_error("DiskANNIndex::load: live slot has reserved external label");
+      }
+      if (!label_to_slot_.emplace(label, slot).second) {
+        throw std::runtime_error("DiskANNIndex::load: duplicate live external label: " +
+                                 std::to_string(label));
+      }
+    }
+  }
+
   void encode_pq_slot(const float *query, uint32_t slot) {
     if (!has_pq_) {
       return;
@@ -1536,6 +1622,39 @@ class DiskANNIndex {
     remove_unlocked_with_neighbors(internal_id, nd.nbrs);
   }
 
+  void remove_internal_locked(uint32_t internal_id) {
+    {
+      std::shared_lock<std::shared_mutex> state_lock(update_mutex_);
+      validate_removable_slot(internal_id);
+    }
+    page_io_->clear_cache();
+    remove_unlocked(internal_id);
+    if (maybe_safety_net_reconnect()) {
+      page_io_->flush_dirty_pages();
+    }
+  }
+
+  void batch_remove_internal_locked(const uint32_t *internal_ids,
+                                    uint32_t count,
+                                    coro::thread_pool *pool) {
+    {
+      std::shared_lock<std::shared_mutex> state_lock(update_mutex_);
+      validate_remove_batch(internal_ids, count);
+    }
+    page_io_->clear_cache();
+    std::vector<std::vector<uint32_t>> old_neighbors =
+        read_delete_neighbors(internal_ids, count, pool);
+    {
+      std::unique_lock<std::shared_mutex> state_lock(update_mutex_);
+      for (uint32_t i = 0; i < count; ++i) {
+        remove_unlocked_with_neighbors(internal_ids[i], std::move(old_neighbors[i]));
+      }
+    }
+    if (maybe_safety_net_reconnect()) {
+      page_io_->flush_dirty_pages();
+    }
+  }
+
   /// Neighbor lists of a delete batch. With the reactor this is one wave of
   /// concurrent io_uring reads over the batch's unique pages (a single
   /// suspension); without it, the blocking std::thread reader.
@@ -1559,6 +1678,11 @@ class DiskANNIndex {
 
   void remove_unlocked_with_neighbors(uint32_t internal_id, std::vector<uint32_t> old_neighbors) {
     update_ctx_.removed_node_nbrs_[internal_id] = std::move(old_neighbors);
+    const uint64_t label = labels_[internal_id];
+    const auto label_it = label_to_slot_.find(label);
+    if (label_it != label_to_slot_.end() && label_it->second == internal_id) {
+      label_to_slot_.erase(label_it);
+    }
     slot_alloc_.free(internal_id);
     --live_count_;
     ++ops_since_last_insert_;
@@ -1696,6 +1820,7 @@ class DiskANNIndex {
     std::unique_lock<std::shared_mutex> state_lock(update_mutex_);
     for (const uint32_t *it = begin; it != end; ++it) {
       slot_alloc_.publish(*it);
+      label_to_slot_[labels_[*it]] = *it;
     }
   }
 
@@ -2099,6 +2224,7 @@ class DiskANNIndex {
     page_io_.reset();
     update_reactor_.reset();  // after page_io_: it holds a raw pointer to the reactor
     update_ctx_.clear();
+    label_to_slot_.clear();
     updatable_ = false;
     loaded_ = false;
   }
@@ -2221,6 +2347,7 @@ class DiskANNIndex {
 
   // in-memory artifacts
   std::vector<uint64_t> labels_;
+  std::unordered_map<uint64_t, uint32_t> label_to_slot_;  ///< Live external label to slot.
   NodeCache cache_;
   PQTable pq_;
   std::unique_ptr<AlignedFileReader> reader_;

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -42,6 +42,7 @@ pybind11_add_module(
   MODULE
   NO_EXTRAS
   src/pybind.cpp
+  src/diskann_bindings.cpp
   src/index_factory.cpp
 )
 add_dependencies(${PYTHON_MODULE_NAME} alaya_codegen)

--- a/python/include/diskann.hpp
+++ b/python/include/diskann.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace alaya::diskann::pybindings {
+
+void register_diskann(pybind11::module_ &module);
+
+}  // namespace alaya::diskann::pybindings

--- a/python/src/alayalite/__init__.py
+++ b/python/src/alayalite/__init__.py
@@ -11,6 +11,7 @@ to all key components like the Client, Collection, and utility functions.
 
 import warnings
 
+from . import diskann  # noqa: E402
 from ._alayalitepy import DiskCollection, MetricType  # noqa: E402
 from .client import Client  # noqa: E402
 from .collection import Collection  # noqa: E402
@@ -37,6 +38,7 @@ __all__ = [
     "Collection",
     "DiskCollection",
     "MetricType",
+    "diskann",
     # utils
     "load_fvecs",
     "load_ivecs",

--- a/python/src/alayalite/diskann/__init__.py
+++ b/python/src/alayalite/diskann/__init__.py
@@ -1,0 +1,11 @@
+"""Python bindings for the standalone updatable DiskANN index."""
+
+from alayalite._alayalitepy import diskann as _diskann_module  # type: ignore[attr-defined]
+
+BuildParams = _diskann_module.BuildParams
+Index = _diskann_module.Index
+LoadParams = _diskann_module.LoadParams
+SearchParams = _diskann_module.SearchParams
+UpdateIO = _diskann_module.UpdateIO
+
+__all__ = ["BuildParams", "Index", "LoadParams", "SearchParams", "UpdateIO"]

--- a/python/src/diskann_bindings.cpp
+++ b/python/src/diskann_bindings.cpp
@@ -1,0 +1,298 @@
+#include "diskann.hpp"
+
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "index/graph/diskann/diskann_index.hpp"
+
+namespace alaya::diskann::pybindings {
+
+namespace py = pybind11;
+
+namespace {
+
+void require_array(const py::array &array,
+                   const py::dtype &dtype,
+                   int dimensions,
+                   const char *name) {
+  if (!array.dtype().is(dtype)) {
+    throw py::type_error(std::string(name) + " must have dtype " +
+                         dtype.attr("name").cast<std::string>());
+  }
+  if (array.ndim() != dimensions) {
+    throw py::value_error(std::string(name) + " must be " + std::to_string(dimensions) + "D");
+  }
+  if ((array.flags() & py::array::c_style) == 0) {
+    throw py::value_error(std::string(name) + " must be C-contiguous");
+  }
+}
+
+uint32_t checked_u32(py::ssize_t value, const char *name) {
+  if (value < 0 || static_cast<uint64_t>(value) > std::numeric_limits<uint32_t>::max()) {
+    throw py::value_error(std::string(name) + " must fit uint32");
+  }
+  return static_cast<uint32_t>(value);
+}
+
+class PyDiskANNIndex {
+ public:
+  static void build(const std::string &path,
+                    const py::array &vectors,
+                    const py::array &labels,
+                    const DiskANNBuildParams &params) {
+    require_array(vectors, py::dtype::of<float>(), 2, "vectors");
+    require_array(labels, py::dtype::of<uint64_t>(), 1, "labels");
+    if (vectors.shape(0) == 0 || vectors.shape(1) == 0) {
+      throw py::value_error("vectors must have non-zero rows and dimensions");
+    }
+    if (labels.shape(0) != vectors.shape(0)) {
+      throw py::value_error("labels length must match vectors rows");
+    }
+    const auto count = static_cast<uint64_t>(vectors.shape(0));
+    const auto dim = static_cast<uint64_t>(vectors.shape(1));
+    const auto *vector_data = static_cast<const float *>(vectors.data());
+    const auto *label_data = static_cast<const uint64_t *>(labels.data());
+    py::gil_scoped_release release;
+    DiskANNIndex::build(path, vector_data, label_data, count, dim, params);
+  }
+
+  static std::unique_ptr<PyDiskANNIndex> open(const std::string &path,
+                                              const DiskANNLoadParams &params) {
+    auto index = std::unique_ptr<PyDiskANNIndex>(new PyDiskANNIndex());
+    {
+      py::gil_scoped_release release;
+      index->index_.load(path, params);
+    }
+    return index;
+  }
+
+  py::tuple search(const py::array &query,
+                   uint32_t top_k,
+                   const DiskANNSearchParams &params) const {
+    require_array(query, py::dtype::of<float>(), 1, "query");
+    if (query.shape(0) != static_cast<py::ssize_t>(index_.dim())) {
+      throw py::value_error("query dimension does not match index dimension");
+    }
+    if (top_k == 0) {
+      throw py::value_error("top_k must be > 0");
+    }
+    std::vector<uint64_t> labels(top_k);
+    std::vector<float> distances(top_k);
+    uint32_t count = 0;
+    {
+      py::gil_scoped_release release;
+      count = index_.search(static_cast<const float *>(query.data()),
+                            top_k,
+                            labels.data(),
+                            distances.data(),
+                            params);
+    }
+    py::array_t<uint64_t> label_array(count);
+    py::array_t<float> distance_array(count);
+    std::memcpy(label_array.mutable_data(), labels.data(), count * sizeof(uint64_t));
+    std::memcpy(distance_array.mutable_data(), distances.data(), count * sizeof(float));
+    return py::make_tuple(std::move(label_array), std::move(distance_array));
+  }
+
+  py::tuple batch_search(const py::array &queries,
+                         uint32_t top_k,
+                         uint32_t num_threads,
+                         const DiskANNSearchParams &params) const {
+    require_array(queries, py::dtype::of<float>(), 2, "queries");
+    if (queries.shape(0) == 0) {
+      throw py::value_error("queries must have at least one row");
+    }
+    if (queries.shape(1) != static_cast<py::ssize_t>(index_.dim())) {
+      throw py::value_error("query dimension does not match index dimension");
+    }
+    if (top_k == 0 || num_threads == 0) {
+      throw py::value_error("top_k and num_threads must be > 0");
+    }
+    const uint32_t count = checked_u32(queries.shape(0), "queries rows");
+    const size_t result_count = static_cast<size_t>(count) * top_k;
+    std::vector<uint64_t> labels(result_count);
+    std::vector<float> distances(result_count);
+    {
+      py::gil_scoped_release release;
+      index_.batch_search(static_cast<const float *>(queries.data()),
+                          count,
+                          top_k,
+                          labels.data(),
+                          distances.data(),
+                          num_threads,
+                          params);
+    }
+    const std::vector<py::ssize_t> shape{static_cast<py::ssize_t>(count),
+                                         static_cast<py::ssize_t>(top_k)};
+    py::array_t<uint64_t> label_array(shape);
+    py::array_t<float> distance_array(shape);
+    std::memcpy(label_array.mutable_data(), labels.data(), result_count * sizeof(uint64_t));
+    std::memcpy(distance_array.mutable_data(), distances.data(), result_count * sizeof(float));
+    return py::make_tuple(std::move(label_array), std::move(distance_array));
+  }
+
+  void insert(const py::array &vector, uint64_t external_id) {
+    require_vector(vector, "vector");
+    py::gil_scoped_release release;
+    index_.insert(static_cast<const float *>(vector.data()), external_id);
+  }
+
+  void batch_insert(const py::array &vectors, const py::array &external_ids, uint32_t batch_size) {
+    require_array(vectors, py::dtype::of<float>(), 2, "vectors");
+    require_array(external_ids, py::dtype::of<uint64_t>(), 1, "external_ids");
+    if (vectors.shape(1) != static_cast<py::ssize_t>(index_.dim())) {
+      throw py::value_error("vectors dimension does not match index dimension");
+    }
+    if (vectors.shape(0) != external_ids.shape(0)) {
+      throw py::value_error("external_ids length must match vectors rows");
+    }
+    const uint32_t count = checked_u32(vectors.shape(0), "vectors rows");
+    py::gil_scoped_release release;
+    index_.batch_insert(static_cast<const float *>(vectors.data()),
+                        static_cast<const uint64_t *>(external_ids.data()),
+                        count,
+                        batch_size);
+  }
+
+  void remove(uint64_t external_id) {
+    try {
+      py::gil_scoped_release release;
+      index_.remove_by_label(external_id);
+    } catch (const std::out_of_range &error) {
+      throw py::key_error(error.what());
+    }
+  }
+
+  void batch_remove(const py::array &external_ids) {
+    require_array(external_ids, py::dtype::of<uint64_t>(), 1, "external_ids");
+    const uint32_t count = checked_u32(external_ids.shape(0), "external_ids length");
+    try {
+      py::gil_scoped_release release;
+      index_.batch_remove_by_labels(static_cast<const uint64_t *>(external_ids.data()), count);
+    } catch (const std::out_of_range &error) {
+      throw py::key_error(error.what());
+    }
+  }
+
+  bool contains(uint64_t external_id) const { return index_.contains_label(external_id); }
+
+  void flush() {
+    py::gil_scoped_release release;
+    index_.flush();
+  }
+
+  uint64_t size() const { return index_.size(); }
+  uint64_t dim() const { return index_.dim(); }
+  bool updatable() const { return index_.updatable(); }
+
+ private:
+  void require_vector(const py::array &vector, const char *name) const {
+    require_array(vector, py::dtype::of<float>(), 1, name);
+    if (vector.shape(0) != static_cast<py::ssize_t>(index_.dim())) {
+      throw py::value_error(std::string(name) + " dimension does not match index dimension");
+    }
+  }
+
+  DiskANNIndex index_;
+};
+
+}  // namespace
+
+void register_diskann(py::module_ &module) {
+  py::enum_<DiskANNUpdateIO>(module, "UpdateIO")
+      .value("AUTO", DiskANNUpdateIO::kAuto)
+      .value("URING", DiskANNUpdateIO::kUring)
+      .value("BLOCKING", DiskANNUpdateIO::kBlocking);
+
+  py::class_<DiskANNBuildParams>(module, "BuildParams")
+      .def(py::init<>())
+      .def_readwrite("R", &DiskANNBuildParams::R)
+      .def_readwrite("L", &DiskANNBuildParams::L)
+      .def_readwrite("alpha", &DiskANNBuildParams::alpha)
+      .def_readwrite("record_capacity", &DiskANNBuildParams::record_capacity)
+      .def_readwrite("pq_n_chunks", &DiskANNBuildParams::pq_n_chunks)
+      .def_readwrite("cache_ratio", &DiskANNBuildParams::cache_ratio)
+      .def_readwrite("num_threads", &DiskANNBuildParams::num_threads)
+      .def_readwrite("pq_train_iters", &DiskANNBuildParams::pq_train_iters)
+      .def_readwrite("seed", &DiskANNBuildParams::seed)
+      .def_readwrite("verbose", &DiskANNBuildParams::verbose);
+
+  py::class_<DiskANNLoadParams>(module, "LoadParams")
+      .def(py::init<>())
+      .def_readwrite("num_threads", &DiskANNLoadParams::num_threads)
+      .def_readwrite("beam_width", &DiskANNLoadParams::beam_width)
+      .def_readwrite("nopq_io_depth", &DiskANNLoadParams::nopq_io_depth)
+      .def_readwrite("scratch_search_list_size", &DiskANNLoadParams::scratch_search_list_size)
+      .def_readwrite("updatable", &DiskANNLoadParams::updatable)
+      .def_readwrite("update_search_l", &DiskANNLoadParams::update_search_l)
+      .def_readwrite("update_rerank", &DiskANNLoadParams::update_rerank)
+      .def_readwrite("update_insert_prune", &DiskANNLoadParams::update_insert_prune)
+      .def_readwrite("update_alpha", &DiskANNLoadParams::update_alpha)
+      .def_readwrite("safety_net_ratio", &DiskANNLoadParams::safety_net_ratio)
+      .def_readwrite("safety_net_ops", &DiskANNLoadParams::safety_net_ops)
+      .def_readwrite("page_cache_capacity", &DiskANNLoadParams::page_cache_capacity)
+      .def_readwrite("update_insert_threads", &DiskANNLoadParams::update_insert_threads)
+      .def_readwrite("update_reconnect_threads", &DiskANNLoadParams::update_reconnect_threads)
+      .def_readwrite("update_io", &DiskANNLoadParams::update_io)
+      .def_readwrite("update_search_concurrency", &DiskANNLoadParams::update_search_concurrency)
+      .def_readwrite("search_page_cache", &DiskANNLoadParams::search_page_cache);
+
+  py::class_<DiskANNSearchParams>(module, "SearchParams")
+      .def(py::init<>())
+      .def_readwrite("search_list_size", &DiskANNSearchParams::search_list_size)
+      .def_readwrite("use_pq", &DiskANNSearchParams::use_pq)
+      .def_readwrite("rerank", &DiskANNSearchParams::rerank)
+      .def_readwrite("rerank_count", &DiskANNSearchParams::rerank_count)
+      .def_readwrite("deterministic", &DiskANNSearchParams::deterministic);
+
+  DiskANNLoadParams default_load_params;
+  default_load_params.updatable = true;
+  py::class_<PyDiskANNIndex>(module, "Index")
+      .def_static("build",
+                  &PyDiskANNIndex::build,
+                  py::arg("path"),
+                  py::arg("vectors"),
+                  py::arg("external_ids"),
+                  py::arg("params") = DiskANNBuildParams{})
+      .def_static("open",
+                  &PyDiskANNIndex::open,
+                  py::arg("path"),
+                  py::arg("params") = default_load_params)
+      .def("search",
+           &PyDiskANNIndex::search,
+           py::arg("query"),
+           py::arg("top_k") = 10,
+           py::arg("params") = DiskANNSearchParams{})
+      .def("batch_search",
+           &PyDiskANNIndex::batch_search,
+           py::arg("queries"),
+           py::arg("top_k") = 10,
+           py::kw_only(),
+           py::arg("num_threads") = 1,
+           py::arg("params") = DiskANNSearchParams{})
+      .def("insert", &PyDiskANNIndex::insert, py::arg("vector"), py::arg("external_id"))
+      .def("batch_insert",
+           &PyDiskANNIndex::batch_insert,
+           py::arg("vectors"),
+           py::arg("external_ids"),
+           py::kw_only(),
+           py::arg("batch_size") = 32)
+      .def("remove", &PyDiskANNIndex::remove, py::arg("external_id"))
+      .def("batch_remove", &PyDiskANNIndex::batch_remove, py::arg("external_ids"))
+      .def("contains", &PyDiskANNIndex::contains, py::arg("external_id"))
+      .def("flush", &PyDiskANNIndex::flush)
+      .def_property_readonly("size", &PyDiskANNIndex::size)
+      .def_property_readonly("dim", &PyDiskANNIndex::dim)
+      .def_property_readonly("updatable", &PyDiskANNIndex::updatable);
+}
+
+}  // namespace alaya::diskann::pybindings

--- a/python/src/pybind.cpp
+++ b/python/src/pybind.cpp
@@ -34,6 +34,7 @@
 
 #include "client.hpp"
 #include "disk_collection.hpp"
+#include "diskann.hpp"
 #include "index.hpp"
 
 namespace py = pybind11;
@@ -55,6 +56,9 @@ PYBIND11_MODULE(_alayalitepy, m) {
   // Registered unconditionally; the builder has no Linux-only deps.
   auto vamana_mod = m.def_submodule("vamana", "Vamana graph builder");
   alaya::vamana::bindings::register_vamana_module(vamana_mod);
+
+  auto diskann_mod = m.def_submodule("diskann", "Standalone updatable DiskANN index");
+  alaya::diskann::pybindings::register_diskann(diskann_mod);
 
   // define version info
 #ifdef VERSION_INFO

--- a/python/tests/diskann/test_update.py
+++ b/python/tests/diskann/test_update.py
@@ -1,0 +1,88 @@
+"""Tests for external-ID based DiskANN update operations."""
+
+import sys
+
+import numpy as np
+import pytest
+from alayalite import diskann
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="DiskANN updates require Linux")
+
+
+def _build_index(path):
+    rng = np.random.default_rng(42)
+    vectors = rng.random((96, 16), dtype=np.float32)
+    external_ids = np.arange(1000, 1096, dtype=np.uint64)
+    build_params = diskann.BuildParams()
+    build_params.R = 16
+    build_params.L = 32
+    diskann.Index.build(str(path), vectors, external_ids, build_params)
+
+    load_params = diskann.LoadParams()
+    load_params.updatable = True
+    load_params.update_io = diskann.UpdateIO.BLOCKING
+    load_params.num_threads = 2
+    load_params.update_insert_threads = 2
+    load_params.update_reconnect_threads = 2
+    return diskann.Index.open(str(path), load_params), vectors
+
+
+def test_update_uses_external_ids_only(tmp_path):
+    index, _ = _build_index(tmp_path / "index")
+    vector = np.random.default_rng(7).random(16, dtype=np.float32)
+
+    index.insert(vector, 5000)
+    assert index.contains(5000)
+    labels, _ = index.search(vector, 5)
+    assert 5000 in labels
+
+    index.remove(5000)
+    assert not index.contains(5000)
+    with pytest.raises(KeyError, match="5000"):
+        index.remove(5000)
+
+
+def test_batch_update_validates_labels_before_mutation(tmp_path):
+    index, _ = _build_index(tmp_path / "index")
+    vectors = np.random.default_rng(8).random((2, 16), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="duplicate external label"):
+        index.batch_insert(vectors, np.array([6000, 6000], dtype=np.uint64))
+    assert not index.contains(6000)
+
+    index.batch_insert(vectors, np.array([6000, 6001], dtype=np.uint64))
+    with pytest.raises(KeyError, match="999999"):
+        index.batch_remove(np.array([6000, 999999], dtype=np.uint64))
+    assert index.contains(6000)
+    assert index.contains(6001)
+
+    index.batch_remove(np.array([6000, 6001], dtype=np.uint64))
+    assert not index.contains(6000)
+    assert not index.contains(6001)
+
+
+def test_external_id_mapping_survives_flush_and_reload(tmp_path):
+    path = tmp_path / "index"
+    index, _ = _build_index(path)
+    vector = np.random.default_rng(9).random(16, dtype=np.float32)
+    index.insert(vector, 7000)
+    index.remove(1001)
+    index.flush()
+    del index
+
+    load_params = diskann.LoadParams()
+    load_params.updatable = True
+    load_params.update_io = diskann.UpdateIO.BLOCKING
+    reopened = diskann.Index.open(str(path), load_params)
+    assert reopened.contains(7000)
+    assert not reopened.contains(1001)
+    reopened.remove(7000)
+
+
+def test_update_arrays_require_exact_dtype_and_layout(tmp_path):
+    index, _ = _build_index(tmp_path / "index")
+
+    with pytest.raises(TypeError, match="float32"):
+        index.insert(np.ones(16, dtype=np.float64), 8000)
+    with pytest.raises(TypeError, match="uint64"):
+        index.batch_remove(np.array([1001], dtype=np.int64))

--- a/tests/diskann/test_diskann_index.cpp
+++ b/tests/diskann/test_diskann_index.cpp
@@ -121,6 +121,15 @@ TEST_F(DiskANNIndexTest, BuildRejectsEmptyInput) {
                std::invalid_argument);
 }
 
+TEST_F(DiskANNIndexTest, BuildRejectsDuplicateExternalLabels) {
+  const auto v = make_vectors(10, 4);
+  auto labels = make_labels(10);
+  labels[7] = labels[2];
+  EXPECT_THROW(DiskANNIndex::build(dir(), v.data(), labels.data(), 10, 4, {}),
+               std::invalid_argument);
+  EXPECT_FALSE(std::filesystem::exists(dir_));
+}
+
 TEST_F(DiskANNIndexTest, BuildRejectsExistingDirectoryBeforeWriting) {
   std::filesystem::create_directories(dir_);
   const auto v = make_vectors(10, 4);

--- a/tests/diskann/test_diskann_update_e2e.cpp
+++ b/tests/diskann/test_diskann_update_e2e.cpp
@@ -236,6 +236,38 @@ TEST_F(UpdateE2ETest, InsertWithPageCacheIsVisibleToSearchAfterReturn) {
   ASSERT_TRUE(top1_is(nv.data(), id_label_[id]));
 }
 
+TEST_F(UpdateE2ETest, ExternalLabelsSupportLookupDeleteAndReuse) {
+  build_and_load(/*n=*/300, /*dim=*/32, /*r=*/32, {});
+  const uint32_t internal_id = deletable_.front();
+  const uint64_t label = id_label_[internal_id];
+
+  EXPECT_TRUE(idx_->contains_label(label));
+  idx_->remove_by_label(label);
+  EXPECT_FALSE(idx_->contains_label(label));
+  EXPECT_TRUE(idx_->is_deleted(internal_id));
+  EXPECT_THROW(idx_->remove_by_label(label), std::out_of_range);
+
+  const auto replacement = make_vectors(1, 32, /*seed=*/8128);
+  const uint32_t reused_id = idx_->insert(replacement.data(), label);
+  EXPECT_EQ(reused_id, internal_id);
+  EXPECT_TRUE(idx_->contains_label(label));
+  EXPECT_TRUE(top1_is(replacement.data(), label));
+}
+
+TEST_F(UpdateE2ETest, InsertRejectsDuplicateExternalLabelsBeforeMutation) {
+  build_and_load(/*n=*/300, /*dim=*/32, /*r=*/32, {});
+  const auto vectors = make_vectors(2, 32, /*seed=*/2048);
+  const uint64_t live_before = idx_->live_count();
+
+  EXPECT_THROW(idx_->insert(vectors.data(), 1001), std::invalid_argument);
+  EXPECT_EQ(idx_->live_count(), live_before);
+
+  const uint64_t labels[] = {9000, 9000};
+  EXPECT_THROW(idx_->batch_insert(vectors.data(), labels, 2, 2), std::invalid_argument);
+  EXPECT_EQ(idx_->live_count(), live_before);
+  EXPECT_FALSE(idx_->contains_label(9000));
+}
+
 TEST_F(UpdateE2ETest, InsertWithParallelReconnectKeepsVectorsSearchable) {
   DiskANNLoadParams lp;
   lp.page_cache_capacity = 16;
@@ -777,6 +809,24 @@ TEST_F(UpdateE2ETest, BatchRemoveHidesVectorsAndFeedsFreeList) {
   }
 }
 
+TEST_F(UpdateE2ETest, BatchRemoveByLabelsValidatesBeforeMutation) {
+  build_and_load(/*n=*/300, /*dim=*/32, /*r=*/32, {});
+  const uint64_t first_label = id_label_[deletable_[0]];
+  const uint64_t second_label = id_label_[deletable_[1]];
+  const uint64_t live_before = idx_->live_count();
+  const uint64_t invalid_labels[] = {first_label, 999999};
+
+  EXPECT_THROW(idx_->batch_remove_by_labels(invalid_labels, 2), std::out_of_range);
+  EXPECT_EQ(idx_->live_count(), live_before);
+  EXPECT_TRUE(idx_->contains_label(first_label));
+
+  const uint64_t labels[] = {first_label, second_label};
+  idx_->batch_remove_by_labels(labels, 2);
+  EXPECT_EQ(idx_->live_count(), live_before - 2);
+  EXPECT_FALSE(idx_->contains_label(first_label));
+  EXPECT_FALSE(idx_->contains_label(second_label));
+}
+
 // 7.5 -----------------------------------------------------------------------
 TEST_F(UpdateE2ETest, PersistenceAcrossFlushReload) {
   build_and_load(300, 32, 32, {});
@@ -801,8 +851,12 @@ TEST_F(UpdateE2ETest, PersistenceAcrossFlushReload) {
 
   EXPECT_EQ(idx_->live_count(), live_before);
   EXPECT_EQ(idx_->tombstone_count(), tomb_before);
+  for (const uint64_t label : inserted_labels) {
+    EXPECT_TRUE(idx_->contains_label(label));
+  }
   for (const uint32_t id : deleted) {
     EXPECT_TRUE(idx_->is_deleted(id)) << "tombstone for " << id << " must survive reload";
+    EXPECT_FALSE(idx_->contains_label(id_label_[id]));
   }
   for (const uint32_t id : {deleted[0], deleted[12], deleted[23]}) {
     uint64_t out_l[10];


### PR DESCRIPTION
## Description

  Expose the standalone updatable DiskANN index through Python bindings.

  Python callers can build, load, search, insert, and remove vectors using external IDs only. External-ID deletion resolves the corresponding internal slot and reuses the existing internal deletion implementation.

  ## Related Issue

  N/A

  ## Type of Change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [x] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Performance improvement
  - [x] Code refactoring
  - [ ] Documentation update
  - [ ] CI/CD changes

  ## Changes Made

  - Add the `alayalite.diskann` Python module with build, load, search, insert, batch insert, remove, batch remove, contains, and flush APIs.
  - Maintain a live external-ID-to-internal-slot mapping for updatable DiskANN indexes.
  - Resolve external IDs before deletion and reuse the shared internal single and batch deletion implementations.
  - Validate reserved, duplicate, and unknown external IDs before mutating the index.
  - Rebuild the external-ID mapping when loading an updatable index and keep it synchronized across insertion, deletion, slot reuse, flush, and reload.
  - Convert missing external IDs to Python `KeyError`.
  - Add C++ and Python coverage for external-ID updates, validation atomicity, slot reuse, and persistence.

  ## Testing

  - [x] Unit tests added/updated
  - [x] Integration tests added/updated
  - [ ] Manual testing performed

  ```bash
  /tmp/alayalite-python-update-build/tests/diskann/test_diskann_index

  ALAYA_DISKANN_UPDATE_IO=blocking \
    /tmp/alayalite-python-update-build/tests/diskann/test_diskann_update_e2e

  PYTHONPATH=/tmp/alayalite-python-update-build/python:python/src \
    .venv/bin/python -c \
    "import sys, _alayalitepy; sys.modules['alayalite._alayalitepy'] = _alayalitepy; import pytest; raise SystemExit(pytest.main(['-q', 'python/tests/diskann/test_update.py']))"
```
  Results:

  - DiskANN C++ unit tests: 16 passed
  - DiskANN update E2E tests: 23 passed
  - Python DiskANN update tests: 4 passed
  - Commit-time lint, formatting, license, and static checks passed

  ## Checklist

  - [x] My code follows the project's coding style
  - [x] I have run make lint and fixed any issues
  - [x] I have added tests that prove my fix/feature works
  - [ ] All new and existing tests pass (make test)
  - [x] I have updated documentation if needed
  - [x] My commits follow the conventional commits (https://www.conventionalcommits.org/) format

  ## Additional Notes

  The Python update API intentionally exposes external IDs only. Internal slot IDs remain an implementation detail of the C++ index.